### PR TITLE
Tighten constraints

### DIFF
--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -284,9 +284,9 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     friend constexpr std::strong_ordering operator<=>(const L& lhs, const R& rhs) noexcept;
 
   private:
-    template <std::unsigned_integral T>
+    template <detail::unsigned_integer T>
     constexpr void assign_magnitude(T value) noexcept;
-    template <std::floating_point F>
+    template <detail::cv_unqualified_floating_point F>
     constexpr void assign_from_float(F value) noexcept;
 
     [[nodiscard]] constexpr alloc_result alloc_limbs(std::size_t n);
@@ -858,8 +858,8 @@ basic_big_int<b, A>::compare_limbs(const std::span<const uint_multiprecision_t, 
 // private helpers
 
 template <std::size_t b, class A>
-template <std::unsigned_integral T>
-constexpr void basic_big_int<b, A>::assign_magnitude(T value) noexcept {
+template <detail::unsigned_integer T>
+constexpr void basic_big_int<b, A>::assign_magnitude(const T value) noexcept {
     if constexpr (sizeof(T) <= sizeof(limb_type)) {
         limb_ptr()[0] = static_cast<limb_type>(value);
         set_limb_count(1);
@@ -878,7 +878,7 @@ constexpr void basic_big_int<b, A>::assign_magnitude(T value) noexcept {
 }
 
 template <std::size_t b, class A>
-template <std::floating_point F>
+template <detail::cv_unqualified_floating_point F>
 constexpr void basic_big_int<b, A>::assign_from_float(const F value) noexcept {
     BEMAN_BIG_INT_ASSERT(std::isfinite(value));
 

--- a/include/beman/big_int/config.hpp
+++ b/include/beman/big_int/config.hpp
@@ -92,19 +92,23 @@ using int_wide_t = int128_t;
 
 #include <cstdint>
 #include <type_traits>
+#include <concepts>
 
 namespace beman::big_int::detail {
 
 template <class T>
 concept cv_unqualified = !std::is_const_v<T> && !std::is_volatile_v<T>;
 
+template <class T>
+concept character_type =                                     //
+    std::is_same_v<T, char> || std::is_same_v<T, wchar_t> || //
+    std::is_same_v<T, char8_t> || std::is_same_v<T, char16_t> || std::is_same_v<T, char32_t>;
+
 // Modeled if `T` is a signed or unsigned integer type.
 // That is, a standard integer type, extended integer type, or bit-precise integer type.
 template <class T>
-concept signed_or_unsigned =
-    std::is_integral_v<T> && cv_unqualified<T> //
-    && !std::is_same_v<T, bool> && !std::is_same_v<T, char> && !std::is_same_v<T, wchar_t> &&
-    !std::is_same_v<T, char8_t> && !std::is_same_v<T, char16_t> && !std::is_same_v<T, char32_t>;
+concept signed_or_unsigned = std::is_integral_v<T> && cv_unqualified<T> //
+                             && !std::is_same_v<T, bool> && !character_type<T>;
 
 // Modeled if `T` is a standard unsigned, extended unsigned, or bit-precise unsigned integer type.
 template <class T>
@@ -112,6 +116,23 @@ concept unsigned_integer = signed_or_unsigned<T> && std::is_unsigned_v<T>;
 // Modeled if `T` is a standard signed, extended signed, or bit-precise signed integer type.
 template <class T>
 concept signed_integer = signed_or_unsigned<T> && std::is_signed_v<T>;
+
+// Alias template that maps a cv-unqualified integral type onto the underlying
+// signed or unsigned integer type.
+// For example, this converts `char8_t` to `unsigned char`, `int` to `int`, etc.
+// The goal is to reduce redundant template instantiations.
+template <class T>
+    requires std::integral<T> && cv_unqualified<T>
+using make_signed_or_unsigned_t =
+    std::conditional_t<std::is_signed_v<T>, std::make_signed_t<T>, std::make_unsigned_t<T>>;
+
+template <class T>
+concept cv_unqualified_floating_point = cv_unqualified<T> && std::floating_point<T>;
+
+template <class T>
+[[nodiscard, maybe_unused]] constexpr make_signed_or_unsigned_t<T> to_signed_or_unsigned(const T x) {
+    return static_cast<make_signed_or_unsigned_t<T>>(x);
+}
 
 } // namespace beman::big_int::detail
 


### PR DESCRIPTION
Direct use of `std::integral`, `std::unsigned_integral`, `std::floating_point` and the like should be avoided because these are almost always underconstrained. They include cv-qualified types and surprises like `bool` and `char.

Internally for things like `assign_magnitude`, `big_int` should only ever handle signed or unsigned integer types. At the boundaries such as constructors, it should convert integral types to signed or unsigned integer types.