### PR TITLE
Switch vars ab to xy in M64 arch path

### DIFF
--- a/include/beman/big_int/wide_ops.hpp
+++ b/include/beman/big_int/wide_ops.hpp
@@ -83,11 +83,11 @@ inline static T high_mul(const T x, const T y) noexcept {
     #elif defined(_M_IA64)
         if constexpr (std::is_signed_v<T>) {
             __int64 result;
-            void(_mul128(a, b, &result));
+            void(_mul128(x, y, &result));
             return result;
         } else {
             unsigned __int64 result;
-            void(_umul128(a, b, &result));
+            void(_umul128(x, y, &result));
             return result;
         }
     #else

--- a/include/beman/big_int/wide_ops.hpp
+++ b/include/beman/big_int/wide_ops.hpp
@@ -144,7 +144,7 @@ template <signed_or_unsigned T>
         const auto product = static_cast<wider_t<T>>(x) * static_cast<wider_t<T>>(y);
         return wide<T>::from_int(product);
     } else {
-    #if defined(_M_IA64)
+    #if defined(_M_AMD64)
         if constexpr (std::is_signed_v<T>) {
             __int64 high;
             __int64 low = _mul128(x, y, &high);
@@ -154,7 +154,7 @@ template <signed_or_unsigned T>
             unsigned __int64 low = _umul128(x, y, &high);
             return {low, high};
         }
-    #else
+    #else // _M_AMD64
         using U = std::make_unsigned_t<T>;
         return {
             .low_bits  = static_cast<T>(static_cast<U>(x) * static_cast<U>(y)),


### PR DESCRIPTION
I believe the same switch-up of `ab` to ` xy` is needed in this architecture branch. I hope I got that right. I wonder why CI is not hitting it? Hi @mborland can we devise a test to at least compile this architecture branch?
