### PR TITLE
Small Cleanup

### DIFF
--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -75,11 +75,10 @@ class basic_big_int {
 
 #endif
 
-    using allocator_type = typename std::allocator_traits<Allocator>::template rebind_alloc<limb_type>;
-
+    using allocator_type     = std::allocator_traits<Allocator>::template rebind_alloc<limb_type>;
     using alloc_traits       = std::allocator_traits<allocator_type>;
-    using limb_pointer       = typename std::allocator_traits<allocator_type>::pointer;
-    using const_limb_pointer = typename std::allocator_traits<allocator_type>::const_pointer;
+    using limb_pointer       = std::allocator_traits<allocator_type>::pointer;
+    using const_limb_pointer = std::allocator_traits<allocator_type>::const_pointer;
 
     static constexpr std::size_t bits_per_limb = sizeof(limb_type) * CHAR_BIT;
 

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -124,125 +124,186 @@ class basic_big_int {
     template <detail::arbitrary_arithmetic T>
         requires(!std::same_as<std::remove_cvref_t<T>, basic_big_int>)
     constexpr explicit(!detail::is_implicit_constructible_from<inplace_bits, Allocator, T>)
-        basic_big_int(T&& value) noexcept(detail::no_alloc_constructible_from<inplace_bits, T>)
-        : m_data{}, m_limbs{1}, m_sign{false}, m_internal{true}, m_alloc{} {
-        if constexpr (std::is_floating_point_v<T>) {
-            // TODO: Implement this
-            // I think we can go down the RYU route to separate a floating point value into significant, exponent, sign
-            // Regardless of method, each of the STLs has a method of accomplishing this already as an implementation
-            // detail to <charconv>
-            static_assert(false, "This has not been implemented yet");
-        } else {
-            if constexpr (std::is_signed_v<T>) {
-                m_sign  = value < T{0};
-                using U = std::make_unsigned_t<T>;
-                assign_magnitude(m_sign ? static_cast<U>(-(static_cast<U>(value))) : static_cast<U>(value));
-            } else {
-                assign_magnitude(value);
-            }
-        }
-    }
+        basic_big_int(T&& value) noexcept(detail::no_alloc_constructible_from<inplace_bits, T>);
 
     template <detail::arbitrary_arithmetic T>
-    constexpr basic_big_int(const T&         value,
-                            const Allocator& a) noexcept(detail::no_alloc_constructible_from<inplace_bits, T>)
-        : m_data{}, m_limbs{1}, m_sign{false}, m_internal{true}, m_alloc{a} {
-        if constexpr (std::is_floating_point_v<T>) {
-            // TODO: Implement this
-            // See implementation note above
-            static_assert(false, "This has not been implemented yet");
-        } else {
-            if constexpr (std::is_signed_v<T>) {
-                m_sign  = value < T{0};
-                using U = std::make_unsigned_t<T>;
-                assign_magnitude(m_sign ? static_cast<U>(-(static_cast<U>(value))) : static_cast<U>(value));
-            } else {
-                assign_magnitude(value);
-            }
-        }
-    }
+    constexpr basic_big_int(const T& value, const Allocator& a) noexcept(
+        detail::no_alloc_constructible_from<inplace_bits, T>);
 
     template <std::ranges::input_range R>
         requires detail::signed_or_unsigned<std::ranges::range_value_t<R>>
-    constexpr explicit basic_big_int(std::from_range_t, R&& r, const Allocator& a = Allocator())
-        : m_data{}, m_limbs{1}, m_sign{false}, m_internal{true}, m_alloc{a} {
-        std::size_t i = 0;
-        for (auto&& elem : r) {
-            using U        = std::make_unsigned_t<std::ranges::range_value_t<R>>;
-            m_data.la[i++] = static_cast<limb_type>(static_cast<U>(elem));
-        }
-        m_limbs = i == 0 ? 1 : i;
-        while (m_limbs > 1 && m_data.la[m_limbs - 1] == 0) {
-            --m_limbs;
-        }
-    }
+    constexpr explicit basic_big_int(std::from_range_t, R&& r, const Allocator& a = Allocator());
 
     // TODO(mborland): Add additional constructors from P4444
 
-    constexpr ~basic_big_int() {
-        // TODO(mborland): This will probably need to get sliced out into a free_storage() function
-        // Good enough to run basic construction tests for now
-        if (!m_internal) {
-            alloc_traits::deallocate(m_alloc, m_data.ld.data, m_data.ld.capacity);
-        }
-    }
+    constexpr ~basic_big_int();
 
     // [big.int.ops]
-    [[nodiscard]] constexpr std::size_t width_mag() const noexcept {
-        const auto top = m_internal ? m_data.la[m_limbs - 1] : m_data.ld.data[m_limbs - 1];
-        if (top == 0) {
-            return 0;
-        }
-
-        return (m_limbs - 1) * bits_per_limb + (bits_per_limb - static_cast<std::size_t>(std::countl_zero(top)) - 1);
-    }
-
-    [[nodiscard]] constexpr std::span<const uint_multiprecision_t> representation() const noexcept {
-        if (m_internal) {
-            return {m_data.la, m_limbs};
-        }
-
-        return {m_data.ld.data, m_limbs};
-    }
-
-    [[nodiscard]] constexpr allocator_type get_allocator() const noexcept { return m_alloc; }
+    [[nodiscard]] constexpr std::size_t                            width_mag() const noexcept;
+    [[nodiscard]] constexpr std::span<const uint_multiprecision_t> representation() const noexcept;
+    [[nodiscard]] constexpr allocator_type                         get_allocator() const noexcept;
 
     // constexpr void shrink_to_fit()
 
     // [big.int.unary]
-    [[nodiscard]] constexpr basic_big_int operator+() const& { return *this; }
-    [[nodiscard]] constexpr basic_big_int operator+() && noexcept { return std::move(*this); }
-
-    [[nodiscard]] constexpr basic_big_int operator-() const& {
-        auto copy   = *this;
-        copy.m_sign = !copy.m_sign;
-        return copy;
-    }
-    [[nodiscard]] constexpr basic_big_int operator-() && noexcept {
-        auto copy   = std::move(*this);
-        copy.m_sign = !copy.m_sign;
-        return copy;
-    }
+    [[nodiscard]] constexpr basic_big_int operator+() const&;
+    [[nodiscard]] constexpr basic_big_int operator+() && noexcept;
+    [[nodiscard]] constexpr basic_big_int operator-() const&;
+    [[nodiscard]] constexpr basic_big_int operator-() && noexcept;
 
   private:
     template <std::unsigned_integral T>
-    constexpr void assign_magnitude(T value) noexcept {
-        if constexpr (sizeof(T) <= sizeof(limb_type)) {
-            m_data.la[0] = static_cast<limb_type>(value);
-            m_limbs      = 1;
+    constexpr void assign_magnitude(T value) noexcept;
+};
+
+// =============================================================================
+// Out-of-class definitions
+// =============================================================================
+
+// [big.int.cons] — constructors
+
+template <std::size_t inplace_bits, class Allocator>
+template <detail::arbitrary_arithmetic T>
+    requires(!std::same_as<std::remove_cvref_t<T>, basic_big_int<inplace_bits, Allocator>>)
+constexpr basic_big_int<inplace_bits, Allocator>::basic_big_int(
+    T&& value) noexcept(detail::no_alloc_constructible_from<inplace_bits, T>)
+    : m_data{}, m_limbs{1}, m_sign{false}, m_internal{true}, m_alloc{} {
+    if constexpr (std::is_floating_point_v<T>) {
+        // TODO: Implement this
+        // I think we can go down the RYU route to separate a floating point value into significant, exponent, sign
+        // Regardless of method, each of the STLs has a method of accomplishing this already as an implementation
+        // detail to <charconv>
+        static_assert(false, "This has not been implemented yet");
+    } else {
+        if constexpr (std::is_signed_v<T>) {
+            m_sign  = value < T{0};
+            using U = std::make_unsigned_t<T>;
+            assign_magnitude(m_sign ? static_cast<U>(-(static_cast<U>(value))) : static_cast<U>(value));
         } else {
-            constexpr std::size_t n = sizeof(T) / sizeof(limb_type);
-            for (std::size_t i = 0; i < n; ++i) {
-                m_data.la[i] = static_cast<limb_type>(value);
-                value >>= bits_per_limb;
-            }
-            m_limbs = n;
-            while (m_limbs > 1 && m_data.la[m_limbs - 1] == 0) {
-                --m_limbs;
-            }
+            assign_magnitude(value);
         }
     }
-};
+}
+
+template <std::size_t inplace_bits, class Allocator>
+template <detail::arbitrary_arithmetic T>
+constexpr basic_big_int<inplace_bits, Allocator>::basic_big_int(
+    const T& value, const Allocator& a) noexcept(detail::no_alloc_constructible_from<inplace_bits, T>)
+    : m_data{}, m_limbs{1}, m_sign{false}, m_internal{true}, m_alloc{a} {
+    if constexpr (std::is_floating_point_v<T>) {
+        // TODO: Implement this
+        // See implementation note above
+        static_assert(false, "This has not been implemented yet");
+    } else {
+        if constexpr (std::is_signed_v<T>) {
+            m_sign  = value < T{0};
+            using U = std::make_unsigned_t<T>;
+            assign_magnitude(m_sign ? static_cast<U>(-(static_cast<U>(value))) : static_cast<U>(value));
+        } else {
+            assign_magnitude(value);
+        }
+    }
+}
+
+template <std::size_t inplace_bits, class Allocator>
+template <std::ranges::input_range R>
+    requires detail::signed_or_unsigned<std::ranges::range_value_t<R>>
+constexpr basic_big_int<inplace_bits, Allocator>::basic_big_int(std::from_range_t, R&& r, const Allocator& a)
+    : m_data{}, m_limbs{1}, m_sign{false}, m_internal{true}, m_alloc{a} {
+    std::size_t i = 0;
+    for (auto&& elem : r) {
+        using U        = std::make_unsigned_t<std::ranges::range_value_t<R>>;
+        m_data.la[i++] = static_cast<limb_type>(static_cast<U>(elem));
+    }
+    m_limbs = i == 0 ? 1 : i;
+    while (m_limbs > 1 && m_data.la[m_limbs - 1] == 0) {
+        --m_limbs;
+    }
+}
+
+template <std::size_t inplace_bits, class Allocator>
+constexpr basic_big_int<inplace_bits, Allocator>::~basic_big_int() {
+    // TODO(mborland): This will probably need to get sliced out into a free_storage() function
+    // Good enough to run basic construction tests for now
+    if (!m_internal) {
+        alloc_traits::deallocate(m_alloc, m_data.ld.data, m_data.ld.capacity);
+    }
+}
+
+// [big.int.ops]
+
+template <std::size_t inplace_bits, class Allocator>
+constexpr std::size_t basic_big_int<inplace_bits, Allocator>::width_mag() const noexcept {
+    const auto top = m_internal ? m_data.la[m_limbs - 1] : m_data.ld.data[m_limbs - 1];
+    if (top == 0) {
+        return 0;
+    }
+
+    return (m_limbs - 1) * bits_per_limb + (bits_per_limb - static_cast<std::size_t>(std::countl_zero(top)) - 1);
+}
+
+template <std::size_t inplace_bits, class Allocator>
+constexpr std::span<const uint_multiprecision_t>
+basic_big_int<inplace_bits, Allocator>::representation() const noexcept {
+    if (m_internal) {
+        return {m_data.la, m_limbs};
+    }
+
+    return {m_data.ld.data, m_limbs};
+}
+
+template <std::size_t inplace_bits, class Allocator>
+constexpr basic_big_int<inplace_bits, Allocator>::allocator_type
+basic_big_int<inplace_bits, Allocator>::get_allocator() const noexcept {
+    return m_alloc;
+}
+
+// [big.int.unary]
+
+template <std::size_t inplace_bits, class Allocator>
+constexpr basic_big_int<inplace_bits, Allocator> basic_big_int<inplace_bits, Allocator>::operator+() const& {
+    return *this;
+}
+
+template <std::size_t inplace_bits, class Allocator>
+constexpr basic_big_int<inplace_bits, Allocator> basic_big_int<inplace_bits, Allocator>::operator+() && noexcept {
+    return std::move(*this);
+}
+
+template <std::size_t inplace_bits, class Allocator>
+constexpr basic_big_int<inplace_bits, Allocator> basic_big_int<inplace_bits, Allocator>::operator-() const& {
+    auto copy   = *this;
+    copy.m_sign = !copy.m_sign;
+    return copy;
+}
+
+template <std::size_t inplace_bits, class Allocator>
+constexpr basic_big_int<inplace_bits, Allocator> basic_big_int<inplace_bits, Allocator>::operator-() && noexcept {
+    auto copy   = std::move(*this);
+    copy.m_sign = !copy.m_sign;
+    return copy;
+}
+
+// private helpers
+
+template <std::size_t inplace_bits, class Allocator>
+template <std::unsigned_integral T>
+constexpr void basic_big_int<inplace_bits, Allocator>::assign_magnitude(T value) noexcept {
+    if constexpr (sizeof(T) <= sizeof(limb_type)) {
+        m_data.la[0] = static_cast<limb_type>(value);
+        m_limbs      = 1;
+    } else {
+        constexpr std::size_t n = sizeof(T) / sizeof(limb_type);
+        for (std::size_t i = 0; i < n; ++i) {
+            m_data.la[i] = static_cast<limb_type>(value);
+            value >>= bits_per_limb;
+        }
+        m_limbs = n;
+        while (m_limbs > 1 && m_data.la[m_limbs - 1] == 0) {
+            --m_limbs;
+        }
+    }
+}
 
 using big_int = basic_big_int<128U, std::allocator<uint_multiprecision_t>>;
 

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -127,8 +127,8 @@ class basic_big_int {
         basic_big_int(T&& value) noexcept(detail::no_alloc_constructible_from<inplace_bits, T>);
 
     template <detail::arbitrary_arithmetic T>
-    constexpr basic_big_int(const T& value, const Allocator& a) noexcept(
-        detail::no_alloc_constructible_from<inplace_bits, T>);
+    constexpr basic_big_int(const T&         value,
+                            const Allocator& a) noexcept(detail::no_alloc_constructible_from<inplace_bits, T>);
 
     template <std::ranges::input_range R>
         requires detail::signed_or_unsigned<std::ranges::range_value_t<R>>
@@ -165,8 +165,8 @@ class basic_big_int {
 template <std::size_t inplace_bits, class Allocator>
 template <detail::arbitrary_arithmetic T>
     requires(!std::same_as<std::remove_cvref_t<T>, basic_big_int<inplace_bits, Allocator>>)
-constexpr basic_big_int<inplace_bits, Allocator>::basic_big_int(
-    T&& value) noexcept(detail::no_alloc_constructible_from<inplace_bits, T>)
+constexpr basic_big_int<inplace_bits, Allocator>::basic_big_int(T&& value) noexcept(
+    detail::no_alloc_constructible_from<inplace_bits, T>)
     : m_data{}, m_limbs{1}, m_sign{false}, m_internal{true}, m_alloc{} {
     if constexpr (std::is_floating_point_v<T>) {
         // TODO: Implement this
@@ -187,8 +187,8 @@ constexpr basic_big_int<inplace_bits, Allocator>::basic_big_int(
 
 template <std::size_t inplace_bits, class Allocator>
 template <detail::arbitrary_arithmetic T>
-constexpr basic_big_int<inplace_bits, Allocator>::basic_big_int(
-    const T& value, const Allocator& a) noexcept(detail::no_alloc_constructible_from<inplace_bits, T>)
+constexpr basic_big_int<inplace_bits, Allocator>::basic_big_int(const T& value, const Allocator& a) noexcept(
+    detail::no_alloc_constructible_from<inplace_bits, T>)
     : m_data{}, m_limbs{1}, m_sign{false}, m_internal{true}, m_alloc{a} {
     if constexpr (std::is_floating_point_v<T>) {
         // TODO: Implement this


### PR DESCRIPTION
Remove `typename`s that are redundant from C++20 and move definitions out of line. We are already looked cluttered in the class and have a ways to go