### PR TITLE
Add basic construction and ops

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -47,22 +47,14 @@ jobs:
                     }
                   ]
                 },
-                { "cxxversions": ["c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++23"],
                   "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
                 }
               ]
             },
             { "versions": ["14", "13"],
               "tests": [
-                { "cxxversions": ["c++26", "c++23", "c++20", "c++17"],
-                  "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
-                }
-              ]
-            },
-            {
-              "versions": ["12", "11"],
-              "tests": [
-                { "cxxversions": ["c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++26", "c++23"],
                   "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
                 }
               ]
@@ -81,7 +73,7 @@ jobs:
                     }
                   ]
                 },
-                { "cxxversions": ["c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++23"],
                   "tests": [
                     {"stdlibs": ["libstdc++", "libc++"], "tests": ["Release.Default"]}
                   ]
@@ -90,7 +82,7 @@ jobs:
             },
             { "versions": ["21", "20", "19"],
               "tests": [
-                { "cxxversions": ["c++26", "c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++26", "c++23"],
                   "tests": [
                     {"stdlibs": ["libstdc++", "libc++"], "tests": ["Release.Default"]}
                   ]
@@ -99,10 +91,10 @@ jobs:
             },
             { "versions": ["18", "17"],
               "tests": [
-                { "cxxversions": ["c++26", "c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++26", "c++23"],
                   "tests": [{"stdlibs": ["libc++"], "tests": ["Release.Default"]}]
                 },
-                { "cxxversions": ["c++20", "c++17"],
+                { "cxxversions": ["c++23"],
                   "tests": [{"stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
                 }
               ]
@@ -111,7 +103,7 @@ jobs:
           "appleclang": [
             { "versions": ["latest"],
               "tests": [
-                { "cxxversions": ["c++26", "c++23", "c++20", "c++17"],
+                { "cxxversions": ["c++26", "c++23"],
                   "tests": [{ "stdlibs": ["libc++"], "tests": ["Release.Default"]}]
                 }
               ]

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -52,7 +52,7 @@ jobs:
                 }
               ]
             },
-            { "versions": ["14", "13"],
+            { "versions": ["14"],
               "tests": [
                 { "cxxversions": ["c++26", "c++23"],
                   "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
@@ -89,16 +89,6 @@ jobs:
                 }
               ]
             },
-            { "versions": ["18", "17"],
-              "tests": [
-                { "cxxversions": ["c++26", "c++23"],
-                  "tests": [{"stdlibs": ["libc++"], "tests": ["Release.Default"]}]
-                },
-                { "cxxversions": ["c++23"],
-                  "tests": [{"stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
-                }
-              ]
-            }
           ],
           "appleclang": [
             { "versions": ["latest"],

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -88,7 +88,7 @@ jobs:
                   ]
                 }
               ]
-            },
+            }
           ],
           "appleclang": [
             { "versions": ["latest"],

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 *.idea
 
 CLAUDE.md
+*.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ include(infra/cmake/beman-install-library.cmake)
 
 add_library(beman.big_int INTERFACE)
 add_library(beman::big_int ALIAS beman.big_int)
-target_compile_features(beman.big_int INTERFACE cxx_std_20)
+target_compile_features(beman.big_int INTERFACE cxx_std_23)
 
 target_sources(
     beman.big_int

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ include(infra/cmake/beman-install-library.cmake)
 
 add_library(beman.big_int INTERFACE)
 add_library(beman::big_int ALIAS beman.big_int)
-target_compile_features(beman.std-big-int INTERFACE cxx_std_20)
+target_compile_features(beman.big_int INTERFACE cxx_std_20)
 
 target_sources(
     beman.big_int

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ include(infra/cmake/beman-install-library.cmake)
 
 add_library(beman.big_int INTERFACE)
 add_library(beman::big_int ALIAS beman.big_int)
+target_compile_features(beman.std-big-int INTERFACE cxx_std_20)
 
 target_sources(
     beman.big_int

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,7 +7,7 @@
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build/${presetName}",
       "cacheVariables": {
-        "CMAKE_CXX_STANDARD": "20",
+        "CMAKE_CXX_STANDARD": "23",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
         "CMAKE_PROJECT_TOP_LEVEL_INCLUDES": "./infra/cmake/use-fetch-content.cmake"
       }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ that this requires GoogleTest to be installed.
 cmake \
   -B build \
   -S . \
-  -DCMAKE_CXX_STANDARD=20 \
+  -DCMAKE_CXX_STANDARD=23 \
   # Your extra arguments here.
 cmake --build build
 ctest --test-dir build
@@ -69,7 +69,7 @@ Example commands:
 cmake \
   -B build \
   -S . \
-  -DCMAKE_CXX_STANDARD=20 \
+  -DCMAKE_CXX_STANDARD=23 \
   -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=./infra/cmake/use-fetch-content.cmake
 cmake --build build
 ctest --test-dir build

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -5,6 +5,7 @@
 #define BEMAN_BIG_INT_BIG_INT_HPP
 
 #include <algorithm>
+#include <bit>
 #include <climits>
 #include <cstddef>
 #include <cstdint>
@@ -128,6 +129,30 @@ public:
             alloc_traits::deallocate(m_alloc, m_data.ld.data, m_data.ld.capacity);
         }
     }
+
+    // [big.int.ops]
+    [[nodiscard]] constexpr std::size_t width_mag() const noexcept {
+        if (m_limbs == 0) {
+            return 0;
+        }
+
+        const auto top = m_internal ? m_data.la[m_limbs - 1] : m_data.ld.data[m_limbs - 1];
+        return (m_limbs - 1) * bits_per_limb + (bits_per_limb - static_cast<std::size_t>(std::countl_zero(top)) - 1);
+    }
+
+    [[nodiscard]] constexpr std::span<const uint_multiprecision_t> representation() const noexcept {
+        if (m_internal) {
+            return {m_data.la, m_limbs};
+        }
+
+        return {m_data.ld.data, m_limbs};
+    }
+
+    [[nodiscard]] constexpr allocator_type get_allocator() const noexcept {
+        return m_alloc;
+    }
+
+    // constexpr void shrink_to_fit()
 };
 
 template <class Allocator = std::allocator<uint_multiprecision_t>>

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -74,7 +74,9 @@ class basic_big_int {
         limb_type la[inplace_bits];
         limb_data ld;
 
-        constexpr data_type() : la {} {}
+        constexpr data_type() noexcept : la {} {}
+        explicit constexpr data_type(const limb_type i) noexcept : la {} { la[0] = i; }
+        constexpr data_type(limb_type* limbs, std::size_t len) noexcept : ld {len, limbs } {}
     };
 
     data_type   m_data;

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -22,10 +22,34 @@ namespace beman::big_int {
 // alias uint_multiprecision_t
 using uint_multiprecision_t = std::uint64_t;
 
+// Forward decl so that we can define our concepts
+template <std::size_t inplace_bits, class Allocator = std::allocator<uint_multiprecision_t>>
+class basic_big_int;
+
+namespace detail {
+
+template <class>
+struct is_basic_big_int : std::false_type {};
+
+template <std::size_t inplace_bits, class Allocator>
+struct is_basic_big_int<basic_big_int<inplace_bits, Allocator>> : std::true_type {};
+
+template <class T>
+inline constexpr bool is_basic_big_int_v = is_basic_big_int<std::remove_cvref_t<T>>::value;
+
+} // namespace detail
+
+// [big.ing.expos]
+template <class T>
+concept signed_or_unsigned = std::is_signed_v<T> || std::is_unsigned_v<T>;
+
+template <class T>
+concept arbitrary_integer = signed_or_unsigned<std::remove_cvref_t<T>> || detail::is_basic_big_int_v<T>;
+
 // [big.int.class], class template basic_big_int
 //  template<size_t inplace_bits, class Allocator = allocator<uint_multiprecision_t>>
 //    class basic_big_int;
-template <std::size_t inplace_bits, class Allocator = std::allocator<uint_multiprecision_t>>
+template <std::size_t inplace_bits, class Allocator>
 class basic_big_int {
 
     using limb_type = uint_multiprecision_t;

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -11,7 +11,13 @@
 #include <memory>
 #include <type_traits>
 
-namespace beman {
+#ifdef _MSC_VER
+
+#include <__msvc_int128.hpp>
+
+#endif // _MSC_VER
+
+namespace beman::big_int {
 
 // alias uint_multiprecision_t
 using uint_multiprecision_t = std::uint64_t;
@@ -22,13 +28,22 @@ using uint_multiprecision_t = std::uint64_t;
 template <std::size_t inplace_bits, class Allocator = std::allocator<uint_multiprecision_t>>
 class basic_big_int {
 
-public:
-
     using limb_type = uint_multiprecision_t;
-    using double_limb_type = unsigned __int128;
-    using allocator_type = typename std::allocator_traits<Allocator>::template rebind_alloc<limb_type>;
+    using signed_limb_type = std::make_signed_t<limb_type>;
 
-private:
+    #ifdef _MSC_VER
+
+    using double_limb_type = std::_Unsigned128;
+    using signed_double_limb_type = std::_Signed128;
+
+    #else
+
+    using double_limb_type = unsigned __int128;
+    using signed_double_limb_type = __int128;
+
+    #endif
+
+    using allocator_type = typename std::allocator_traits<Allocator>::template rebind_alloc<limb_type>;
 
     using alloc_traits = std::allocator_traits<allocator_type>;
     using limb_pointer = typename std::allocator_traits<allocator_type>::pointer;

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -40,14 +40,14 @@ struct is_basic_big_int<basic_big_int<inplace_bits, Allocator>> : std::true_type
 template <class T>
 inline constexpr bool is_basic_big_int_v = is_basic_big_int<std::remove_cvref_t<T>>::value;
 
-} // namespace detail
-
 // [big.ing.expos]
 template <class T>
 concept signed_or_unsigned = std::is_signed_v<T> || std::is_unsigned_v<T>;
 
 template <class T>
 concept arbitrary_integer = signed_or_unsigned<std::remove_cvref_t<T>> || detail::is_basic_big_int_v<T>;
+
+} // namespace detail
 
 // [big.int.class], class template basic_big_int
 //  template<size_t inplace_bits, class Allocator = allocator<uint_multiprecision_t>>

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -111,9 +111,9 @@ class basic_big_int {
 
   public:
     // [big.int.cons], construct/copy/destroy
-    constexpr basic_big_int() noexcept(noexcept(Allocator())) : m_data{}, m_limbs{}, m_sign{}, m_internal{false} {}
+    constexpr basic_big_int() noexcept(noexcept(Allocator())) : m_data{}, m_limbs{1}, m_sign{}, m_internal{true} {}
     constexpr explicit basic_big_int(const Allocator& a) noexcept
-        : m_data{}, m_limbs{}, m_sign{}, m_internal{false}, m_alloc{a} {}
+        : m_data{}, m_limbs{1}, m_sign{}, m_internal{true}, m_alloc{a} {}
     constexpr basic_big_int(const basic_big_int& x)     = default;
     constexpr basic_big_int(basic_big_int&& x) noexcept = default;
 
@@ -122,25 +122,22 @@ class basic_big_int {
     constexpr ~basic_big_int() {
         // TODO(mborland): This will probably need to get sliced out into a free_storage() function
         // Good enough to run basic construction tests for now
-        if (!m_internal && m_limbs > 0) {
+        if (!m_internal) {
             alloc_traits::deallocate(m_alloc, m_data.ld.data, m_data.ld.capacity);
         }
     }
 
     // [big.int.ops]
     [[nodiscard]] constexpr std::size_t width_mag() const noexcept {
-        if (m_limbs == 0) {
+        const auto top = m_internal ? m_data.la[m_limbs - 1] : m_data.ld.data[m_limbs - 1];
+        if (top == 0) {
             return 0;
         }
 
-        const auto top = m_internal ? m_data.la[m_limbs - 1] : m_data.ld.data[m_limbs - 1];
         return (m_limbs - 1) * bits_per_limb + (bits_per_limb - static_cast<std::size_t>(std::countl_zero(top)) - 1);
     }
 
     [[nodiscard]] constexpr std::span<const uint_multiprecision_t> representation() const noexcept {
-        if (m_limbs == 0) {
-            return {};
-        }
         if (m_internal) {
             return {m_data.la, m_limbs};
         }

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -10,6 +10,8 @@
 #include <cstdint>
 #include <memory>
 #include <type_traits>
+#include <span>
+#include <concepts>
 
 #ifdef _MSC_VER
 
@@ -108,6 +110,24 @@ class basic_big_int {
     bool        m_sign;      // true = negative (sign + magnitude)
     bool        m_internal;  // true = using la[], false = using ld
     [[no_unique_address]] allocator_type m_alloc;
+
+public:
+
+    // [big.int.cons], construct/copy/destroy
+    constexpr basic_big_int() noexcept(noexcept(Allocator())) : m_data{}, m_limbs{}, m_sign{}, m_internal{false} {}
+    constexpr explicit basic_big_int(const Allocator& a) noexcept : m_data{}, m_limbs{}, m_sign{}, m_internal{false}, m_alloc{a} {}
+    constexpr basic_big_int(const basic_big_int& x) = default;
+    constexpr basic_big_int(basic_big_int&& x) noexcept = default;
+
+    // TODO(mborland): Add additional constructors from P4444
+
+    constexpr ~basic_big_int() {
+        // TODO(mborland): This will probably need to get sliced out into a free_storage() function
+        // Good enough to run basic construction tests for now
+        if (!m_internal) {
+            alloc_traits::deallocate(m_alloc, m_data.ld.data, m_data.ld.capacity);
+        }
+    }
 };
 
 template <class Allocator = std::allocator<uint_multiprecision_t>>

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -125,7 +125,7 @@ public:
     constexpr ~basic_big_int() {
         // TODO(mborland): This will probably need to get sliced out into a free_storage() function
         // Good enough to run basic construction tests for now
-        if (!m_internal) {
+        if (!m_internal && m_limbs > 0) {
             alloc_traits::deallocate(m_alloc, m_data.ld.data, m_data.ld.capacity);
         }
     }
@@ -141,6 +141,9 @@ public:
     }
 
     [[nodiscard]] constexpr std::span<const uint_multiprecision_t> representation() const noexcept {
+        if (m_limbs == 0) {
+            return {};
+        }
         if (m_internal) {
             return {m_data.la, m_limbs};
         }

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -16,7 +16,7 @@
 
 #ifdef _MSC_VER
 
-#include <__msvc_int128.hpp>
+    #include <__msvc_int128.hpp>
 
 #endif // _MSC_VER
 
@@ -55,45 +55,42 @@ concept arbitrary_integer = signed_or_unsigned<std::remove_cvref_t<T>> || detail
 template <std::size_t inplace_bits, class Allocator>
 class basic_big_int {
 
-    using limb_type = uint_multiprecision_t;
+    using limb_type        = uint_multiprecision_t;
     using signed_limb_type = std::make_signed_t<limb_type>;
 
-    #ifdef _MSC_VER
+#ifdef _MSC_VER
 
-    using double_limb_type = std::_Unsigned128;
+    using double_limb_type        = std::_Unsigned128;
     using signed_double_limb_type = std::_Signed128;
 
-    #else
+#else
 
-    using double_limb_type = unsigned __int128;
+    using double_limb_type        = unsigned __int128;
     using signed_double_limb_type = __int128;
 
-    #endif
+#endif
 
     using allocator_type = typename std::allocator_traits<Allocator>::template rebind_alloc<limb_type>;
 
-    using alloc_traits = std::allocator_traits<allocator_type>;
-    using limb_pointer = typename std::allocator_traits<allocator_type>::pointer;
+    using alloc_traits       = std::allocator_traits<allocator_type>;
+    using limb_pointer       = typename std::allocator_traits<allocator_type>::pointer;
     using const_limb_pointer = typename std::allocator_traits<allocator_type>::const_pointer;
 
     static constexpr std::size_t bits_per_limb = sizeof(limb_type) * CHAR_BIT;
 
-    static constexpr std::size_t inplace_limbs =
-        []() constexpr {
-            constexpr std::size_t from_bits =
-                (inplace_bits + bits_per_limb - 1) / bits_per_limb;
-            // never fewer limbs than would fit in the pointer+size_t footprint
-            // of limb_data, so the union doesn't waste space
-            constexpr std::size_t from_struct =
-                (sizeof(limb_pointer) + sizeof(std::size_t)
-                 + sizeof(limb_type) - 1) / sizeof(limb_type);
-            return from_bits > from_struct ? from_bits : from_struct;
-        }();
+    static constexpr std::size_t inplace_limbs = []() constexpr {
+        constexpr std::size_t from_bits = (inplace_bits + bits_per_limb - 1) / bits_per_limb;
+        // never fewer limbs than would fit in the pointer+size_t footprint
+        // of limb_data, so the union doesn't waste space
+        constexpr std::size_t from_struct =
+            (sizeof(limb_pointer) + sizeof(std::size_t) + sizeof(limb_type) - 1) / sizeof(limb_type);
+        return from_bits > from_struct ? from_bits : from_struct;
+    }();
 
     static_assert(inplace_bits > 0, "inplace_bits must be positive");
 
     struct limb_data {
-        std::size_t capacity;
+        std::size_t  capacity;
         limb_pointer data;
     };
 
@@ -101,23 +98,23 @@ class basic_big_int {
         limb_type la[inplace_bits];
         limb_data ld;
 
-        constexpr data_type() noexcept : la {} {}
-        explicit constexpr data_type(const limb_type i) noexcept : la {} { la[0] = i; }
-        constexpr data_type(limb_type* limbs, std::size_t len) noexcept : ld {len, limbs } {}
+        constexpr data_type() noexcept : la{} {}
+        explicit constexpr data_type(const limb_type i) noexcept : la{} { la[0] = i; }
+        constexpr data_type(limb_type* limbs, std::size_t len) noexcept : ld{len, limbs} {}
     };
 
-    data_type   m_data;
-    std::size_t m_limbs;     // number of active limbs
-    bool        m_sign;      // true = negative (sign + magnitude)
-    bool        m_internal;  // true = using la[], false = using ld
+    data_type                            m_data;
+    std::size_t                          m_limbs;    // number of active limbs
+    bool                                 m_sign;     // true = negative (sign + magnitude)
+    bool                                 m_internal; // true = using la[], false = using ld
     [[no_unique_address]] allocator_type m_alloc;
 
-public:
-
+  public:
     // [big.int.cons], construct/copy/destroy
     constexpr basic_big_int() noexcept(noexcept(Allocator())) : m_data{}, m_limbs{}, m_sign{}, m_internal{false} {}
-    constexpr explicit basic_big_int(const Allocator& a) noexcept : m_data{}, m_limbs{}, m_sign{}, m_internal{false}, m_alloc{a} {}
-    constexpr basic_big_int(const basic_big_int& x) = default;
+    constexpr explicit basic_big_int(const Allocator& a) noexcept
+        : m_data{}, m_limbs{}, m_sign{}, m_internal{false}, m_alloc{a} {}
+    constexpr basic_big_int(const basic_big_int& x)     = default;
     constexpr basic_big_int(basic_big_int&& x) noexcept = default;
 
     // TODO(mborland): Add additional constructors from P4444
@@ -151,9 +148,7 @@ public:
         return {m_data.ld.data, m_limbs};
     }
 
-    [[nodiscard]] constexpr allocator_type get_allocator() const noexcept {
-        return m_alloc;
-    }
+    [[nodiscard]] constexpr allocator_type get_allocator() const noexcept { return m_alloc; }
 
     // constexpr void shrink_to_fit()
 };
@@ -161,6 +156,6 @@ public:
 template <class Allocator = std::allocator<uint_multiprecision_t>>
 using big_int = basic_big_int<128U, Allocator>;
 
-} // namespace beman
+} // namespace beman::big_int
 
 #endif // BEMAN_BIG_INT_BIG_INT_HPP

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -4,6 +4,74 @@
 #ifndef BEMAN_STD_BIG_INT_STD_BIG_INT_HPP
 #define BEMAN_STD_BIG_INT_STD_BIG_INT_HPP
 
-#include <beman/big_int/todo.hpp>
+#include <algorithm>
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <type_traits>
+
+namespace beman {
+
+// alias uint_multiprecision_t
+using uint_multiprecision_t = std::uint64_t;
+
+// [big.int.class], class template basic_big_int
+//  template<size_t inplace_bits, class Allocator = allocator<uint_multiprecision_t>>
+//    class basic_big_int;
+template <std::size_t inplace_bits, class Allocator = std::allocator<uint_multiprecision_t>>
+class basic_big_int {
+
+public:
+
+    using limb_type = uint_multiprecision_t;
+    using double_limb_type = unsigned __int128;
+    using allocator_type = typename std::allocator_traits<Allocator>::template rebind_alloc<limb_type>;
+
+private:
+
+    using alloc_traits = std::allocator_traits<allocator_type>;
+    using limb_pointer = typename std::allocator_traits<allocator_type>::pointer;
+    using const_limb_pointer = typename std::allocator_traits<allocator_type>::const_pointer;
+
+    static constexpr std::size_t bits_per_limb = sizeof(limb_type) * CHAR_BIT;
+
+    static constexpr std::size_t inplace_limbs =
+        []() constexpr {
+            constexpr std::size_t from_bits =
+                (inplace_bits + bits_per_limb - 1) / bits_per_limb;
+            // never fewer limbs than would fit in the pointer+size_t footprint
+            // of limb_data, so the union doesn't waste space
+            constexpr std::size_t from_struct =
+                (sizeof(limb_pointer) + sizeof(std::size_t)
+                 + sizeof(limb_type) - 1) / sizeof(limb_type);
+            return from_bits > from_struct ? from_bits : from_struct;
+        }();
+
+    static_assert(inplace_bits > 0, "inplace_bits must be positive");
+
+    struct limb_data {
+        std::size_t capacity;
+        limb_pointer data;
+    };
+
+    union data_type {
+        limb_type la[inplace_bits];
+        limb_data ld;
+
+        constexpr data_type() : la {} {}
+    };
+
+    data_type   m_data;
+    std::size_t m_limbs;     // number of active limbs
+    bool        m_sign;      // true = negative (sign + magnitude)
+    bool        m_internal;  // true = using la[], false = using ld
+    [[no_unique_address]] allocator_type m_alloc;
+};
+
+template <class Allocator = std::allocator<uint_multiprecision_t>>
+using big_int = basic_big_int<128U, Allocator>;
+
+} // namespace beman
 
 #endif // BEMAN_STD_BIG_INT_STD_BIG_INT_HPP

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-License-Identifier: BSL-1.0
 
-#ifndef BEMAN_STD_BIG_INT_STD_BIG_INT_HPP
-#define BEMAN_STD_BIG_INT_STD_BIG_INT_HPP
+#ifndef BEMAN_BIG_INT_BIG_INT_HPP
+#define BEMAN_BIG_INT_BIG_INT_HPP
 
 #include <algorithm>
 #include <climits>
@@ -74,4 +74,4 @@ using big_int = basic_big_int<128U, Allocator>;
 
 } // namespace beman
 
-#endif // BEMAN_STD_BIG_INT_STD_BIG_INT_HPP
+#endif // BEMAN_BIG_INT_BIG_INT_HPP

--- a/include/beman/big_int/todo.hpp
+++ b/include/beman/big_int/todo.hpp
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-License-Identifier: BSL-1.0
 
-#ifndef BEMAN_STD_BIG_INT_TODO_HPP
-#define BEMAN_STD_BIG_INT_TODO_HPP
+#ifndef BEMAN_BIG_INT_TODO_HPP
+#define BEMAN_BIG_INT_TODO_HPP
 
-namespace beman::std_big_int {} // namespace beman::std_big_int
+namespace beman::big_int {} // namespace beman::big_int
 
-#endif // BEMAN_STD_BIG_INT_TODO_HPP
+#endif // BEMAN_BIG_INT_TODO_HPP

--- a/tests/beman/big_int/CMakeLists.txt
+++ b/tests/beman/big_int/CMakeLists.txt
@@ -1,11 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-
-add_executable(beman.big_int.tests.todo)
-target_sources(beman.big_int.tests.todo PRIVATE todo.test.cpp)
-target_link_libraries(
-    beman.big_int.tests.todo
-    PRIVATE beman::big_int GTest::gtest_main
-)
+# SPDX-License-Identifier: BSL-1.0
 
 include(GoogleTest)
-gtest_discover_tests(beman.big_int.tests.todo)
+
+file(GLOB TEST_SOURCES "*.test.cpp")
+
+foreach(test_source ${TEST_SOURCES})
+    get_filename_component(test_name ${test_source} NAME_WE)
+    set(test_target beman.big_int.tests.${test_name})
+
+    add_executable(${test_target})
+    target_sources(${test_target} PRIVATE ${test_source})
+    target_link_libraries(${test_target} PRIVATE beman::big_int GTest::gtest_main)
+    gtest_discover_tests(${test_target})
+endforeach()

--- a/tests/beman/big_int/CMakeLists.txt
+++ b/tests/beman/big_int/CMakeLists.txt
@@ -11,6 +11,9 @@ foreach(test_source ${TEST_SOURCES})
 
     add_executable(${test_target})
     target_sources(${test_target} PRIVATE ${test_source})
-    target_link_libraries(${test_target} PRIVATE beman::big_int GTest::gtest_main)
+    target_link_libraries(
+        ${test_target}
+        PRIVATE beman::big_int GTest::gtest_main
+    )
     gtest_discover_tests(${test_target})
 endforeach()

--- a/tests/beman/big_int/basic_construction.test.cpp
+++ b/tests/beman/big_int/basic_construction.test.cpp
@@ -14,7 +14,7 @@ static_assert(test_default_construction());
 
 consteval bool test_allocator_construction() {
     std::allocator<beman::big_int::uint_multiprecision_t> a;
-    beman::big_int::big_int x(a);
+    beman::big_int::big_int                               x(a);
     return x.width_mag() == 0 && x.representation().size() == 0;
 }
 static_assert(test_allocator_construction());
@@ -43,7 +43,7 @@ TEST(BasicConstruction, DefaultConstruction) {
 
 TEST(BasicConstruction, AllocatorConstruction) {
     std::allocator<beman::big_int::uint_multiprecision_t> a;
-    beman::big_int::big_int x(a);
+    beman::big_int::big_int                               x(a);
     EXPECT_EQ(x.width_mag(), 0U);
     EXPECT_EQ(x.representation().size(), 0U);
 }

--- a/tests/beman/big_int/basic_construction.test.cpp
+++ b/tests/beman/big_int/basic_construction.test.cpp
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: BSL-1.0
+
+#include <beman/big_int/big_int.hpp>
+#include <gtest/gtest.h>
+
+// ----- compile-time tests -----
+
+consteval bool test_default_construction() {
+    beman::big_int::big_int x;
+    return x.width_mag() == 0 && x.representation().size() == 0;
+}
+static_assert(test_default_construction());
+
+consteval bool test_allocator_construction() {
+    std::allocator<beman::big_int::uint_multiprecision_t> a;
+    beman::big_int::big_int x(a);
+    return x.width_mag() == 0 && x.representation().size() == 0;
+}
+static_assert(test_allocator_construction());
+
+consteval bool test_copy_construction() {
+    beman::big_int::big_int x;
+    beman::big_int::big_int y(x);
+    return y.width_mag() == 0 && y.representation().size() == 0;
+}
+static_assert(test_copy_construction());
+
+consteval bool test_move_construction() {
+    beman::big_int::big_int x;
+    beman::big_int::big_int y(std::move(x));
+    return y.width_mag() == 0 && y.representation().size() == 0;
+}
+static_assert(test_move_construction());
+
+// ----- runtime tests -----
+
+TEST(BasicConstruction, DefaultConstruction) {
+    beman::big_int::big_int x;
+    EXPECT_EQ(x.width_mag(), 0U);
+    EXPECT_EQ(x.representation().size(), 0U);
+}
+
+TEST(BasicConstruction, AllocatorConstruction) {
+    std::allocator<beman::big_int::uint_multiprecision_t> a;
+    beman::big_int::big_int x(a);
+    EXPECT_EQ(x.width_mag(), 0U);
+    EXPECT_EQ(x.representation().size(), 0U);
+}
+
+TEST(BasicConstruction, CopyConstruction) {
+    beman::big_int::big_int x;
+    beman::big_int::big_int y(x);
+    EXPECT_EQ(y.width_mag(), 0U);
+    EXPECT_EQ(y.representation().size(), 0U);
+}
+
+TEST(BasicConstruction, MoveConstruction) {
+    beman::big_int::big_int x;
+    beman::big_int::big_int y(std::move(x));
+    EXPECT_EQ(y.width_mag(), 0U);
+    EXPECT_EQ(y.representation().size(), 0U);
+}
+
+TEST(BasicConstruction, NonDefaultInplaceBits) {
+    beman::big_int::basic_big_int<256> x;
+    EXPECT_EQ(x.width_mag(), 0U);
+    EXPECT_EQ(x.representation().size(), 0U);
+}

--- a/tests/beman/big_int/basic_construction.test.cpp
+++ b/tests/beman/big_int/basic_construction.test.cpp
@@ -8,28 +8,28 @@
 
 consteval bool test_default_construction() {
     beman::big_int::big_int x;
-    return x.width_mag() == 0 && x.representation().size() == 0;
+    return x.width_mag() == 0 && x.representation().size() == 1;
 }
 static_assert(test_default_construction());
 
 consteval bool test_allocator_construction() {
     std::allocator<beman::big_int::uint_multiprecision_t> a;
     beman::big_int::big_int                               x(a);
-    return x.width_mag() == 0 && x.representation().size() == 0;
+    return x.width_mag() == 0 && x.representation().size() == 1;
 }
 static_assert(test_allocator_construction());
 
 consteval bool test_copy_construction() {
     beman::big_int::big_int x;
     beman::big_int::big_int y(x);
-    return y.width_mag() == 0 && y.representation().size() == 0;
+    return y.width_mag() == 0 && y.representation().size() == 1;
 }
 static_assert(test_copy_construction());
 
 consteval bool test_move_construction() {
     beman::big_int::big_int x;
     beman::big_int::big_int y(std::move(x));
-    return y.width_mag() == 0 && y.representation().size() == 0;
+    return y.width_mag() == 0 && y.representation().size() == 1;
 }
 static_assert(test_move_construction());
 
@@ -38,32 +38,32 @@ static_assert(test_move_construction());
 TEST(BasicConstruction, DefaultConstruction) {
     beman::big_int::big_int x;
     EXPECT_EQ(x.width_mag(), 0U);
-    EXPECT_EQ(x.representation().size(), 0U);
+    EXPECT_EQ(x.representation().size(), 1U);
 }
 
 TEST(BasicConstruction, AllocatorConstruction) {
     std::allocator<beman::big_int::uint_multiprecision_t> a;
     beman::big_int::big_int                               x(a);
     EXPECT_EQ(x.width_mag(), 0U);
-    EXPECT_EQ(x.representation().size(), 0U);
+    EXPECT_EQ(x.representation().size(), 1U);
 }
 
 TEST(BasicConstruction, CopyConstruction) {
     beman::big_int::big_int x;
     beman::big_int::big_int y(x);
     EXPECT_EQ(y.width_mag(), 0U);
-    EXPECT_EQ(y.representation().size(), 0U);
+    EXPECT_EQ(y.representation().size(), 1U);
 }
 
 TEST(BasicConstruction, MoveConstruction) {
     beman::big_int::big_int x;
     beman::big_int::big_int y(std::move(x));
     EXPECT_EQ(y.width_mag(), 0U);
-    EXPECT_EQ(y.representation().size(), 0U);
+    EXPECT_EQ(y.representation().size(), 1U);
 }
 
 TEST(BasicConstruction, NonDefaultInplaceBits) {
     beman::big_int::basic_big_int<256> x;
     EXPECT_EQ(x.width_mag(), 0U);
-    EXPECT_EQ(x.representation().size(), 0U);
+    EXPECT_EQ(x.representation().size(), 1U);
 }


### PR DESCRIPTION
- Removes the `STD_` and `std_` from namespace and macros like discussed in #2 
- Adds the basic constructors for the `basic_big_int` type which exercise the internal constructors. Tested both at runtime and via `consteval` functions
- Add 3 of the 4 functions from big.int.ops
- Replaces the need to explicitly write out every test in the test CML, now it's just a glob loop

