### PR TITLE
Trivial syntax arm-none-eabi warn zero nullptr

### DIFF
--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -892,16 +892,16 @@ constexpr std::strong_ordering operator<=>(const L& lhs, const R& rhs) noexcept 
         }
     } else {
         static_assert(detail::is_basic_big_int_v<R>);
-        #if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
+#if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
         BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
         BEMAN_BIG_INT_DIAGNOSTIC_IGNORED("-Wzero-as-null-pointer-constant")
-        #endif
+#endif
         static_assert((0 <=> std::strong_ordering::less) == std::strong_ordering::greater,
                       "This trick to flip the ordering should work.");
         return 0 <=> rhs.compare_integer(lhs);
-        #if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
+#if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
         BEMAN_BIG_INT_DIAGNOSTIC_POP()
-        #endif
+#endif
     }
 }
 
@@ -1049,16 +1049,14 @@ basic_big_int<b, A>::compare_limbs(const std::span<const uint_multiprecision_t, 
                                    const bool limbs_negative) const noexcept {
     // A mismatch between signs lets us short-circuit without comparing the magnitudes.
     const auto sign_compare = limbs_negative <=> is_negative();
-    #if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
+#if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
     BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
     BEMAN_BIG_INT_DIAGNOSTIC_IGNORED("-Wzero-as-null-pointer-constant")
     if (sign_compare != 0) {
         return sign_compare;
     }
-    #endif
-    #if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
     BEMAN_BIG_INT_DIAGNOSTIC_POP()
-    #endif
+#endif
     const auto rep = representation();
 
     // If there are more significant nonzero digits in limbs, this integer is lower.
@@ -1079,16 +1077,16 @@ basic_big_int<b, A>::compare_limbs(const std::span<const uint_multiprecision_t, 
     // from most significant to least significant.
     for (std::size_t i = std::min(limbs.size(), rep.size()); i-- > 0;) {
         const auto result = rep[i] <=> limbs[i];
-        #if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
+#if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
         BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
         BEMAN_BIG_INT_DIAGNOSTIC_IGNORED("-Wzero-as-null-pointer-constant")
-        #endif
+#endif
         if (result != 0) {
             return result;
         }
-        #if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
+#if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
         BEMAN_BIG_INT_DIAGNOSTIC_POP()
-        #endif
+#endif
     }
     // Having eliminated any possible mismatch, the two sides are equal.
     return std::strong_ordering::equal;

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -894,7 +894,7 @@ constexpr std::strong_ordering operator<=>(const L& lhs, const R& rhs) noexcept 
         static_assert(detail::is_basic_big_int_v<R>);
         BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
         BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Wzero-as-null-pointer-constant")
-        BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_CLANG("-Wzero-as-null-pointer-constant")        BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
+        BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_CLANG("-Wzero-as-null-pointer-constant")
         static_assert((0 <=> std::strong_ordering::less) == std::strong_ordering::greater,
                       "This trick to flip the ordering should work.");
         return 0 <=> rhs.compare_integer(lhs);

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -892,16 +892,13 @@ constexpr std::strong_ordering operator<=>(const L& lhs, const R& rhs) noexcept 
         }
     } else {
         static_assert(detail::is_basic_big_int_v<R>);
-#if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
         BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
-        BEMAN_BIG_INT_DIAGNOSTIC_IGNORED("-Wzero-as-null-pointer-constant")
-#endif
+        BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Wzero-as-null-pointer-constant")
+        BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_CLANG("-Wzero-as-null-pointer-constant")        BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
         static_assert((0 <=> std::strong_ordering::less) == std::strong_ordering::greater,
                       "This trick to flip the ordering should work.");
         return 0 <=> rhs.compare_integer(lhs);
-#if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
         BEMAN_BIG_INT_DIAGNOSTIC_POP()
-#endif
     }
 }
 
