### PR TITLE
Implement operators add and sub

### DIFF
--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -972,6 +972,46 @@ template <class T, std::size_t N>
     return std::span<const T, N>(arr);
 }
 
+// Three-way compares the magnitudes represented by two limb spans (little-endian, zero-padded).
+// Treats both as non-negative; callers layer sign handling on top.
+// Split on which side is longer so each branch carries only one high-tail scan.
+// When an extent is not `dynamic_extent`, `.size()` is a compile-time constant,
+// so the loops are easier to unroll.
+template <std::size_t extent_a, std::size_t extent_b>
+[[nodiscard]] constexpr std::strong_ordering
+compare_limb_magnitudes(const std::span<const uint_multiprecision_t, extent_a> a,
+                        const std::span<const uint_multiprecision_t, extent_b> b) noexcept {
+    if (a.size() > b.size()) {
+        // If there are more significant nonzero digits in `a`, it is greater.
+        // Decimal example: 123 > 23
+        for (std::size_t i = a.size(); i-- > b.size();) {
+            if (a[i] != 0) {
+                return std::strong_ordering::greater;
+            }
+        }
+        // Compare the common digits from most to least significant.
+        for (std::size_t i = b.size(); i-- > 0;) {
+            const auto result = a[i] <=> b[i];
+            if (std::is_neq(result)) {
+                return result;
+            }
+        }
+    } else {
+        for (std::size_t i = b.size(); i-- > a.size();) {
+            if (b[i] != 0) {
+                return std::strong_ordering::less;
+            }
+        }
+        for (std::size_t i = a.size(); i-- > 0;) {
+            const auto result = a[i] <=> b[i];
+            if (std::is_neq(result)) {
+                return result;
+            }
+        }
+    }
+    return std::strong_ordering::equal;
+}
+
 } // namespace detail
 
 template <std::size_t b, class A>

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -1277,10 +1277,10 @@ basic_big_int<b, A>::assign_sum_of_limbs(const std::span<const uint_multiprecisi
     // When `lhs >= rhs` (in magnitude) compute `lhs - rhs` and take sign `lhs_neg`; otherwise
     // compute `rhs - lhs` with sign `rhs_neg`. Equal magnitudes fall into the first branch
     // and produce a normalized `+0`.
-    const std::span<const uint_multiprecision_t> larger  = std::is_gteq(magnitude_order) //
+    const std::span<const uint_multiprecision_t> larger  = std::is_gteq(magnitude_order)
                                                               ? std::span<const uint_multiprecision_t>(lhs)
                                                               : std::span<const uint_multiprecision_t>(rhs);
-    const std::span<const uint_multiprecision_t> smaller = std::is_gteq(magnitude_order) //
+    const std::span<const uint_multiprecision_t> smaller = std::is_gteq(magnitude_order)
                                                               ? std::span<const uint_multiprecision_t>(rhs)
                                                               : std::span<const uint_multiprecision_t>(lhs);
     const bool result_sign = std::is_gteq(magnitude_order) ? lhs_neg : rhs_neg;

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -361,9 +361,9 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     template <std::size_t extent_a, std::size_t extent_b>
     [[nodiscard]] static constexpr basic_big_int
     make_sum_of_limbs(std::span<const uint_multiprecision_t, extent_a> lhs,
-                 bool                                             lhs_neg,
-                 std::span<const uint_multiprecision_t, extent_b> rhs,
-                 bool                                             rhs_neg);
+                      bool                                             lhs_neg,
+                      std::span<const uint_multiprecision_t, extent_b> rhs,
+                      bool                                             rhs_neg);
 
     static constexpr bool        has_inplace_to_bit_uint = inplace_bits <= BEMAN_BIG_INT_BITINT_MAXWIDTH;
     [[nodiscard]] constexpr auto inplace_to_bit_uint() const noexcept
@@ -1038,20 +1038,26 @@ constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y) {
     using RT     = std::remove_cvref_t<R>;
 
     if constexpr (detail::is_basic_big_int_v<LT> && detail::is_basic_big_int_v<RT>) {
-        return Result::make_sum_of_limbs(x.representation(), x.is_negative(), //
-                                    y.representation(), y.is_negative());
+        return Result::make_sum_of_limbs(x.representation(),
+                                         x.is_negative(), //
+                                         y.representation(),
+                                         y.is_negative());
     } else if constexpr (detail::is_basic_big_int_v<LT>) {
         // `y` is a primitive integer; materialize it as a fixed-extent limb array
         // so the span we pass to the helper stays valid for the call.
         const auto y_limbs = detail::to_limbs(detail::uabs(y));
-        return Result::make_sum_of_limbs(x.representation(), x.is_negative(), //
-                                    detail::to_fixed_span(y_limbs), detail::integer_signbit(y));
+        return Result::make_sum_of_limbs(x.representation(),
+                                         x.is_negative(), //
+                                         detail::to_fixed_span(y_limbs),
+                                         detail::integer_signbit(y));
     } else {
         // `x` is a primitive integer
         static_assert(detail::is_basic_big_int_v<RT>);
         const auto x_limbs = detail::to_limbs(detail::uabs(x));
-        return Result::make_sum_of_limbs(detail::to_fixed_span(x_limbs), detail::integer_signbit(x), //
-                                    y.representation(), y.is_negative());
+        return Result::make_sum_of_limbs(detail::to_fixed_span(x_limbs),
+                                         detail::integer_signbit(x), //
+                                         y.representation(),
+                                         y.is_negative());
     }
 }
 
@@ -1065,19 +1071,25 @@ constexpr detail::common_big_int_type<L, R> operator-(L&& x, R&& y) {
     using RT     = std::remove_cvref_t<R>;
 
     if constexpr (detail::is_basic_big_int_v<LT> && detail::is_basic_big_int_v<RT>) {
-        return Result::make_sum_of_limbs(x.representation(), x.is_negative(), //
-                                    y.representation(), !y.is_negative());
+        return Result::make_sum_of_limbs(x.representation(),
+                                         x.is_negative(), //
+                                         y.representation(),
+                                         !y.is_negative());
     } else if constexpr (detail::is_basic_big_int_v<LT>) {
         // `y` is a primitive integer
         const auto y_limbs = detail::to_limbs(detail::uabs(y));
-        return Result::make_sum_of_limbs(x.representation(), x.is_negative(), //
-                                    detail::to_fixed_span(y_limbs), !detail::integer_signbit(y));
+        return Result::make_sum_of_limbs(x.representation(),
+                                         x.is_negative(), //
+                                         detail::to_fixed_span(y_limbs),
+                                         !detail::integer_signbit(y));
     } else {
         // `x` is a primitive integer
         static_assert(detail::is_basic_big_int_v<RT>);
         const auto x_limbs = detail::to_limbs(detail::uabs(x));
-        return Result::make_sum_of_limbs(detail::to_fixed_span(x_limbs), detail::integer_signbit(x), //
-                                    y.representation(), !y.is_negative());
+        return Result::make_sum_of_limbs(detail::to_fixed_span(x_limbs),
+                                         detail::integer_signbit(x), //
+                                         y.representation(),
+                                         !y.is_negative());
     }
 }
 

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -307,9 +307,9 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     friend constexpr std::strong_ordering operator<=>(const L& lhs, const R& rhs) noexcept;
 
     // [big.int.binary]
-    template <class L, detail::common_big_int_type_with<L> R>
+    template <class L, class R>
     friend constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y);
-    template <class L, detail::common_big_int_type_with<L> R>
+    template <class L, class R>
     friend constexpr detail::common_big_int_type<L, R> operator-(L&& x, R&& y);
 
   private:

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -116,6 +116,24 @@ template <signed_integer T>
     BEMAN_BIG_INT_DIAGNOSTIC_POP()
 }
 
