### PR TITLE
Comparison Operator Fixes

### DIFF
--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -1079,30 +1079,55 @@ basic_big_int<b, A>::compare_limbs(const std::span<const uint_multiprecision_t, 
     }
     const auto rep = representation();
 
-    // If there are more significant nonzero digits in limbs, this integer is lower.
-    // Decimal example: 23 < 123
-    for (std::size_t i = limbs.size(); i-- > rep.size();) {
-        if (limbs[i] != 0) {
-            return std::strong_ordering::less;
+    if constexpr (extent == 0) {
+        // With an empty limbs span, the common-prefix compare and the
+        // limbs has trailing zeroes scan are both provably empty, so only
+        // the self-tail zero scan is required
+        for (std::size_t i = rep.size(); i-- > 0;) {
+            if (rep[i] != 0) {
+                return std::strong_ordering::greater;
+            }
         }
-    }
-    // If there are more significant nonzero digits in this integer, it is greater.
-    // Decimal example: 123 > 23
-    for (std::size_t i = rep.size(); i-- > limbs.size();) {
-        if (rep[i] != 0) {
-            return std::strong_ordering::greater;
+        return std::strong_ordering::equal;
+    } else {
+        // Split on which side is longer so each branch carries only one tail-zero loop.
+        // When extent != dynamic_extent, `limbs.size()` is a compile-time constant,
+        // so these loops can be more easily unrolled.
+        // We also don't need to do all three scans, just two for any given case
+        if (rep.size() > limbs.size()) {
+            // If there are more significant nonzero digits in this integer, it is greater.
+            // Decimal example: 123 > 23
+            for (std::size_t i = rep.size(); i-- > limbs.size();) {
+                if (rep[i] != 0) {
+                    return std::strong_ordering::greater;
+                }
+            }
+            // Compare the common digits from most to least significant.
+            for (std::size_t i = limbs.size(); i-- > 0;) {
+                const auto result = rep[i] <=> limbs[i];
+                if (std::is_neq(result)) {
+                    return result;
+                }
+            }
+        } else {
+            // If there are more significant nonzero digits in limbs, this integer is lower.
+            // Decimal example: 23 < 123
+            for (std::size_t i = limbs.size(); i-- > rep.size();) {
+                if (limbs[i] != 0) {
+                    return std::strong_ordering::less;
+                }
+            }
+            // Compare the common digits from most to least significant.
+            for (std::size_t i = rep.size(); i-- > 0;) {
+                const auto result = rep[i] <=> limbs[i];
+                if (std::is_neq(result)) {
+                    return result;
+                }
+            }
         }
+        // Having eliminated any possible mismatch, the two sides are equal.
+        return std::strong_ordering::equal;
     }
-    // Otherwise, we nee need to compare the common digits to one another,
-    // from most significant to least significant.
-    for (std::size_t i = std::min(limbs.size(), rep.size()); i-- > 0;) {
-        const auto result = rep[i] <=> limbs[i];
-        if (std::is_neq(result)) {
-            return result;
-        }
-    }
-    // Having eliminated any possible mismatch, the two sides are equal.
-    return std::strong_ordering::equal;
 }
 
 // private helpers

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -986,28 +986,51 @@ constexpr bool basic_big_int<b, A>::equals_limbs(const std::span<const uint_mult
         return false;
     }
 
-    std::size_t       i    = 0;
-    const auto* const self = limb_ptr();
-    // In the limbs that are common,
-    // there can be no mismatch.
-    for (; i < limbs.size() && i < limb_count(); ++i) {
-        if (self[i] != limbs[i]) {
-            return false;
+    const auto* const   self = limb_ptr();
+    const std::uint32_t lc   = limb_count();
+
+    if constexpr (extent == 0) {
+        // With an empty limbs span, the common-prefix compare and the
+        // limbs has trailing zeroes scan are both provably empty, so only
+        // the self-tail zero scan is required
+        for (std::size_t i = 0; i < lc; ++i) {
+            if (self[i] != 0) {
+                return false;
+            }
         }
-    }
-    // The provided limbs can have additional ignored zeroes.
-    for (; i < limbs.size(); ++i) {
-        if (limbs[i] != 0) {
-            return false;
+        return true;
+    } else {
+        // Split on which side is longer so each branch carries only one tail-zero loop.
+        // When extent != dynamic_extent, `limbs.size()` is a compile-time constant,
+        // so these loops can be more easily unrolled.
+        // We also don't need to do all three scans, just two for any given case
+        if (lc >= limbs.size()) {
+            for (std::size_t i = 0; i < limbs.size(); ++i) {
+                if (self[i] != limbs[i]) {
+                    return false;
+                }
+            }
+            // Our own limbs can have additional ignored zeroes.
+            for (std::size_t i = limbs.size(); i < lc; ++i) {
+                if (self[i] != 0) {
+                    return false;
+                }
+            }
+        } else {
+            for (std::size_t i = 0; i < lc; ++i) {
+                if (self[i] != limbs[i]) {
+                    return false;
+                }
+            }
+            // The provided limbs can have additional ignored zeroes.
+            for (std::size_t i = lc; i < limbs.size(); ++i) {
+                if (limbs[i] != 0) {
+                    return false;
+                }
+            }
         }
+        return true;
     }
-    // Our own limbs can have additional ignored zeroes.
-    for (; i < limb_count(); ++i) {
-        if (self[i] != 0) {
-            return false;
-        }
-    }
-    return true;
 }
 
 template <std::size_t b, class A>

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -316,7 +316,7 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
 
     template <detail::signed_or_unsigned Integer>
     [[nodiscard]] constexpr bool equals_integer(Integer x) const noexcept;
-    [[nodiscard]] constexpr bool equals_big_int(const basic_big_int& other) const noexcept;
+    [[nodiscard]] constexpr bool equals_big_int(const basic_big_int& x) const noexcept;
     template <std::size_t extent>
     [[nodiscard]] constexpr bool equals_limbs(std::span<const uint_multiprecision_t, extent> limbs,
                                               bool limbs_negative) const noexcept;

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -989,48 +989,36 @@ constexpr bool basic_big_int<b, A>::equals_limbs(const std::span<const uint_mult
     const auto* const   self = limb_ptr();
     const std::uint32_t lc   = limb_count();
 
-    if constexpr (extent == 0) {
-        // With an empty limbs span, the common-prefix compare and the
-        // limbs has trailing zeroes scan are both provably empty, so only
-        // the self-tail zero scan is required
-        for (std::size_t i = 0; i < lc; ++i) {
+    // Split on which side is longer so each branch carries only one tail-zero loop.
+    // When extent != dynamic_extent, `limbs.size()` is a compile-time constant,
+    // so these loops can be more easily unrolled.
+    // We also don't need to do all three scans, just two for any given case.
+    if (lc >= limbs.size()) {
+        for (std::size_t i = 0; i < limbs.size(); ++i) {
+            if (self[i] != limbs[i]) {
+                return false;
+            }
+        }
+        // Our own limbs can have additional ignored zeroes.
+        for (std::size_t i = limbs.size(); i < lc; ++i) {
             if (self[i] != 0) {
                 return false;
             }
         }
-        return true;
     } else {
-        // Split on which side is longer so each branch carries only one tail-zero loop.
-        // When extent != dynamic_extent, `limbs.size()` is a compile-time constant,
-        // so these loops can be more easily unrolled.
-        // We also don't need to do all three scans, just two for any given case
-        if (lc >= limbs.size()) {
-            for (std::size_t i = 0; i < limbs.size(); ++i) {
-                if (self[i] != limbs[i]) {
-                    return false;
-                }
-            }
-            // Our own limbs can have additional ignored zeroes.
-            for (std::size_t i = limbs.size(); i < lc; ++i) {
-                if (self[i] != 0) {
-                    return false;
-                }
-            }
-        } else {
-            for (std::size_t i = 0; i < lc; ++i) {
-                if (self[i] != limbs[i]) {
-                    return false;
-                }
-            }
-            // The provided limbs can have additional ignored zeroes.
-            for (std::size_t i = lc; i < limbs.size(); ++i) {
-                if (limbs[i] != 0) {
-                    return false;
-                }
+        for (std::size_t i = 0; i < lc; ++i) {
+            if (self[i] != limbs[i]) {
+                return false;
             }
         }
-        return true;
+        // The provided limbs can have additional ignored zeroes.
+        for (std::size_t i = lc; i < limbs.size(); ++i) {
+            if (limbs[i] != 0) {
+                return false;
+            }
+        }
     }
+    return true;
 }
 
 template <std::size_t b, class A>
@@ -1053,7 +1041,10 @@ constexpr std::strong_ordering basic_big_int<b, A>::compare_integer(const Intege
                 if (std::is_neq(sign_compare)) {
                     return sign_compare;
                 }
-                return inplace_to_bit_uint() <=> detail::uabs(x);
+                // For two-negative operands, bigger magnitude means a smaller
+                // value, so swap the operand order of the magnitude compare.
+                return is_negative() ? detail::uabs(x) <=> inplace_to_bit_uint()
+                                     : inplace_to_bit_uint() <=> detail::uabs(x);
             }
         }
         const auto limbs = detail::to_limbs(detail::uabs(x));
@@ -1079,21 +1070,15 @@ basic_big_int<b, A>::compare_limbs(const std::span<const uint_multiprecision_t, 
     }
     const auto rep = representation();
 
-    if constexpr (extent == 0) {
-        // With an empty limbs span, the common-prefix compare and the
-        // limbs has trailing zeroes scan are both provably empty, so only
-        // the self-tail zero scan is required
-        for (std::size_t i = rep.size(); i-- > 0;) {
-            if (rep[i] != 0) {
-                return std::strong_ordering::greater;
-            }
-        }
-        return std::strong_ordering::equal;
-    } else {
-        // Split on which side is longer so each branch carries only one tail-zero loop.
-        // When extent != dynamic_extent, `limbs.size()` is a compile-time constant,
-        // so these loops can be more easily unrolled.
-        // We also don't need to do all three scans, just two for any given case
+    // Compute the ordering as if both operands were non-negative (i.e., compare
+    // magnitudes). For two-negative operands we invert the result at the end,
+    // because a larger magnitude means a smaller value.
+    //
+    // Split on which side is longer so each branch carries only one high-tail scan.
+    // When extent != dynamic_extent, `limbs.size()` is a compile-time constant,
+    // so these loops can be more easily unrolled.
+    // We also don't need to do all three scans, just two for any given case.
+    const auto magnitude_ordering = [&]() -> std::strong_ordering {
         if (rep.size() > limbs.size()) {
             // If there are more significant nonzero digits in this integer, it is greater.
             // Decimal example: 123 > 23
@@ -1127,7 +1112,18 @@ basic_big_int<b, A>::compare_limbs(const std::span<const uint_multiprecision_t, 
         }
         // Having eliminated any possible mismatch, the two sides are equal.
         return std::strong_ordering::equal;
+    }();
+
+    if (is_negative()) {
+        // Invert: less <-> greater; equal is unchanged.
+        if (std::is_lt(magnitude_ordering)) {
+            return std::strong_ordering::greater;
+        }
+        if (std::is_gt(magnitude_ordering)) {
+            return std::strong_ordering::less;
+        }
     }
+    return magnitude_ordering;
 }
 
 // private helpers

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -323,7 +323,7 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
 
     template <detail::signed_or_unsigned Integer>
     [[nodiscard]] constexpr std::strong_ordering compare_integer(Integer x) const noexcept;
-    [[nodiscard]] constexpr std::strong_ordering compare_big_int(const basic_big_int& other) const noexcept;
+    [[nodiscard]] constexpr std::strong_ordering compare_big_int(const basic_big_int& x) const noexcept;
     template <std::size_t extent>
     [[nodiscard]] constexpr std::strong_ordering compare_limbs(std::span<const uint_multiprecision_t, extent> limbs,
                                                                bool limbs_negative) const noexcept;

--- a/tests/beman/big_int/comparison.test.cpp
+++ b/tests/beman/big_int/comparison.test.cpp
@@ -165,4 +165,43 @@ TEST(Comparison, OrderingWideIntegers) {
     EXPECT_EQ((big_int{1} <=> wide_neg), std::strong_ordering::greater);
 }
 
+// Covers same-sign negative operands of differing magnitude, which the other
+// comparison suites do not exercise.
+TEST(Comparison, EqualityNegativeMagnitudes) {
+    const big_int neg_three{-3};
+    const big_int neg_five{-5};
+    const big_int neg_three_copy{-3};
+
+    EXPECT_EQ(neg_three == neg_three_copy, true);
+    EXPECT_EQ(neg_three == neg_five, false);
+    EXPECT_EQ(neg_five == neg_three, false);
+    EXPECT_EQ(neg_three == -3, true);
+    EXPECT_EQ(neg_three == -5, false);
+    EXPECT_EQ(-3 == neg_three, true);
+    EXPECT_EQ(-5 == neg_three, false);
+}
+
+TEST(Comparison, OrderingNegativeMagnitudes) {
+    const big_int neg_three{-3};
+    const big_int neg_five{-5};
+
+    // big_int <=> big_int via compare_big_int (dynamic-extent path).
+    EXPECT_EQ((neg_five <=> neg_three), std::strong_ordering::less);
+    EXPECT_EQ((neg_three <=> neg_five), std::strong_ordering::greater);
+
+    // big_int <=> int via compare_integer (fixed-extent path).
+    EXPECT_EQ((neg_five <=> -3), std::strong_ordering::less);
+    EXPECT_EQ((-3 <=> neg_five), std::strong_ordering::greater);
+
+    // Wide negative magnitudes exercise the `rep.size() > limbs.size()`
+    // branch (wide-vs-narrow) and the equal-size common-compare branch.
+    const big_int neg_one{-1};
+    const big_int wide_neg_small = -big_int{1.0e20};
+    const big_int wide_neg_large = -big_int{2.0e20};
+    EXPECT_EQ((wide_neg_small <=> neg_one), std::strong_ordering::less);
+    EXPECT_EQ((neg_one <=> wide_neg_small), std::strong_ordering::greater);
+    EXPECT_EQ((wide_neg_large <=> wide_neg_small), std::strong_ordering::less);
+    EXPECT_EQ((wide_neg_small <=> wide_neg_large), std::strong_ordering::greater);
+}
+
 } // namespace


### PR DESCRIPTION
- Reduces the number of loops from 3 to 2 by branching on the limb size. Should be more easily auto-vectorized in this manner
- Fixes the comparisons of two negative numbers
- Fixes 2 instances of declaration and implementation have different parameter names 