@@ -1025,16 +1022,9 @@ constexpr std::strong_ordering basic_big_int<b, A>::compare_integer(const Intege
         if constexpr (has_inplace_to_bit_uint) {
             if (is_storage_static()) {
                 const auto sign_compare = (x < 0) <=> is_negative();
-#if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
-                BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
-                BEMAN_BIG_INT_DIAGNOSTIC_IGNORED("-Wzero-as-null-pointer-constant")
-#endif
-                if (sign_compare != 0) {
+                if (std::is_neq(sign_compare)) {
                     return sign_compare;
                 }
-#if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
-                BEMAN_BIG_INT_DIAGNOSTIC_POP()
-#endif
                 return inplace_to_bit_uint() <=> detail::uabs(x);
             }
         }
@@ -1056,14 +1046,9 @@ basic_big_int<b, A>::compare_limbs(const std::span<const uint_multiprecision_t, 
                                    const bool limbs_negative) const noexcept {
     // A mismatch between signs lets us short-circuit without comparing the magnitudes.
     const auto sign_compare = limbs_negative <=> is_negative();
-#if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
-    BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
-    BEMAN_BIG_INT_DIAGNOSTIC_IGNORED("-Wzero-as-null-pointer-constant")
-    if (sign_compare != 0) {
+    if (std::is_neq(sign_compare)) {
         return sign_compare;
     }
-    BEMAN_BIG_INT_DIAGNOSTIC_POP()
-#endif
     const auto rep = representation();
 
     // If there are more significant nonzero digits in limbs, this integer is lower.
@@ -1084,16 +1069,9 @@ basic_big_int<b, A>::compare_limbs(const std::span<const uint_multiprecision_t, 
     // from most significant to least significant.
     for (std::size_t i = std::min(limbs.size(), rep.size()); i-- > 0;) {
         const auto result = rep[i] <=> limbs[i];
-#if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
-        BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
-        BEMAN_BIG_INT_DIAGNOSTIC_IGNORED("-Wzero-as-null-pointer-constant")
-#endif
-        if (result != 0) {
+        if (std::is_neq(result)) {
             return result;
         }
-#if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
-        BEMAN_BIG_INT_DIAGNOSTIC_POP()
-#endif
     }
     // Having eliminated any possible mismatch, the two sides are equal.
     return std::strong_ordering::equal;

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -662,7 +662,7 @@ constexpr std::strong_ordering operator<=>(const L& lhs, const R& rhs) noexcept 
         }
     } else {
         static_assert(detail::is_basic_big_int_v<R>);
-        static_assert((0 <=> std::strong_ordering::less) == std::strong_ordering::greater,
+        static_assert((nullptr <=> std::strong_ordering::less) == std::strong_ordering::greater,
                       "This trick to flip the ordering should work.");
         return 0 <=> rhs.compare_integer(lhs);
     }

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -1025,9 +1025,16 @@ constexpr std::strong_ordering basic_big_int<b, A>::compare_integer(const Intege
         if constexpr (has_inplace_to_bit_uint) {
             if (is_storage_static()) {
                 const auto sign_compare = (x < 0) <=> is_negative();
+#if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
+                BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
+                BEMAN_BIG_INT_DIAGNOSTIC_IGNORED("-Wzero-as-null-pointer-constant")
+#endif
                 if (sign_compare != 0) {
                     return sign_compare;
                 }
+#if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
+                BEMAN_BIG_INT_DIAGNOSTIC_POP()
+#endif
                 return inplace_to_bit_uint() <=> detail::uabs(x);
             }
         }

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -1049,9 +1049,16 @@ basic_big_int<b, A>::compare_limbs(const std::span<const uint_multiprecision_t, 
                                    const bool limbs_negative) const noexcept {
     // A mismatch between signs lets us short-circuit without comparing the magnitudes.
     const auto sign_compare = limbs_negative <=> is_negative();
+    #if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
+    BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
+    BEMAN_BIG_INT_DIAGNOSTIC_IGNORED("-Wzero-as-null-pointer-constant")
     if (sign_compare != 0) {
         return sign_compare;
     }
+    #endif
+    #if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
+    BEMAN_BIG_INT_DIAGNOSTIC_POP()
+    #endif
     const auto rep = representation();
 
     // If there are more significant nonzero digits in limbs, this integer is lower.
@@ -1072,9 +1079,16 @@ basic_big_int<b, A>::compare_limbs(const std::span<const uint_multiprecision_t, 
     // from most significant to least significant.
     for (std::size_t i = std::min(limbs.size(), rep.size()); i-- > 0;) {
         const auto result = rep[i] <=> limbs[i];
+        #if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
+        BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
+        BEMAN_BIG_INT_DIAGNOSTIC_IGNORED("-Wzero-as-null-pointer-constant")
+        #endif
         if (result != 0) {
             return result;
         }
+        #if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
+        BEMAN_BIG_INT_DIAGNOSTIC_POP()
+        #endif
     }
     // Having eliminated any possible mismatch, the two sides are equal.
     return std::strong_ordering::equal;

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -662,7 +662,7 @@ constexpr std::strong_ordering operator<=>(const L& lhs, const R& rhs) noexcept 
         }
     } else {
         static_assert(detail::is_basic_big_int_v<R>);
-        static_assert((nullptr <=> std::strong_ordering::less) == std::strong_ordering::greater,
+        static_assert((0 <=> std::strong_ordering::less) == std::strong_ordering::greater,
                       "This trick to flip the ordering should work.");
         return 0 <=> rhs.compare_integer(lhs);
     }

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -892,8 +892,15 @@ constexpr std::strong_ordering operator<=>(const L& lhs, const R& rhs) noexcept 
         }
     } else {
         static_assert(detail::is_basic_big_int_v<R>);
+        #if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
+        BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
+        BEMAN_BIG_INT_DIAGNOSTIC_IGNORED("-Wzero-as-null-pointer-constant")
+        #endif
         static_assert((0 <=> std::strong_ordering::less) == std::strong_ordering::greater,
                       "This trick to flip the ordering should work.");
+        #if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
+        BEMAN_BIG_INT_DIAGNOSTIC_POP()
+        #endif
         return 0 <=> rhs.compare_integer(lhs);
     }
 }

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -14,8 +14,8 @@
 #include <cstdint>
 #include <memory>
 #include <ranges>
-#include <type_traits>
 #include <span>
+#include <type_traits>
 
 #include <beman/big_int/config.hpp>
 #include <beman/big_int/wide_ops.hpp>

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -898,10 +898,10 @@ constexpr std::strong_ordering operator<=>(const L& lhs, const R& rhs) noexcept 
         #endif
         static_assert((0 <=> std::strong_ordering::less) == std::strong_ordering::greater,
                       "This trick to flip the ordering should work.");
+        return 0 <=> rhs.compare_integer(lhs);
         #if (defined(BEMAN_BIG_INT_GCC) || defined(BEMAN_BIG_INT_CLANG))
         BEMAN_BIG_INT_DIAGNOSTIC_POP()
         #endif
-        return 0 <=> rhs.compare_integer(lhs);
     }
 }
 

--- a/include/beman/big_int/wide_ops.hpp
+++ b/include/beman/big_int/wide_ops.hpp
@@ -94,10 +94,10 @@ inline static T high_mul(const T x, const T y) noexcept {
         if constexpr (std::is_signed_v<T>) {
             if constexpr (width_v<T> == 64) {
                 // https://stackoverflow.com/a/28904636/5740428
-                const T a_lo = static_cast<unsigned>(a);
-                const T a_hi = static_cast<unsigned>(a >> 32);
-                const T b_lo = static_cast<unsigned>(b);
-                const T b_hi = static_cast<unsigned>(b >> 32);
+                const T a_lo = static_cast<unsigned>(x);
+                const T a_hi = static_cast<unsigned>(x >> 32);
+                const T b_lo = static_cast<unsigned>(y);
+                const T b_hi = static_cast<unsigned>(y >> 32);
 
                 const T a_x_b_hi  = a_hi * b_hi;
                 const T a_x_b_mid = a_hi * b_lo;

--- a/include/beman/big_int/wide_ops.hpp
+++ b/include/beman/big_int/wide_ops.hpp
@@ -94,10 +94,10 @@ inline static T high_mul(const T x, const T y) noexcept {
         if constexpr (std::is_signed_v<T>) {
             if constexpr (width_v<T> == 64) {
                 // https://stackoverflow.com/a/28904636/5740428
-                const T a_lo = static_cast<unsigned>(x);
-                const T a_hi = static_cast<unsigned>(x >> 32);
-                const T b_lo = static_cast<unsigned>(y);
-                const T b_hi = static_cast<unsigned>(y >> 32);
+                const T a_lo = static_cast<unsigned>(a);
+                const T a_hi = static_cast<unsigned>(a >> 32);
+                const T b_lo = static_cast<unsigned>(b);
+                const T b_hi = static_cast<unsigned>(b >> 32);
 
                 const T a_x_b_hi  = a_hi * b_hi;
                 const T a_x_b_mid = a_hi * b_lo;

--- a/include/beman/big_int/wide_ops.hpp
+++ b/include/beman/big_int/wide_ops.hpp
@@ -4,9 +4,9 @@
 #ifndef BEMAN_BIG_INT_WIDE_OPS_HPP
 #define BEMAN_BIG_INT_WIDE_OPS_HPP
 
-#include <limits>
 #include <bit>
 #include <concepts>
+#include <limits>
 
 #include <beman/big_int/config.hpp>
 
@@ -94,10 +94,10 @@ inline static T high_mul(const T x, const T y) noexcept {
         if constexpr (std::is_signed_v<T>) {
             if constexpr (width_v<T> == 64) {
                 // https://stackoverflow.com/a/28904636/5740428
-                const T a_lo = static_cast<unsigned>(a);
-                const T a_hi = static_cast<unsigned>(a >> 32);
-                const T b_lo = static_cast<unsigned>(b);
-                const T b_hi = static_cast<unsigned>(b >> 32);
+                const T a_lo = static_cast<unsigned>(x);
+                const T a_hi = static_cast<unsigned>(x >> 32);
+                const T b_lo = static_cast<unsigned>(y);
+                const T b_hi = static_cast<unsigned>(y >> 32);
 
                 const T a_x_b_hi  = a_hi * b_hi;
                 const T a_x_b_mid = a_hi * b_lo;

--- a/tests/beman/big_int/CMakeLists.txt
+++ b/tests/beman/big_int/CMakeLists.txt
@@ -31,6 +31,7 @@ foreach(test_source ${TEST_SOURCES})
                 -Wundef
                 -Wold-style-cast
                 -Wfloat-equal
+                -Wzero-as-null-pointer-constant
         )
     endif()
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")


### PR DESCRIPTION
Hi @eisenwave thx for working so hard on the 32/64 limb topic. I took a run at it on `arm-none-eabi-gcc` with many warnings activated.

This simplistic PR is intended to handle a final syntax warning (warn zero as nullptr) on `arm-none-eabi-gcc`

Cc: @eisenwave