+// This is purely for convenience, so we don't have to check all the time if an integer is signed or not
+template <unsigned_integer T>
+[[nodiscard]] constexpr T uabs(const T x) noexcept {
+    return x;
+}
+
+// The integer version of signbit, and again with unsigned impl purely out of convenience
+// Follows std::signbit convention: True = value is negative, False = value is positive
+template <signed_integer T>
+[[nodiscard]] constexpr bool integer_signbit(const T x) noexcept {
+    return x < T{0};
+}
+
+template <unsigned_integer T>
+[[nodiscard]] constexpr bool integer_signbit(const T) noexcept {
+    return false;
+}
+
 } // namespace detail
 
 // [big.int.class], class template basic_big_int

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -1129,51 +1129,11 @@ basic_big_int<b, A>::compare_limbs(const std::span<const uint_multiprecision_t, 
     if (std::is_neq(sign_compare)) {
         return sign_compare;
     }
-    const auto rep = representation();
 
-    // Compute the ordering as if both operands were non-negative (i.e., compare
-    // magnitudes). For two-negative operands we invert the result at the end,
-    // because a larger magnitude means a smaller value.
-    //
-    // Split on which side is longer so each branch carries only one high-tail scan.
-    // When extent != dynamic_extent, `limbs.size()` is a compile-time constant,
-    // so these loops can be more easily unrolled.
-    // We also don't need to do all three scans, just two for any given case.
-    const auto magnitude_ordering = [&]() -> std::strong_ordering {
-        if (rep.size() > limbs.size()) {
-            // If there are more significant nonzero digits in this integer, it is greater.
-            // Decimal example: 123 > 23
-            for (std::size_t i = rep.size(); i-- > limbs.size();) {
-                if (rep[i] != 0) {
-                    return std::strong_ordering::greater;
-                }
-            }
-            // Compare the common digits from most to least significant.
-            for (std::size_t i = limbs.size(); i-- > 0;) {
-                const auto result = rep[i] <=> limbs[i];
-                if (std::is_neq(result)) {
-                    return result;
-                }
-            }
-        } else {
-            // If there are more significant nonzero digits in limbs, this integer is lower.
-            // Decimal example: 23 < 123
-            for (std::size_t i = limbs.size(); i-- > rep.size();) {
-                if (limbs[i] != 0) {
-                    return std::strong_ordering::less;
-                }
-            }
-            // Compare the common digits from most to least significant.
-            for (std::size_t i = rep.size(); i-- > 0;) {
-                const auto result = rep[i] <=> limbs[i];
-                if (std::is_neq(result)) {
-                    return result;
-                }
-            }
-        }
-        // Having eliminated any possible mismatch, the two sides are equal.
-        return std::strong_ordering::equal;
-    }();
+    // Compute the ordering as if both operands were non-negative. For two-negative
+    // operands we invert the result at the end, because a larger magnitude means a
+    // smaller value.
+    const auto magnitude_ordering = detail::compare_limb_magnitudes(representation(), limbs);
 
     if (is_negative()) {
         // Invert: less <-> greater; equal is unchanged.
@@ -1185,6 +1145,96 @@ basic_big_int<b, A>::compare_limbs(const std::span<const uint_multiprecision_t, 
         }
     }
     return magnitude_ordering;
+}
+
+// Assigns the sum or difference of limbs to a "result" *this
+template <std::size_t b, class A>
+template <std::size_t extent_a, std::size_t extent_b>
+constexpr void
+basic_big_int<b, A>::assign_sum_of_limbs(const std::span<const uint_multiprecision_t, extent_a> lhs,
+                                         const bool                                             lhs_neg,
+                                         const std::span<const uint_multiprecision_t, extent_b> rhs,
+                                         const bool                                             rhs_neg) {
+    // Precondition: `*this` is in the default-constructed state (one inline limb of zero, sign positive).
+    BEMAN_BIG_INT_DEBUG_ASSERT(is_storage_static());
+    BEMAN_BIG_INT_DEBUG_ASSERT(limb_count() == 1);
+    BEMAN_BIG_INT_DEBUG_ASSERT(limb_ptr()[0] == 0);
+    BEMAN_BIG_INT_DEBUG_ASSERT(!is_negative());
+
+    if (lhs_neg == rhs_neg) {
+        // Same sign: add magnitudes limb-by-limb using carrying_add.
+        const std::size_t big = std::max(lhs.size(), rhs.size());
+
+        // `grow(big)` only allocates if `big > inplace_limbs`; otherwise it's a no-op
+        // and we stay in inline storage.
+        grow(big);
+        limb_type* const limbs = limb_ptr();
+
+        bool carry = false;
+        for (std::size_t i = 0; i < big; ++i) {
+            const limb_type li = i < lhs.size() ? lhs[i] : limb_type{0};
+            const limb_type ri = i < rhs.size() ? rhs[i] : limb_type{0};
+            const auto      [r_value, r_carry]  = detail::carrying_add(li, ri, carry);
+            limbs[i]           = r_value;
+            carry              = r_carry;
+        }
+        set_limb_count(static_cast<std::uint32_t>(big));
+
+        // If the ripple carry has actually produced an out-of-range carry, we allocate the extra limb.
+        // We want to avoid allocation or leaving inline storage as much as possible
+        if (carry) {
+            grow(big + 1);
+            limb_ptr()[big] = limb_type{1};
+            set_limb_count(static_cast<std::uint32_t>(big + 1));
+        }
+
+        // Preserve the "no negative zero" invariant
+        if (!is_zero()) {
+            set_sign(lhs_neg);
+        }
+        return;
+    }
+
+    // Differing signs: subtract the smaller magnitude from the larger,
+    // and take the sign of the larger-magnitude operand.
+    const auto magnitude_order = detail::compare_limb_magnitudes(lhs, rhs);
+
+    // When `lhs >= rhs` (in magnitude) compute `lhs - rhs` and take sign `lhs_neg`; otherwise
+    // compute `rhs - lhs` with sign `rhs_neg`. Equal magnitudes fall into the first branch
+    // and produce a normalized `+0`.
+    const std::span<const uint_multiprecision_t> larger  = std::is_gteq(magnitude_order) //
+                                                              ? std::span<const uint_multiprecision_t>(lhs)
+                                                              : std::span<const uint_multiprecision_t>(rhs);
+    const std::span<const uint_multiprecision_t> smaller = std::is_gteq(magnitude_order) //
+                                                              ? std::span<const uint_multiprecision_t>(rhs)
+                                                              : std::span<const uint_multiprecision_t>(lhs);
+    const bool result_sign = std::is_gteq(magnitude_order) ? lhs_neg : rhs_neg;
+
+    const std::size_t n = larger.size();
+    // Subtraction can never produce more limbs than the larger operand, so this grow is tight.
+    grow(n);
+    limb_type* const limbs = limb_ptr();
+
+    bool borrow = false;
+    for (std::size_t i = 0; i < n; ++i) {
+        const limb_type li = larger[i];
+        const limb_type si = i < smaller.size() ? smaller[i] : limb_type{0};
+        const auto      [r_value, r_borrow]  = detail::borrowing_sub(li, si, borrow);
+        limbs[i]           = r_value;
+        borrow             = r_borrow;
+    }
+    // Having picked `larger` correctly, the final borrow must be zero.
+    BEMAN_BIG_INT_DEBUG_ASSERT(!borrow);
+    set_limb_count(static_cast<std::uint32_t>(n));
+
+    // Trim leading zero limbs to maintain the "top limb non-zero unless value is zero" invariant.
+    while (limb_count() > 1 && limbs[limb_count() - 1] == 0) {
+        set_limb_count(limb_count() - 1);
+    }
+
+    if (!is_zero()) {
+        set_sign(result_sign);
+    }
 }
 
 // private helpers

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -1039,21 +1039,20 @@ constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y) {
     Result result;
 
     if constexpr (detail::is_basic_big_int_v<LT> && detail::is_basic_big_int_v<RT>) {
-        result.assign_sum_of_limbs(x.representation(), x.is_negative(),
-                                   y.representation(), y.is_negative());
+        result.assign_sum_of_limbs(x.representation(), x.is_negative(), y.representation(), y.is_negative());
     } else if constexpr (detail::is_basic_big_int_v<LT>) {
         // `y` is a primitive integer
         // Convert to a span for use in assign_sum_of_limbs
         const auto y_limbs = detail::to_limbs(detail::uabs(y));
-        result.assign_sum_of_limbs(x.representation(), x.is_negative(),
-                                   detail::to_fixed_span(y_limbs), detail::integer_signbit(y));
+        result.assign_sum_of_limbs(
+            x.representation(), x.is_negative(), detail::to_fixed_span(y_limbs), detail::integer_signbit(y));
     } else {
         // `x` is a primitive integer
         // Convert to a span for use in assign_sum_of_limbs
         static_assert(detail::is_basic_big_int_v<RT>);
         const auto x_limbs = detail::to_limbs(detail::uabs(x));
-        result.assign_sum_of_limbs(detail::to_fixed_span(x_limbs), detail::integer_signbit(x),
-                                   y.representation(), y.is_negative());
+        result.assign_sum_of_limbs(
+            detail::to_fixed_span(x_limbs), detail::integer_signbit(x), y.representation(), y.is_negative());
     }
 
     return result;
@@ -1071,19 +1070,18 @@ constexpr detail::common_big_int_type<L, R> operator-(L&& x, R&& y) {
     Result result;
 
     if constexpr (detail::is_basic_big_int_v<LT> && detail::is_basic_big_int_v<RT>) {
-        result.assign_sum_of_limbs(x.representation(), x.is_negative(),
-                                   y.representation(), !y.is_negative());
+        result.assign_sum_of_limbs(x.representation(), x.is_negative(), y.representation(), !y.is_negative());
     } else if constexpr (detail::is_basic_big_int_v<LT>) {
         // `y` is a primitive integer
         const auto y_limbs = detail::to_limbs(detail::uabs(y));
-        result.assign_sum_of_limbs(x.representation(), x.is_negative(),
-                                   detail::to_fixed_span(y_limbs), !detail::integer_signbit(y));
+        result.assign_sum_of_limbs(
+            x.representation(), x.is_negative(), detail::to_fixed_span(y_limbs), !detail::integer_signbit(y));
     } else {
         // `x` is a primitive integer
         static_assert(detail::is_basic_big_int_v<RT>);
         const auto x_limbs = detail::to_limbs(detail::uabs(x));
-        result.assign_sum_of_limbs(detail::to_fixed_span(x_limbs), detail::integer_signbit(x),
-                                   y.representation(), !y.is_negative());
+        result.assign_sum_of_limbs(
+            detail::to_fixed_span(x_limbs), detail::integer_signbit(x), y.representation(), !y.is_negative());
     }
 
     return result;
@@ -1225,11 +1223,10 @@ basic_big_int<b, A>::compare_limbs(const std::span<const uint_multiprecision_t, 
 // Assigns the sum or difference of limbs to a "result" *this
 template <std::size_t b, class A>
 template <std::size_t extent_a, std::size_t extent_b>
-constexpr void
-basic_big_int<b, A>::assign_sum_of_limbs(const std::span<const uint_multiprecision_t, extent_a> lhs,
-                                         const bool                                             lhs_neg,
-                                         const std::span<const uint_multiprecision_t, extent_b> rhs,
-                                         const bool                                             rhs_neg) {
+constexpr void basic_big_int<b, A>::assign_sum_of_limbs(const std::span<const uint_multiprecision_t, extent_a> lhs,
+                                                        const bool                                             lhs_neg,
+                                                        const std::span<const uint_multiprecision_t, extent_b> rhs,
+                                                        const bool rhs_neg) {
     // Precondition: `*this` is in the default-constructed state (one inline limb of zero, sign positive).
     BEMAN_BIG_INT_DEBUG_ASSERT(is_storage_static());
     BEMAN_BIG_INT_DEBUG_ASSERT(limb_count() == 1);
@@ -1247,11 +1244,11 @@ basic_big_int<b, A>::assign_sum_of_limbs(const std::span<const uint_multiprecisi
 
         bool carry = false;
         for (std::size_t i = 0; i < big; ++i) {
-            const limb_type li = i < lhs.size() ? lhs[i] : limb_type{0};
-            const limb_type ri = i < rhs.size() ? rhs[i] : limb_type{0};
-            const auto      [r_value, r_carry]  = detail::carrying_add(li, ri, carry);
-            limbs[i]           = r_value;
-            carry              = r_carry;
+            const limb_type li            = i < lhs.size() ? lhs[i] : limb_type{0};
+            const limb_type ri            = i < rhs.size() ? rhs[i] : limb_type{0};
+            const auto [r_value, r_carry] = detail::carrying_add(li, ri, carry);
+            limbs[i]                      = r_value;
+            carry                         = r_carry;
         }
         set_limb_count(static_cast<std::uint32_t>(big));
 
@@ -1277,13 +1274,13 @@ basic_big_int<b, A>::assign_sum_of_limbs(const std::span<const uint_multiprecisi
     // When `lhs >= rhs` (in magnitude) compute `lhs - rhs` and take sign `lhs_neg`; otherwise
     // compute `rhs - lhs` with sign `rhs_neg`. Equal magnitudes fall into the first branch
     // and produce a normalized `+0`.
-    const std::span<const uint_multiprecision_t> larger  = std::is_gteq(magnitude_order)
-                                                              ? std::span<const uint_multiprecision_t>(lhs)
-                                                              : std::span<const uint_multiprecision_t>(rhs);
-    const std::span<const uint_multiprecision_t> smaller = std::is_gteq(magnitude_order)
-                                                              ? std::span<const uint_multiprecision_t>(rhs)
-                                                              : std::span<const uint_multiprecision_t>(lhs);
-    const bool result_sign = std::is_gteq(magnitude_order) ? lhs_neg : rhs_neg;
+    const std::span<const uint_multiprecision_t> larger      = std::is_gteq(magnitude_order)
+                                                                   ? std::span<const uint_multiprecision_t>(lhs)
+                                                                   : std::span<const uint_multiprecision_t>(rhs);
+    const std::span<const uint_multiprecision_t> smaller     = std::is_gteq(magnitude_order)
+                                                                   ? std::span<const uint_multiprecision_t>(rhs)
+                                                                   : std::span<const uint_multiprecision_t>(lhs);
+    const bool                                   result_sign = std::is_gteq(magnitude_order) ? lhs_neg : rhs_neg;
 
     const std::size_t n = larger.size();
     // Subtraction can never produce more limbs than the larger operand, so this grow is tight.
@@ -1292,11 +1289,11 @@ basic_big_int<b, A>::assign_sum_of_limbs(const std::span<const uint_multiprecisi
 
     bool borrow = false;
     for (std::size_t i = 0; i < n; ++i) {
-        const limb_type li = larger[i];
-        const limb_type si = i < smaller.size() ? smaller[i] : limb_type{0};
-        const auto      [r_value, r_borrow]  = detail::borrowing_sub(li, si, borrow);
-        limbs[i]           = r_value;
-        borrow             = r_borrow;
+        const limb_type li             = larger[i];
+        const limb_type si             = i < smaller.size() ? smaller[i] : limb_type{0};
+        const auto [r_value, r_borrow] = detail::borrowing_sub(li, si, borrow);
+        limbs[i]                       = r_value;
+        borrow                         = r_borrow;
     }
     // Having picked `larger` correctly, the final borrow must be zero.
     BEMAN_BIG_INT_DEBUG_ASSERT(!borrow);

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -306,6 +306,12 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     template <class L, detail::common_big_int_type_with<L> R>
     friend constexpr std::strong_ordering operator<=>(const L& lhs, const R& rhs) noexcept;
 
+    // [big.int.binary]
+    template <class L, detail::common_big_int_type_with<L> R>
+    friend constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y);
+    template <class L, detail::common_big_int_type_with<L> R>
+    friend constexpr detail::common_big_int_type<L, R> operator-(L&& x, R&& y);
+
   private:
     template <detail::unsigned_integer T>
     constexpr void assign_magnitude(T value) noexcept;
@@ -348,6 +354,15 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     template <std::size_t extent>
     [[nodiscard]] constexpr std::strong_ordering compare_limbs(std::span<const uint_multiprecision_t, extent> limbs,
                                                                bool limbs_negative) const noexcept;
+
+    // Overwrites `*this` with the sum `(lhs, lhs_neg) + (rhs, rhs_neg)`,
+    // Assumes `*this` is in the default-constructed state (inline storage, magnitude zero, sign positive).
+    // Only allocates heap storage if the final result is certain to exceed the inline limb capacity
+    template <std::size_t extent_a, std::size_t extent_b>
+    constexpr void assign_sum_of_limbs(std::span<const uint_multiprecision_t, extent_a> lhs,
+                                       bool                                             lhs_neg,
+                                       std::span<const uint_multiprecision_t, extent_b> rhs,
+                                       bool                                             rhs_neg);
 
     static constexpr bool        has_inplace_to_bit_uint = inplace_bits <= BEMAN_BIG_INT_BITINT_MAXWIDTH;
     [[nodiscard]] constexpr auto inplace_to_bit_uint() const noexcept
@@ -1013,6 +1028,66 @@ compare_limb_magnitudes(const std::span<const uint_multiprecision_t, extent_a> a
 }
 
 } // namespace detail
+
+// [big.int.binary]
+template <class L, detail::common_big_int_type_with<L> R>
+constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y) {
+    using Result = detail::common_big_int_type<L, R>;
+    using LT     = std::remove_cvref_t<L>;
+    using RT     = std::remove_cvref_t<R>;
+
+    Result result;
+
+    if constexpr (detail::is_basic_big_int_v<LT> && detail::is_basic_big_int_v<RT>) {
+        result.assign_sum_of_limbs(x.representation(), x.is_negative(),
+                                   y.representation(), y.is_negative());
+    } else if constexpr (detail::is_basic_big_int_v<LT>) {
+        // `y` is a primitive integer
+        // Convert to a span for use in assign_sum_of_limbs
+        const auto y_limbs = detail::to_limbs(detail::uabs(y));
+        result.assign_sum_of_limbs(x.representation(), x.is_negative(),
+                                   detail::to_fixed_span(y_limbs), detail::integer_signbit(y));
+    } else {
+        // `x` is a primitive integer
+        // Convert to a span for use in assign_sum_of_limbs
+        static_assert(detail::is_basic_big_int_v<RT>);
+        const auto x_limbs = detail::to_limbs(detail::uabs(x));
+        result.assign_sum_of_limbs(detail::to_fixed_span(x_limbs), detail::integer_signbit(x),
+                                   y.representation(), y.is_negative());
+    }
+
+    return result;
+}
+
+// `x - y` is implemented as `x + (-y)`: we flip the sign of the right-hand operand
+// (without materializing a negated value) and dispatch through the same magnitude
+// add/subtract path as `operator+`.
+template <class L, detail::common_big_int_type_with<L> R>
+constexpr detail::common_big_int_type<L, R> operator-(L&& x, R&& y) {
+    using Result = detail::common_big_int_type<L, R>;
+    using LT     = std::remove_cvref_t<L>;
+    using RT     = std::remove_cvref_t<R>;
+
+    Result result;
+
+    if constexpr (detail::is_basic_big_int_v<LT> && detail::is_basic_big_int_v<RT>) {
+        result.assign_sum_of_limbs(x.representation(), x.is_negative(),
+                                   y.representation(), !y.is_negative());
+    } else if constexpr (detail::is_basic_big_int_v<LT>) {
+        // `y` is a primitive integer
+        const auto y_limbs = detail::to_limbs(detail::uabs(y));
+        result.assign_sum_of_limbs(x.representation(), x.is_negative(),
+                                   detail::to_fixed_span(y_limbs), !detail::integer_signbit(y));
+    } else {
+        // `x` is a primitive integer
+        static_assert(detail::is_basic_big_int_v<RT>);
+        const auto x_limbs = detail::to_limbs(detail::uabs(x));
+        result.assign_sum_of_limbs(detail::to_fixed_span(x_limbs), detail::integer_signbit(x),
+                                   y.representation(), !y.is_negative());
+    }
+
+    return result;
+}
 
 template <std::size_t b, class A>
 template <detail::signed_or_unsigned Integer>

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -355,14 +355,15 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     [[nodiscard]] constexpr std::strong_ordering compare_limbs(std::span<const uint_multiprecision_t, extent> limbs,
                                                                bool limbs_negative) const noexcept;
 
-    // Overwrites `*this` with the sum `(lhs, lhs_neg) + (rhs, rhs_neg)`,
-    // Assumes `*this` is in the default-constructed state (inline storage, magnitude zero, sign positive).
+    // Returns the sum `(lhs, lhs_neg) + (rhs, rhs_neg)` as a fresh `basic_big_int`.
     // Only allocates heap storage if the final result is certain to exceed the inline limb capacity
+    // (a speculative top-limb carry only triggers a grow after the carry actually occurs).
     template <std::size_t extent_a, std::size_t extent_b>
-    constexpr void assign_sum_of_limbs(std::span<const uint_multiprecision_t, extent_a> lhs,
-                                       bool                                             lhs_neg,
-                                       std::span<const uint_multiprecision_t, extent_b> rhs,
-                                       bool                                             rhs_neg);
+    [[nodiscard]] static constexpr basic_big_int
+    make_sum_of_limbs(std::span<const uint_multiprecision_t, extent_a> lhs,
+                 bool                                             lhs_neg,
+                 std::span<const uint_multiprecision_t, extent_b> rhs,
+                 bool                                             rhs_neg);
 
     static constexpr bool        has_inplace_to_bit_uint = inplace_bits <= BEMAN_BIG_INT_BITINT_MAXWIDTH;
     [[nodiscard]] constexpr auto inplace_to_bit_uint() const noexcept
@@ -1030,61 +1031,54 @@ compare_limb_magnitudes(const std::span<const uint_multiprecision_t, extent_a> a
 } // namespace detail
 
 // [big.int.binary]
-template <class L, detail::common_big_int_type_with<L> R>
+template <class L, class R>
 constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y) {
     using Result = detail::common_big_int_type<L, R>;
     using LT     = std::remove_cvref_t<L>;
     using RT     = std::remove_cvref_t<R>;
 
-    Result result;
-
     if constexpr (detail::is_basic_big_int_v<LT> && detail::is_basic_big_int_v<RT>) {
-        result.assign_sum_of_limbs(x.representation(), x.is_negative(), y.representation(), y.is_negative());
+        return Result::make_sum_of_limbs(x.representation(), x.is_negative(), //
+                                    y.representation(), y.is_negative());
     } else if constexpr (detail::is_basic_big_int_v<LT>) {
-        // `y` is a primitive integer
-        // Convert to a span for use in assign_sum_of_limbs
+        // `y` is a primitive integer; materialize it as a fixed-extent limb array
+        // so the span we pass to the helper stays valid for the call.
         const auto y_limbs = detail::to_limbs(detail::uabs(y));
-        result.assign_sum_of_limbs(
-            x.representation(), x.is_negative(), detail::to_fixed_span(y_limbs), detail::integer_signbit(y));
+        return Result::make_sum_of_limbs(x.representation(), x.is_negative(), //
+                                    detail::to_fixed_span(y_limbs), detail::integer_signbit(y));
     } else {
         // `x` is a primitive integer
-        // Convert to a span for use in assign_sum_of_limbs
         static_assert(detail::is_basic_big_int_v<RT>);
         const auto x_limbs = detail::to_limbs(detail::uabs(x));
-        result.assign_sum_of_limbs(
-            detail::to_fixed_span(x_limbs), detail::integer_signbit(x), y.representation(), y.is_negative());
+        return Result::make_sum_of_limbs(detail::to_fixed_span(x_limbs), detail::integer_signbit(x), //
+                                    y.representation(), y.is_negative());
     }
-
-    return result;
 }
 
 // `x - y` is implemented as `x + (-y)`: we flip the sign of the right-hand operand
 // (without materializing a negated value) and dispatch through the same magnitude
 // add/subtract path as `operator+`.
-template <class L, detail::common_big_int_type_with<L> R>
+template <class L, class R>
 constexpr detail::common_big_int_type<L, R> operator-(L&& x, R&& y) {
     using Result = detail::common_big_int_type<L, R>;
     using LT     = std::remove_cvref_t<L>;
     using RT     = std::remove_cvref_t<R>;
 
-    Result result;
-
     if constexpr (detail::is_basic_big_int_v<LT> && detail::is_basic_big_int_v<RT>) {
-        result.assign_sum_of_limbs(x.representation(), x.is_negative(), y.representation(), !y.is_negative());
+        return Result::make_sum_of_limbs(x.representation(), x.is_negative(), //
+                                    y.representation(), !y.is_negative());
     } else if constexpr (detail::is_basic_big_int_v<LT>) {
         // `y` is a primitive integer
         const auto y_limbs = detail::to_limbs(detail::uabs(y));
-        result.assign_sum_of_limbs(
-            x.representation(), x.is_negative(), detail::to_fixed_span(y_limbs), !detail::integer_signbit(y));
+        return Result::make_sum_of_limbs(x.representation(), x.is_negative(), //
+                                    detail::to_fixed_span(y_limbs), !detail::integer_signbit(y));
     } else {
         // `x` is a primitive integer
         static_assert(detail::is_basic_big_int_v<RT>);
         const auto x_limbs = detail::to_limbs(detail::uabs(x));
-        result.assign_sum_of_limbs(
-            detail::to_fixed_span(x_limbs), detail::integer_signbit(x), y.representation(), !y.is_negative());
+        return Result::make_sum_of_limbs(detail::to_fixed_span(x_limbs), detail::integer_signbit(x), //
+                                    y.representation(), !y.is_negative());
     }
-
-    return result;
 }
 
 template <std::size_t b, class A>
@@ -1220,18 +1214,15 @@ basic_big_int<b, A>::compare_limbs(const std::span<const uint_multiprecision_t, 
     return magnitude_ordering;
 }
 
-// Assigns the sum or difference of limbs to a "result" *this
+// Builds the sum or difference of two limb spans and returns it as a fresh `basic_big_int`.
 template <std::size_t b, class A>
 template <std::size_t extent_a, std::size_t extent_b>
-constexpr void basic_big_int<b, A>::assign_sum_of_limbs(const std::span<const uint_multiprecision_t, extent_a> lhs,
-                                                        const bool                                             lhs_neg,
-                                                        const std::span<const uint_multiprecision_t, extent_b> rhs,
-                                                        const bool rhs_neg) {
-    // Precondition: `*this` is in the default-constructed state (one inline limb of zero, sign positive).
-    BEMAN_BIG_INT_DEBUG_ASSERT(is_storage_static());
-    BEMAN_BIG_INT_DEBUG_ASSERT(limb_count() == 1);
-    BEMAN_BIG_INT_DEBUG_ASSERT(limb_ptr()[0] == 0);
-    BEMAN_BIG_INT_DEBUG_ASSERT(!is_negative());
+constexpr basic_big_int<b, A>
+basic_big_int<b, A>::make_sum_of_limbs(const std::span<const uint_multiprecision_t, extent_a> lhs,
+                                       const bool                                             lhs_neg,
+                                       const std::span<const uint_multiprecision_t, extent_b> rhs,
+                                       const bool                                             rhs_neg) {
+    basic_big_int result;
 
     if (lhs_neg == rhs_neg) {
         // Same sign: add magnitudes limb-by-limb using carrying_add.
@@ -1239,8 +1230,8 @@ constexpr void basic_big_int<b, A>::assign_sum_of_limbs(const std::span<const ui
 
         // `grow(big)` only allocates if `big > inplace_limbs`; otherwise it's a no-op
         // and we stay in inline storage.
-        grow(big);
-        limb_type* const limbs = limb_ptr();
+        result.grow(big);
+        limb_type* const limbs = result.limb_ptr();
 
         bool carry = false;
         for (std::size_t i = 0; i < big; ++i) {
@@ -1250,21 +1241,21 @@ constexpr void basic_big_int<b, A>::assign_sum_of_limbs(const std::span<const ui
             limbs[i]                      = r_value;
             carry                         = r_carry;
         }
-        set_limb_count(static_cast<std::uint32_t>(big));
+        result.set_limb_count(static_cast<std::uint32_t>(big));
 
         // If the ripple carry has actually produced an out-of-range carry, we allocate the extra limb.
         // We want to avoid allocation or leaving inline storage as much as possible
         if (carry) {
-            grow(big + 1);
-            limb_ptr()[big] = limb_type{1};
-            set_limb_count(static_cast<std::uint32_t>(big + 1));
+            result.grow(big + 1);
+            result.limb_ptr()[big] = limb_type{1};
+            result.set_limb_count(static_cast<std::uint32_t>(big + 1));
         }
 
         // Preserve the "no negative zero" invariant
-        if (!is_zero()) {
-            set_sign(lhs_neg);
+        if (!result.is_zero()) {
+            result.set_sign(lhs_neg);
         }
-        return;
+        return result;
     }
 
     // Differing signs: subtract the smaller magnitude from the larger,
@@ -1284,8 +1275,8 @@ constexpr void basic_big_int<b, A>::assign_sum_of_limbs(const std::span<const ui
 
     const std::size_t n = larger.size();
     // Subtraction can never produce more limbs than the larger operand, so this grow is tight.
-    grow(n);
-    limb_type* const limbs = limb_ptr();
+    result.grow(n);
+    limb_type* const limbs = result.limb_ptr();
 
     bool borrow = false;
     for (std::size_t i = 0; i < n; ++i) {
@@ -1297,16 +1288,17 @@ constexpr void basic_big_int<b, A>::assign_sum_of_limbs(const std::span<const ui
     }
     // Having picked `larger` correctly, the final borrow must be zero.
     BEMAN_BIG_INT_DEBUG_ASSERT(!borrow);
-    set_limb_count(static_cast<std::uint32_t>(n));
+    result.set_limb_count(static_cast<std::uint32_t>(n));
 
     // Trim leading zero limbs to maintain the "top limb non-zero unless value is zero" invariant.
-    while (limb_count() > 1 && limbs[limb_count() - 1] == 0) {
-        set_limb_count(limb_count() - 1);
+    while (result.limb_count() > 1 && limbs[result.limb_count() - 1] == 0) {
+        result.set_limb_count(result.limb_count() - 1);
     }
 
-    if (!is_zero()) {
-        set_sign(result_sign);
+    if (!result.is_zero()) {
+        result.set_sign(result_sign);
     }
+    return result;
 }
 
 // private helpers

--- a/include/beman/big_int/wide_ops.hpp
+++ b/include/beman/big_int/wide_ops.hpp
@@ -276,37 +276,31 @@ template <unsigned_integer T>
     // This is more portable.
     // Each branch returns directly, so we don't share uninitialized state
     // across the `if constexpr` chain.
-    // We also have to duplicate the fall through case because if not consteval is broken on msvc
-
-    if consteval {
-        const auto result = static_cast<wider_t<T>>(x) + static_cast<wider_t<T>>(y) + carry;
-        return {.value = static_cast<T>(result), .carry = (result >> width_v<T>) != 0};
-    }
-
-    if constexpr (std::is_same_v<T, std::uint8_t>) {
-        T                   value;
-        const unsigned char carry_out = _addcarry_u8(static_cast<unsigned char>(carry), x, y, &value);
-        return {.value = value, .carry = carry_out != 0};
-    } else if constexpr (std::is_same_v<T, std::uint16_t>) {
-        T                   value;
-        const unsigned char carry_out = _addcarry_u16(static_cast<unsigned char>(carry), x, y, &value);
-        return {.value = value, .carry = carry_out != 0};
-    } else if constexpr (std::is_same_v<T, std::uint32_t>) {
-        T                   value;
-        const unsigned char carry_out = _addcarry_u32(static_cast<unsigned char>(carry), x, y, &value);
-        return {.value = value, .carry = carry_out != 0};
-    }
+    if BEMAN_BIG_INT_IS_NOT_CONSTEVAL {
+        if constexpr (std::is_same_v<T, std::uint8_t>) {
+            T                   value;
+            const unsigned char carry_out = _addcarry_u8(static_cast<unsigned char>(carry), x, y, &value);
+            return {.value = value, .carry = carry_out != 0};
+        } else if constexpr (std::is_same_v<T, std::uint16_t>) {
+            T                   value;
+            const unsigned char carry_out = _addcarry_u16(static_cast<unsigned char>(carry), x, y, &value);
+            return {.value = value, .carry = carry_out != 0};
+        } else if constexpr (std::is_same_v<T, std::uint32_t>) {
+            T                   value;
+            const unsigned char carry_out = _addcarry_u32(static_cast<unsigned char>(carry), x, y, &value);
+            return {.value = value, .carry = carry_out != 0};
+        }
     #ifdef _M_AMD64
-    else if constexpr (std::is_same_v<T, std::uint64_t>) {
-        T                   value;
-        const unsigned char carry_out = _addcarry_u64(static_cast<unsigned char>(carry), x, y, &value);
-        return {.value = value, .carry = carry_out != 0};
-    }
+        else if constexpr (std::is_same_v<T, std::uint64_t>) {
+            T                   value;
+            const unsigned char carry_out = _addcarry_u64(static_cast<unsigned char>(carry), x, y, &value);
+            return {.value = value, .carry = carry_out != 0};
+        }
     #endif
-    else {
-        const auto result = static_cast<wider_t<T>>(x) + static_cast<wider_t<T>>(y) + carry;
-        return {.value = static_cast<T>(result), .carry = (result >> width_v<T>) != 0};
     }
+    // Fallback: reached at consteval time, or at runtime when `T` has no matching intrinsic.
+    const auto result = static_cast<wider_t<T>>(x) + static_cast<wider_t<T>>(y) + carry;
+    return {.value = static_cast<T>(result), .carry = (result >> width_v<T>) != 0};
 #else
     auto result    = static_cast<wider_t<T>>(x) + static_cast<wider_t<T>>(y) + carry;
     bool carry_out = (result >> width_v<T>) != 0;
@@ -336,36 +330,31 @@ template <unsigned_integer T>
     // Mirror the `carrying_add` MSVC path using the matching `_subborrow_*` intrinsics.
     // Each branch returns directly, so we don't share uninitialized state across the
     // `if constexpr` chain.
-
-    if consteval {
-        const auto result = static_cast<wider_t<T>>(x) - static_cast<wider_t<T>>(y) - borrow;
-        return {.value = static_cast<T>(result), .borrow = (result >> width_v<T>) != 0};
-    }
-
-    if constexpr (std::is_same_v<T, std::uint8_t>) {
-        T                   value;
-        const unsigned char borrow_out = _subborrow_u8(static_cast<unsigned char>(borrow), x, y, &value);
-        return {.value = value, .borrow = borrow_out != 0};
-    } else if constexpr (std::is_same_v<T, std::uint16_t>) {
-        T                   value;
-        const unsigned char borrow_out = _subborrow_u16(static_cast<unsigned char>(borrow), x, y, &value);
-        return {.value = value, .borrow = borrow_out != 0};
-    } else if constexpr (std::is_same_v<T, std::uint32_t>) {
-        T                   value;
-        const unsigned char borrow_out = _subborrow_u32(static_cast<unsigned char>(borrow), x, y, &value);
-        return {.value = value, .borrow = borrow_out != 0};
-    }
+    if BEMAN_BIG_INT_IS_NOT_CONSTEVAL {
+        if constexpr (std::is_same_v<T, std::uint8_t>) {
+            T                   value;
+            const unsigned char borrow_out = _subborrow_u8(static_cast<unsigned char>(borrow), x, y, &value);
+            return {.value = value, .borrow = borrow_out != 0};
+        } else if constexpr (std::is_same_v<T, std::uint16_t>) {
+            T                   value;
+            const unsigned char borrow_out = _subborrow_u16(static_cast<unsigned char>(borrow), x, y, &value);
+            return {.value = value, .borrow = borrow_out != 0};
+        } else if constexpr (std::is_same_v<T, std::uint32_t>) {
+            T                   value;
+            const unsigned char borrow_out = _subborrow_u32(static_cast<unsigned char>(borrow), x, y, &value);
+            return {.value = value, .borrow = borrow_out != 0};
+        }
     #ifdef _M_AMD64
-    else if constexpr (std::is_same_v<T, std::uint64_t>) {
-        T                   value;
-        const unsigned char borrow_out = _subborrow_u64(static_cast<unsigned char>(borrow), x, y, &value);
-        return {.value = value, .borrow = borrow_out != 0};
-    }
+        else if constexpr (std::is_same_v<T, std::uint64_t>) {
+            T                   value;
+            const unsigned char borrow_out = _subborrow_u64(static_cast<unsigned char>(borrow), x, y, &value);
+            return {.value = value, .borrow = borrow_out != 0};
+        }
     #endif
-    else {
-        const auto result = static_cast<wider_t<T>>(x) - static_cast<wider_t<T>>(y) - borrow;
-        return {.value = static_cast<T>(result), .borrow = (result >> width_v<T>) != 0};
     }
+    // Fallback: reached at consteval time, or at runtime when `T` has no matching intrinsic.
+    const auto result = static_cast<wider_t<T>>(x) - static_cast<wider_t<T>>(y) - borrow;
+    return {.value = static_cast<T>(result), .borrow = (result >> width_v<T>) != 0};
 #else
     auto result     = static_cast<wider_t<T>>(x) - static_cast<wider_t<T>>(y) - borrow;
     bool borrow_out = (result >> width_v<T>) != 0;

--- a/include/beman/big_int/wide_ops.hpp
+++ b/include/beman/big_int/wide_ops.hpp
@@ -276,6 +276,13 @@ template <unsigned_integer T>
     // This is more portable.
     // Each branch returns directly, so we don't share uninitialized state
     // across the `if constexpr` chain.
+    // We also have to duplicate the fall through case because if not consteval is broken on msvc
+
+    if consteval {
+        const auto result = static_cast<wider_t<T>>(x) + static_cast<wider_t<T>>(y) + carry;
+        return {.value = static_cast<T>(result), .carry = (result >> width_v<T>) != 0};
+    }
+
     if constexpr (std::is_same_v<T, std::uint8_t>) {
         T                   value;
         const unsigned char carry_out = _addcarry_u8(static_cast<unsigned char>(carry), x, y, &value);
@@ -329,6 +336,12 @@ template <unsigned_integer T>
     // Mirror the `carrying_add` MSVC path using the matching `_subborrow_*` intrinsics.
     // Each branch returns directly, so we don't share uninitialized state across the
     // `if constexpr` chain.
+
+    if consteval {
+        const auto result = static_cast<wider_t<T>>(x) - static_cast<wider_t<T>>(y) - borrow;
+        return {.value = static_cast<T>(result), .borrow = (result >> width_v<T>) != 0};
+    }
+
     if constexpr (std::is_same_v<T, std::uint8_t>) {
         T                   value;
         const unsigned char borrow_out = _subborrow_u8(static_cast<unsigned char>(borrow), x, y, &value);

--- a/include/beman/big_int/wide_ops.hpp
+++ b/include/beman/big_int/wide_ops.hpp
@@ -271,6 +271,35 @@ template <unsigned_integer T>
     unsigned long long carry_out;
     unsigned long long value = __builtin_addcll(x, y, carry, &carry_out);
     return {.value = value, .carry = carry_out != 0};
+#elif defined(BEMAN_BIG_INT_MSVC) && (defined(_M_AMD64) || defined(_M_IX86))
+    // Theoretically we could use the ADX intrinsic, but then the user always has to compile for it
+    // This is more portable.
+    // Each branch returns directly, so we don't share uninitialized state
+    // across the `if constexpr` chain.
+    if constexpr (std::is_same_v<T, std::uint8_t>) {
+        T                   value;
+        const unsigned char carry_out = _addcarry_u8(static_cast<unsigned char>(carry), x, y, &value);
+        return {.value = value, .carry = carry_out != 0};
+    } else if constexpr (std::is_same_v<T, std::uint16_t>) {
+        T                   value;
+        const unsigned char carry_out = _addcarry_u16(static_cast<unsigned char>(carry), x, y, &value);
+        return {.value = value, .carry = carry_out != 0};
+    } else if constexpr (std::is_same_v<T, std::uint32_t>) {
+        T                   value;
+        const unsigned char carry_out = _addcarry_u32(static_cast<unsigned char>(carry), x, y, &value);
+        return {.value = value, .carry = carry_out != 0};
+    }
+    #ifdef _M_AMD64
+    else if constexpr (std::is_same_v<T, std::uint64_t>) {
+        T                   value;
+        const unsigned char carry_out = _addcarry_u64(static_cast<unsigned char>(carry), x, y, &value);
+        return {.value = value, .carry = carry_out != 0};
+    }
+    #endif
+    else {
+        const auto result = static_cast<wider_t<T>>(x) + static_cast<wider_t<T>>(y) + carry;
+        return {.value = static_cast<T>(result), .carry = (result >> width_v<T>) != 0};
+    }
 #else
     auto result    = static_cast<wider_t<T>>(x) + static_cast<wider_t<T>>(y) + carry;
     bool carry_out = (result >> width_v<T>) != 0;
@@ -296,6 +325,34 @@ template <unsigned_integer T>
     unsigned long long borrow_out;
     unsigned long long value = __builtin_subcll(x, y, borrow, &borrow_out);
     return {.value = value, .borrow = borrow_out != 0};
+#elif defined(BEMAN_BIG_INT_MSVC) && (defined(_M_AMD64) || defined(_M_IX86))
+    // Mirror the `carrying_add` MSVC path using the matching `_subborrow_*` intrinsics.
+    // Each branch returns directly, so we don't share uninitialized state across the
+    // `if constexpr` chain.
+    if constexpr (std::is_same_v<T, std::uint8_t>) {
+        T                   value;
+        const unsigned char borrow_out = _subborrow_u8(static_cast<unsigned char>(borrow), x, y, &value);
+        return {.value = value, .borrow = borrow_out != 0};
+    } else if constexpr (std::is_same_v<T, std::uint16_t>) {
+        T                   value;
+        const unsigned char borrow_out = _subborrow_u16(static_cast<unsigned char>(borrow), x, y, &value);
+        return {.value = value, .borrow = borrow_out != 0};
+    } else if constexpr (std::is_same_v<T, std::uint32_t>) {
+        T                   value;
+        const unsigned char borrow_out = _subborrow_u32(static_cast<unsigned char>(borrow), x, y, &value);
+        return {.value = value, .borrow = borrow_out != 0};
+    }
+    #ifdef _M_AMD64
+    else if constexpr (std::is_same_v<T, std::uint64_t>) {
+        T                   value;
+        const unsigned char borrow_out = _subborrow_u64(static_cast<unsigned char>(borrow), x, y, &value);
+        return {.value = value, .borrow = borrow_out != 0};
+    }
+    #endif
+    else {
+        const auto result = static_cast<wider_t<T>>(x) - static_cast<wider_t<T>>(y) - borrow;
+        return {.value = static_cast<T>(result), .borrow = (result >> width_v<T>) != 0};
+    }
 #else
     auto result     = static_cast<wider_t<T>>(x) - static_cast<wider_t<T>>(y) - borrow;
     bool borrow_out = (result >> width_v<T>) != 0;

--- a/tests/beman/big_int/addition.test.cpp
+++ b/tests/beman/big_int/addition.test.cpp
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: BSL-1.0
+
+#include <cstdint>
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include <beman/big_int/big_int.hpp>
+
+namespace {
+
+using beman::big_int::basic_big_int;
+using beman::big_int::big_int;
+using beman::big_int::uint_multiprecision_t;
+
+// ----- compile-time sanity -----
+// Note: we compare big_int-to-big_int rather than big_int-to-primitive to avoid
+// the `_BitInt` bit_cast path that some toolchains don't yet support in constant
+// evaluation. Sign / storage-promotion properties are covered by the runtime tests.
+
+consteval bool ce_zero_plus_zero() {
+    return (big_int{0} + big_int{0}) == big_int{0};
+}
+static_assert(ce_zero_plus_zero());
+
+consteval bool ce_small_positive() {
+    return (big_int{1} + big_int{2}) == big_int{3};
+}
+static_assert(ce_small_positive());
+
+consteval bool ce_cancel_to_zero() {
+    return (big_int{-5} + big_int{5}) == big_int{0};
+}
+static_assert(ce_cancel_to_zero());
+
+consteval bool ce_mixed_sign_positive_result() {
+    return (big_int{5} + big_int{-3}) == big_int{2};
+}
+static_assert(ce_mixed_sign_positive_result());
+
+consteval bool ce_mixed_sign_negative_result() {
+    return (big_int{-5} + big_int{3}) == big_int{-2};
+}
+static_assert(ce_mixed_sign_negative_result());
+
+consteval bool ce_same_sign_negative() {
+    return (big_int{-5} + big_int{-3}) == big_int{-8};
+}
+static_assert(ce_same_sign_negative());
+
+// ----- runtime tests -----
+
+TEST(Addition, SmallPositivePositive) {
+    EXPECT_EQ(big_int{1} + big_int{2}, 3);
+    EXPECT_EQ(big_int{40} + big_int{2}, 42);
+}
+
+TEST(Addition, SmallNegativeNegative) {
+    EXPECT_EQ(big_int{-1} + big_int{-2}, -3);
+    EXPECT_EQ(big_int{-40} + big_int{-2}, -42);
+}
+
+TEST(Addition, MixedSigns) {
+    EXPECT_EQ(big_int{-5} + big_int{3}, -2);
+    EXPECT_EQ(big_int{5} + big_int{-3}, 2);
+    EXPECT_EQ(big_int{3} + big_int{-5}, -2);
+    EXPECT_EQ(big_int{-3} + big_int{5}, 2);
+}
+
+TEST(Addition, CancelToExactZeroIsPositive) {
+    // The "no negative zero" invariant must hold: -a + a must be +0.
+    const big_int r = big_int{-7} + big_int{7};
+    EXPECT_EQ(r, 0);
+    EXPECT_FALSE(r < 0);
+
+    const big_int r2 = big_int{100} + big_int{-100};
+    EXPECT_EQ(r2, 0);
+    EXPECT_FALSE(r2 < 0);
+}
+
+TEST(Addition, ZeroIdentity) {
+    EXPECT_EQ(big_int{0} + big_int{0}, 0);
+    EXPECT_EQ(big_int{42} + big_int{0}, 42);
+    EXPECT_EQ(big_int{0} + big_int{42}, 42);
+    EXPECT_EQ(big_int{-42} + big_int{0}, -42);
+    EXPECT_EQ(big_int{0} + big_int{-42}, -42);
+}
+
+TEST(Addition, CarryOutOfTopLimbPromotesToHeap) {
+    // `basic_big_int<64>` with a 64-bit limb has exactly one inline limb.
+    // UINT64_MAX + 1 requires two limbs, so the result must live on the heap.
+    const big_int a{std::numeric_limits<std::uint64_t>::max()};
+    const big_int b{1};
+    ASSERT_TRUE(a.representation().size() == 1);
+    const big_int r = a + b;
+    // Value is 2^64.
+    EXPECT_EQ(r.representation().size(), 2u);
+    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
+    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+    EXPECT_FALSE(r < 0);
+    // Storage should have promoted out of inline.
+    EXPECT_GT(r.capacity(), 0u);
+}
+
+TEST(Addition, NoAllocationWhenInlineFits) {
+    // `basic_big_int<256>` has at least 4 inline limbs on any supported limb width.
+    // Small-value sum must remain in inline storage (capacity() == 0).
+    using big_int_256 = basic_big_int<256>;
+    const big_int_256 a{1};
+    const big_int_256 b{2};
+    const big_int_256 r = a + b;
+    EXPECT_EQ(r, 3);
+    EXPECT_EQ(r.capacity(), 0u);
+
+    // Even with both operands near the inline limit (but no carry out of
+    // the top inline limb), we should not allocate.
+    const big_int_256 c{std::numeric_limits<std::uint64_t>::max()};
+    const big_int_256 d{1};
+    const big_int_256 s = c + d;
+    // Value is 2^64, which fits in <= 4 inline limbs → no allocation.
+    EXPECT_EQ(s.capacity(), 0u);
+    EXPECT_EQ(s.representation().size(), 2u);
+    EXPECT_EQ(s.representation()[0], uint_multiprecision_t{0});
+    EXPECT_EQ(s.representation()[1], uint_multiprecision_t{1});
+}
+
+TEST(Addition, MultiLimbValuesSameSign) {
+    // Build 2^64 via UINT64_MAX + 1, then add another 2^64 to reach 2^65.
+    const big_int two_64     = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const big_int two_64_alt = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const big_int two_65     = two_64 + two_64_alt;
+    // 2^65 = [0, 2] in a 64-bit-limb representation.
+    ASSERT_EQ(two_65.representation().size(), 2u);
+    EXPECT_EQ(two_65.representation()[0], uint_multiprecision_t{0});
+    EXPECT_EQ(two_65.representation()[1], uint_multiprecision_t{2});
+}
+
+TEST(Addition, MultiLimbOppositeSignTrimsLeadingZeros) {
+    // 2^64 + (-1) = 2^64 - 1 = UINT64_MAX, which fits in a single limb.
+    const big_int two_64 = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    ASSERT_EQ(two_64.representation().size(), 2u);
+
+    const big_int r = two_64 + big_int{-1};
+    // The subtraction path must trim the now-zero upper limb.
+    ASSERT_EQ(r.representation().size(), 1u);
+    EXPECT_EQ(r.representation()[0], std::numeric_limits<std::uint64_t>::max());
+    EXPECT_FALSE(r < 0);
+}
+
+TEST(Addition, MultiLimbSubtractionToZero) {
+    // 2^64 + (-2^64) = 0 → must produce +0 with limb_count == 1.
+    const big_int two_64     = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const big_int neg_two_64 = -two_64;
+    const big_int r          = two_64 + neg_two_64;
+    ASSERT_EQ(r.representation().size(), 1u);
+    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
+    EXPECT_EQ(r, 0);
+    EXPECT_FALSE(r < 0);
+}
+
+TEST(Addition, BigIntPlusPrimitiveUnsigned) {
+    EXPECT_EQ(big_int{10} + 5U, 15);
+    EXPECT_EQ(big_int{-10} + 5U, -5);
+    EXPECT_EQ(big_int{-10} + 20U, 10);
+    EXPECT_EQ(big_int{10} + 0U, 10);
+}
+
+TEST(Addition, PrimitiveUnsignedPlusBigInt) {
+    EXPECT_EQ(5U + big_int{10}, 15);
+    EXPECT_EQ(5U + big_int{-10}, -5);
+    EXPECT_EQ(20U + big_int{-10}, 10);
+    EXPECT_EQ(0U + big_int{10}, 10);
+}
+
+TEST(Addition, BigIntPlusPrimitiveSigned) {
+    EXPECT_EQ(big_int{10} + 5, 15);
+    EXPECT_EQ(big_int{10} + -5, 5);
+    EXPECT_EQ(big_int{-10} + 5, -5);
+    EXPECT_EQ(big_int{-10} + -5, -15);
+    EXPECT_EQ(big_int{5} + -5, 0);
+}
+
+TEST(Addition, PrimitiveSignedPlusBigInt) {
+    EXPECT_EQ(5 + big_int{10}, 15);
+    EXPECT_EQ(-5 + big_int{10}, 5);
+    EXPECT_EQ(5 + big_int{-10}, -5);
+    EXPECT_EQ(-5 + big_int{-10}, -15);
+    EXPECT_EQ(-5 + big_int{5}, 0);
+}
+
+TEST(Addition, PrimitiveCarryIntoUpperLimb) {
+    // big_int{UINT64_MAX} + 1U must promote to two limbs.
+    const big_int r = big_int{std::numeric_limits<std::uint64_t>::max()} + 1U;
+    ASSERT_EQ(r.representation().size(), 2u);
+    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
+    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+}
+
+TEST(Addition, NegativePrimitiveIntoMultiLimb) {
+    // 2^64 + (-1) via primitive operand.
+    const big_int two_64 = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const big_int r      = two_64 + -1;
+    ASSERT_EQ(r.representation().size(), 1u);
+    EXPECT_EQ(r.representation()[0], std::numeric_limits<std::uint64_t>::max());
+}
+
+TEST(Addition, UnequalLengthMultiLimb) {
+    // (2^64 + 7) + 3 = 2^64 + 10, spanning two limbs on the left and one on the right.
+    const big_int two_64  = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const big_int a       = two_64 + big_int{7};
+    const big_int r       = a + big_int{3};
+    ASSERT_EQ(r.representation().size(), 2u);
+    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{10});
+    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+
+    // Same but with a negative short operand: (2^64 + 7) + (-3) = 2^64 + 4.
+    const big_int r2 = a + big_int{-3};
+    ASSERT_EQ(r2.representation().size(), 2u);
+    EXPECT_EQ(r2.representation()[0], uint_multiprecision_t{4});
+    EXPECT_EQ(r2.representation()[1], uint_multiprecision_t{1});
+}
+
+} // namespace

--- a/tests/beman/big_int/addition.test.cpp
+++ b/tests/beman/big_int/addition.test.cpp
@@ -19,24 +19,16 @@ using beman::big_int::uint_multiprecision_t;
 // the `_BitInt` bit_cast path that some toolchains don't yet support in constant
 // evaluation. Sign / storage-promotion properties are covered by the runtime tests.
 
-consteval bool ce_zero_plus_zero() {
-    return (big_int{0} + big_int{0}) == big_int{0};
-}
+consteval bool ce_zero_plus_zero() { return (big_int{0} + big_int{0}) == big_int{0}; }
 static_assert(ce_zero_plus_zero());
 
-consteval bool ce_small_positive() {
-    return (big_int{1} + big_int{2}) == big_int{3};
-}
+consteval bool ce_small_positive() { return (big_int{1} + big_int{2}) == big_int{3}; }
 static_assert(ce_small_positive());
 
-consteval bool ce_cancel_to_zero() {
-    return (big_int{-5} + big_int{5}) == big_int{0};
-}
+consteval bool ce_cancel_to_zero() { return (big_int{-5} + big_int{5}) == big_int{0}; }
 static_assert(ce_cancel_to_zero());
 
-consteval bool ce_mixed_sign_positive_result() {
-    return (big_int{5} + big_int{-3}) == big_int{2};
-}
+consteval bool ce_mixed_sign_positive_result() { return (big_int{5} + big_int{-3}) == big_int{2}; }
 static_assert(ce_mixed_sign_positive_result());
 
 consteval bool ce_mixed_sign_negative_result() {
@@ -44,9 +36,7 @@ consteval bool ce_mixed_sign_negative_result() {
 }
 static_assert(ce_mixed_sign_negative_result());
 
-consteval bool ce_same_sign_negative() {
-    return (big_int{-5} + big_int{-3}) == big_int{-8};
-}
+consteval bool ce_same_sign_negative() { return (big_int{-5} + big_int{-3}) == big_int{-8}; }
 static_assert(ce_same_sign_negative());
 
 // ----- runtime tests -----
@@ -207,9 +197,9 @@ TEST(Addition, NegativePrimitiveIntoMultiLimb) {
 
 TEST(Addition, UnequalLengthMultiLimb) {
     // (2^64 + 7) + 3 = 2^64 + 10, spanning two limbs on the left and one on the right.
-    const big_int two_64  = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
-    const big_int a       = two_64 + big_int{7};
-    const big_int r       = a + big_int{3};
+    const big_int two_64 = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const big_int a      = two_64 + big_int{7};
+    const big_int r      = a + big_int{3};
     ASSERT_EQ(r.representation().size(), 2u);
     EXPECT_EQ(r.representation()[0], uint_multiprecision_t{10});
     EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});

--- a/tests/beman/big_int/addition.test.cpp
+++ b/tests/beman/big_int/addition.test.cpp
@@ -31,9 +31,7 @@ static_assert(ce_cancel_to_zero());
 consteval bool ce_mixed_sign_positive_result() { return (big_int{5} + big_int{-3}) == big_int{2}; }
 static_assert(ce_mixed_sign_positive_result());
 
-consteval bool ce_mixed_sign_negative_result() {
-    return (big_int{-5} + big_int{3}) == big_int{-2};
-}
+consteval bool ce_mixed_sign_negative_result() { return (big_int{-5} + big_int{3}) == big_int{-2}; }
 static_assert(ce_mixed_sign_negative_result());
 
 consteval bool ce_same_sign_negative() { return (big_int{-5} + big_int{-3}) == big_int{-8}; }

--- a/tests/beman/big_int/subtraction.test.cpp
+++ b/tests/beman/big_int/subtraction.test.cpp
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: BSL-1.0
+
+#include <cstdint>
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include <beman/big_int/big_int.hpp>
+
+namespace {
+
+using beman::big_int::basic_big_int;
+using beman::big_int::big_int;
+using beman::big_int::uint_multiprecision_t;
+
+// ----- compile-time sanity -----
+// See addition.test.cpp for why we compare big_int-to-big_int in consteval tests.
+
+consteval bool ce_zero_minus_zero() {
+    return (big_int{0} - big_int{0}) == big_int{0};
+}
+static_assert(ce_zero_minus_zero());
+
+consteval bool ce_small_positive() {
+    return (big_int{5} - big_int{3}) == big_int{2};
+}
+static_assert(ce_small_positive());
+
+consteval bool ce_small_negative_result() {
+    return (big_int{3} - big_int{5}) == big_int{-2};
+}
+static_assert(ce_small_negative_result());
+
+consteval bool ce_cancel_to_zero() {
+    return (big_int{7} - big_int{7}) == big_int{0};
+}
+static_assert(ce_cancel_to_zero());
+
+consteval bool ce_negative_minus_negative() {
+    return (big_int{-5} - big_int{-3}) == big_int{-2};
+}
+static_assert(ce_negative_minus_negative());
+
+consteval bool ce_negative_minus_positive() {
+    return (big_int{-5} - big_int{3}) == big_int{-8};
+}
+static_assert(ce_negative_minus_positive());
+
+consteval bool ce_positive_minus_negative() {
+    return (big_int{5} - big_int{-3}) == big_int{8};
+}
+static_assert(ce_positive_minus_negative());
+
+// ----- runtime tests -----
+
+TEST(Subtraction, SmallPositive) {
+    EXPECT_EQ(big_int{5} - big_int{3}, 2);
+    EXPECT_EQ(big_int{42} - big_int{40}, 2);
+    EXPECT_EQ(big_int{3} - big_int{5}, -2);
+}
+
+TEST(Subtraction, SmallNegative) {
+    EXPECT_EQ(big_int{-5} - big_int{-3}, -2);
+    EXPECT_EQ(big_int{-3} - big_int{-5}, 2);
+}
+
+TEST(Subtraction, MixedSigns) {
+    EXPECT_EQ(big_int{5} - big_int{-3}, 8);
+    EXPECT_EQ(big_int{-5} - big_int{3}, -8);
+    EXPECT_EQ(big_int{3} - big_int{-5}, 8);
+    EXPECT_EQ(big_int{-3} - big_int{5}, -8);
+}
+
+TEST(Subtraction, CancelToExactZeroIsPositive) {
+    // x - x must produce +0, never -0.
+    const big_int r = big_int{7} - big_int{7};
+    EXPECT_EQ(r, 0);
+    EXPECT_FALSE(r < 0);
+
+    const big_int r2 = big_int{-100} - big_int{-100};
+    EXPECT_EQ(r2, 0);
+    EXPECT_FALSE(r2 < 0);
+}
+
+TEST(Subtraction, ZeroIdentity) {
+    EXPECT_EQ(big_int{0} - big_int{0}, 0);
+    EXPECT_EQ(big_int{42} - big_int{0}, 42);
+    EXPECT_EQ(big_int{0} - big_int{42}, -42);
+    EXPECT_EQ(big_int{-42} - big_int{0}, -42);
+    EXPECT_EQ(big_int{0} - big_int{-42}, 42);
+}
+
+TEST(Subtraction, BorrowAcrossLimbPromotesToHeap) {
+    // 0 - UINT64_MAX requires two limbs' worth of magnitude? No — the magnitude
+    // UINT64_MAX fits in one limb. But `(UINT64_MAX + 1) - 1` goes through the
+    // carry path and shrinks back. Here we go the opposite way: pick two values
+    // whose sum of magnitudes exceeds a single limb.
+    const big_int a{std::numeric_limits<std::uint64_t>::max()};
+    const big_int b{-1};
+    // a - b = a + 1 = 2^64 → two-limb result, must promote to heap.
+    const big_int r = a - b;
+    ASSERT_EQ(r.representation().size(), 2u);
+    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
+    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+    EXPECT_GT(r.capacity(), 0u);
+}
+
+TEST(Subtraction, NoAllocationWhenInlineFits) {
+    using big_int_256 = basic_big_int<256>;
+    const big_int_256 a{std::numeric_limits<std::uint64_t>::max()};
+    const big_int_256 b{-1};
+    const big_int_256 r = a - b;  // 2^64 — still fits inline in a 256-bit inline buffer.
+    EXPECT_EQ(r.capacity(), 0u);
+    ASSERT_EQ(r.representation().size(), 2u);
+    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
+    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+}
+
+TEST(Subtraction, MultiLimbSameSignTrimsLeadingZeros) {
+    // 2^64 - 1 = UINT64_MAX → must trim back to one limb.
+    const big_int two_64 = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const big_int r      = two_64 - big_int{1};
+    ASSERT_EQ(r.representation().size(), 1u);
+    EXPECT_EQ(r.representation()[0], std::numeric_limits<std::uint64_t>::max());
+}
+
+TEST(Subtraction, MultiLimbCancelsToZero) {
+    const big_int two_64 = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const big_int r      = two_64 - two_64;
+    ASSERT_EQ(r.representation().size(), 1u);
+    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
+    EXPECT_EQ(r, 0);
+    EXPECT_FALSE(r < 0);
+}
+
+TEST(Subtraction, MultiLimbSameSignCrossesLimbBoundary) {
+    // 2^65 - 2^64 = 2^64, spanning a limb transition on the larger side.
+    const big_int two_64 = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const big_int two_65 = two_64 + two_64;
+    const big_int r      = two_65 - two_64;
+    ASSERT_EQ(r.representation().size(), 2u);
+    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
+    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+}
+
+TEST(Subtraction, BigIntMinusPrimitiveUnsigned) {
+    EXPECT_EQ(big_int{10} - 5U, 5);
+    EXPECT_EQ(big_int{5} - 10U, -5);
+    EXPECT_EQ(big_int{-10} - 5U, -15);
+    EXPECT_EQ(big_int{10} - 0U, 10);
+}
+
+TEST(Subtraction, PrimitiveUnsignedMinusBigInt) {
+    EXPECT_EQ(10U - big_int{5}, 5);
+    EXPECT_EQ(5U - big_int{10}, -5);
+    EXPECT_EQ(5U - big_int{-10}, 15);
+    EXPECT_EQ(0U - big_int{10}, -10);
+}
+
+TEST(Subtraction, BigIntMinusPrimitiveSigned) {
+    EXPECT_EQ(big_int{10} - 5, 5);
+    EXPECT_EQ(big_int{10} - -5, 15);
+    EXPECT_EQ(big_int{-10} - 5, -15);
+    EXPECT_EQ(big_int{-10} - -5, -5);
+    EXPECT_EQ(big_int{5} - 5, 0);
+}
+
+TEST(Subtraction, PrimitiveSignedMinusBigInt) {
+    EXPECT_EQ(5 - big_int{10}, -5);
+    EXPECT_EQ(-5 - big_int{10}, -15);
+    EXPECT_EQ(5 - big_int{-10}, 15);
+    EXPECT_EQ(-5 - big_int{-10}, 5);
+    EXPECT_EQ(5 - big_int{5}, 0);
+}
+
+TEST(Subtraction, PrimitiveBorrowAcrossLimb) {
+    // big_int{UINT64_MAX} - (-1) = 2^64 via primitive rhs.
+    const big_int r = big_int{std::numeric_limits<std::uint64_t>::max()} - -1;
+    ASSERT_EQ(r.representation().size(), 2u);
+    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
+    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+}
+
+TEST(Subtraction, UnequalLengthMultiLimb) {
+    // (2^64 + 10) - 3 = 2^64 + 7: long minus short, same sign, no trim.
+    const big_int two_64 = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const big_int a      = two_64 + big_int{10};
+    const big_int r      = a - big_int{3};
+    ASSERT_EQ(r.representation().size(), 2u);
+    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{7});
+    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+
+    // (2^64 + 10) - (-3) = 2^64 + 13: long minus negative short, same-sign add path.
+    const big_int r2 = a - big_int{-3};
+    ASSERT_EQ(r2.representation().size(), 2u);
+    EXPECT_EQ(r2.representation()[0], uint_multiprecision_t{13});
+    EXPECT_EQ(r2.representation()[1], uint_multiprecision_t{1});
+}
+
+TEST(Subtraction, AgreesWithAdditionOfNegated) {
+    // Property: (a - b) == (a + (-b)) for a variety of inputs.
+    const big_int cases[] = {
+        big_int{0},
+        big_int{1},
+        big_int{-1},
+        big_int{std::numeric_limits<std::uint64_t>::max()},
+        big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1},
+        -(big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1}),
+    };
+    for (const auto& a : cases) {
+        for (const auto& b : cases) {
+            EXPECT_EQ(a - b, a + (-b));
+        }
+    }
+}
+
+} // namespace

--- a/tests/beman/big_int/subtraction.test.cpp
+++ b/tests/beman/big_int/subtraction.test.cpp
@@ -26,9 +26,7 @@ static_assert(ce_small_positive());
 consteval bool ce_small_negative_result() { return (big_int{3} - big_int{5}) == big_int{-2}; }
 static_assert(ce_small_negative_result());
 
-consteval bool ce_cancel_to_zero() {
-    return (big_int{7} - big_int{7}) == big_int{0};
-}
+consteval bool ce_cancel_to_zero() { return (big_int{7} - big_int{7}) == big_int{0}; }
 static_assert(ce_cancel_to_zero());
 
 consteval bool ce_negative_minus_negative() { return (big_int{-5} - big_int{-3}) == big_int{-2}; }

--- a/tests/beman/big_int/subtraction.test.cpp
+++ b/tests/beman/big_int/subtraction.test.cpp
@@ -17,19 +17,13 @@ using beman::big_int::uint_multiprecision_t;
 // ----- compile-time sanity -----
 // See addition.test.cpp for why we compare big_int-to-big_int in consteval tests.
 
-consteval bool ce_zero_minus_zero() {
-    return (big_int{0} - big_int{0}) == big_int{0};
-}
+consteval bool ce_zero_minus_zero() { return (big_int{0} - big_int{0}) == big_int{0}; }
 static_assert(ce_zero_minus_zero());
 
-consteval bool ce_small_positive() {
-    return (big_int{5} - big_int{3}) == big_int{2};
-}
+consteval bool ce_small_positive() { return (big_int{5} - big_int{3}) == big_int{2}; }
 static_assert(ce_small_positive());
 
-consteval bool ce_small_negative_result() {
-    return (big_int{3} - big_int{5}) == big_int{-2};
-}
+consteval bool ce_small_negative_result() { return (big_int{3} - big_int{5}) == big_int{-2}; }
 static_assert(ce_small_negative_result());
 
 consteval bool ce_cancel_to_zero() {
@@ -37,19 +31,13 @@ consteval bool ce_cancel_to_zero() {
 }
 static_assert(ce_cancel_to_zero());
 
-consteval bool ce_negative_minus_negative() {
-    return (big_int{-5} - big_int{-3}) == big_int{-2};
-}
+consteval bool ce_negative_minus_negative() { return (big_int{-5} - big_int{-3}) == big_int{-2}; }
 static_assert(ce_negative_minus_negative());
 
-consteval bool ce_negative_minus_positive() {
-    return (big_int{-5} - big_int{3}) == big_int{-8};
-}
+consteval bool ce_negative_minus_positive() { return (big_int{-5} - big_int{3}) == big_int{-8}; }
 static_assert(ce_negative_minus_positive());
 
-consteval bool ce_positive_minus_negative() {
-    return (big_int{5} - big_int{-3}) == big_int{8};
-}
+consteval bool ce_positive_minus_negative() { return (big_int{5} - big_int{-3}) == big_int{8}; }
 static_assert(ce_positive_minus_negative());
 
 // ----- runtime tests -----
@@ -110,7 +98,7 @@ TEST(Subtraction, NoAllocationWhenInlineFits) {
     using big_int_256 = basic_big_int<256>;
     const big_int_256 a{std::numeric_limits<std::uint64_t>::max()};
     const big_int_256 b{-1};
-    const big_int_256 r = a - b;  // 2^64 — still fits inline in a 256-bit inline buffer.
+    const big_int_256 r = a - b; // 2^64 — still fits inline in a 256-bit inline buffer.
     EXPECT_EQ(r.capacity(), 0u);
     ASSERT_EQ(r.representation().size(), 2u);
     EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});


### PR DESCRIPTION
- Implements operators add and sub through unified generating function
- Add NOOP `uabs` function
- Add `integer_signbit` helpers
- Pull out magnitude logic from `operator<=>` for use in add and sub
- Add MSVC path for `carrying_add` and `borrowing_sub`
- Fix MSVC detection macro for `widening_mul`