### PR TITLE
Reduce unnecessary allocations

### DIFF
--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -1040,13 +1040,11 @@ compare_limb_magnitudes(const std::span<const uint_multiprecision_t, extent_a> a
 // constructing from a primitive), then fold the other operand in via `add_in_place`.
 // `add_in_place` handles carry, borrow, trim, and sign normalization uniformly.
 //
-// Dispatch priority for the destination is:
-//   1. lhs is an rvalue `basic_big_int`   -> move-from lhs
-//   2. rhs is an rvalue `basic_big_int`   -> move-from rhs (addition is commutative;
-//                                             for subtraction we negate first)
-//   3. lhs is an lvalue `basic_big_int`   -> copy lhs
-//   4. otherwise lhs is a primitive and rhs must be an lvalue `basic_big_int`
-//                                          -> copy rhs (with negate for subtraction)
+// Destination priority:
+//   * both `basic_big_int` rvalues  -> move the one with more limbs (no subsequent grow)
+//   * one  `basic_big_int` rvalue   -> move it
+//   * both `basic_big_int` lvalues  -> copy the one with more limbs
+//   * one  `basic_big_int` lvalue   -> copy it (the other side is a primitive)
 //
 // `common_big_int_type` only yields a type when both `basic_big_int` operands are the
 // exact same `basic_big_int<b, A>` instantiation, so the operand type already matches
@@ -1057,10 +1055,23 @@ constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y) {
     using LT     = std::remove_cvref_t<L>;
     using RT     = std::remove_cvref_t<R>;
 
-    if constexpr (detail::is_basic_big_int_v<LT> && !std::is_reference_v<L>) {
-        // (1) rvalue lhs `basic_big_int`: steal its storage.
-        // `std::forward` and `std::move` are equivalent under this guard (L deduced
-        // as a non-reference); `forward` silences the forwarding-reference lint.
+    if constexpr (detail::is_basic_big_int_v<LT> && !std::is_reference_v<L> //
+                  && detail::is_basic_big_int_v<RT> && !std::is_reference_v<R>) {
+        // (1) both rvalue `basic_big_int`s: move the larger. Whichever we don't
+        // pick is freed at scope exit anyway, so we might as well take the one
+        // whose existing capacity already covers the result. `std::forward` and
+        // `std::move` are equivalent under the non-reference guard; `forward`
+        // silences the forwarding-reference lint.
+        if (x.limb_count() >= y.limb_count()) {
+            Result r = std::forward<L>(x);
+            r.add_in_place(y.representation(), y.is_negative());
+            return r;
+        }
+        Result r = std::forward<R>(y);
+        r.add_in_place(x.representation(), x.is_negative());
+        return r;
+    } else if constexpr (detail::is_basic_big_int_v<LT> && !std::is_reference_v<L>) {
+        // (2) rvalue lhs only: steal its storage.
         Result r = std::forward<L>(x);
         if constexpr (detail::is_basic_big_int_v<RT>) {
             r.add_in_place(y.representation(), y.is_negative());
@@ -1070,7 +1081,7 @@ constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y) {
         }
         return r;
     } else if constexpr (detail::is_basic_big_int_v<RT> && !std::is_reference_v<R>) {
-        // (2) rvalue rhs `basic_big_int`; addition is commutative, so reuse it.
+        // (3) rvalue rhs only (addition is commutative, so we reuse rhs).
         Result r = std::forward<R>(y);
         if constexpr (detail::is_basic_big_int_v<LT>) {
             r.add_in_place(x.representation(), x.is_negative());
@@ -1079,20 +1090,27 @@ constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y) {
             r.add_in_place(detail::to_fixed_span(x_limbs), detail::integer_signbit(x));
         }
         return r;
-    } else if constexpr (detail::is_basic_big_int_v<LT>) {
-        // (3) lvalue lhs `basic_big_int`: copy into the result, then fold rhs in.
-        Result r = x;
-        if constexpr (detail::is_basic_big_int_v<RT>) {
+    } else if constexpr (detail::is_basic_big_int_v<LT> && detail::is_basic_big_int_v<RT>) {
+        // (4) both lvalue `basic_big_int`s: copy the larger-limb-count source so
+        // that `add_in_place`'s subsequent `grow(max(|x|,|y|))` is a no-op. Only
+        // a top-limb carry-out can force a further allocation.
+        if (x.limb_count() >= y.limb_count()) {
+            Result r = x;
             r.add_in_place(y.representation(), y.is_negative());
-        } else {
-            const auto y_limbs = detail::to_limbs(detail::uabs(y));
-            r.add_in_place(detail::to_fixed_span(y_limbs), detail::integer_signbit(y));
+            return r;
         }
+        Result r = y;
+        r.add_in_place(x.representation(), x.is_negative());
+        return r;
+    } else if constexpr (detail::is_basic_big_int_v<LT>) {
+        // (5) lvalue `basic_big_int` lhs, primitive rhs.
+        Result     r       = x;
+        const auto y_limbs = detail::to_limbs(detail::uabs(y));
+        r.add_in_place(detail::to_fixed_span(y_limbs), detail::integer_signbit(y));
         return r;
     } else {
-        // (4) lhs is primitive; rhs must be an lvalue `basic_big_int` (any rvalue rhs
-        // would have been caught by branch (2), and primitive+primitive is forbidden
-        // by `common_big_int_type`).
+        // (6) primitive lhs, lvalue `basic_big_int` rhs (primitive+primitive is
+        // forbidden by `common_big_int_type`; rvalue rhs was caught in (3)).
         static_assert(detail::is_basic_big_int_v<RT>);
         Result     r       = y;
         const auto x_limbs = detail::to_limbs(detail::uabs(x));
@@ -1103,20 +1121,30 @@ constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y) {
 
 // `x - y` is implemented as `x + (-y)`: we flip the sign of the right-hand operand
 // (without materializing a negated value) and dispatch through the same magnitude
-// add/subtract core as `operator+`.
-// Dispatch follows the same 4-way pattern as `operator+` (rvalue lhs / rvalue rhs / lvalue lhs / primitive lhs).
-// The only difference is how the "not reused" side is signed:
-//   - lhs-destination paths: pass the other side's span with sign `!rhs_neg`
-//   - rhs-destination paths: `r.negate()` first (cheap XOR), then add the lhs side
-//     with its own sign so the result is `(-y) + x = x - y`
+// add/subtract core as `operator+`. Destination priority matches `operator+`:
+//   * lhs-destination paths pass the other side's span with sign `!rhs_neg`
+//   * rhs-destination paths `r.negate()` first (cheap XOR on the sign word),
+//     then add the lhs side with its own sign, yielding `(-y) + x = x - y`
 template <class L, class R>
 constexpr detail::common_big_int_type<L, R> operator-(L&& x, R&& y) {
     using Result = detail::common_big_int_type<L, R>;
     using LT     = std::remove_cvref_t<L>;
     using RT     = std::remove_cvref_t<R>;
 
-    if constexpr (detail::is_basic_big_int_v<LT> && !std::is_reference_v<L>) {
-        // (1) rvalue lhs: `r = x; r += (-y)`.
+    if constexpr (detail::is_basic_big_int_v<LT> && !std::is_reference_v<L> //
+                  && detail::is_basic_big_int_v<RT> && !std::is_reference_v<R>) {
+        // (1) both rvalue `basic_big_int`s: move the larger-limb-count source.
+        if (x.limb_count() >= y.limb_count()) {
+            Result r = std::forward<L>(x);
+            r.add_in_place(y.representation(), !y.is_negative()); // r + (-y)
+            return r;
+        }
+        Result r = std::forward<R>(y);
+        r.negate();                                               // r = -y
+        r.add_in_place(x.representation(), x.is_negative());      // (-y) + x = x - y
+        return r;
+    } else if constexpr (detail::is_basic_big_int_v<LT> && !std::is_reference_v<L>) {
+        // (2) rvalue lhs only: `r = x; r += (-y)`.
         Result r = std::forward<L>(x);
         if constexpr (detail::is_basic_big_int_v<RT>) {
             r.add_in_place(y.representation(), !y.is_negative());
@@ -1126,7 +1154,7 @@ constexpr detail::common_big_int_type<L, R> operator-(L&& x, R&& y) {
         }
         return r;
     } else if constexpr (detail::is_basic_big_int_v<RT> && !std::is_reference_v<R>) {
-        // (2) rvalue rhs: `r = -y; r += x` gives `x - y`.
+        // (3) rvalue rhs only: `r = -y; r += x` gives `x - y`.
         Result r = std::forward<R>(y);
         r.negate();
         if constexpr (detail::is_basic_big_int_v<LT>) {
@@ -1136,19 +1164,25 @@ constexpr detail::common_big_int_type<L, R> operator-(L&& x, R&& y) {
             r.add_in_place(detail::to_fixed_span(x_limbs), detail::integer_signbit(x));
         }
         return r;
-    } else if constexpr (detail::is_basic_big_int_v<LT>) {
-        // (3) lvalue lhs `basic_big_int`: copy, then fold in `-y`.
-        Result r = x;
-        if constexpr (detail::is_basic_big_int_v<RT>) {
+    } else if constexpr (detail::is_basic_big_int_v<LT> && detail::is_basic_big_int_v<RT>) {
+        // (4) both lvalue `basic_big_int`s: copy the larger, then subtract the smaller.
+        if (x.limb_count() >= y.limb_count()) {
+            Result r = x;
             r.add_in_place(y.representation(), !y.is_negative());
-        } else {
-            const auto y_limbs = detail::to_limbs(detail::uabs(y));
-            r.add_in_place(detail::to_fixed_span(y_limbs), !detail::integer_signbit(y));
+            return r;
         }
+        Result r = y;
+        r.negate();
+        r.add_in_place(x.representation(), x.is_negative());
+        return r;
+    } else if constexpr (detail::is_basic_big_int_v<LT>) {
+        // (5) lvalue `basic_big_int` lhs, primitive rhs.
+        Result     r       = x;
+        const auto y_limbs = detail::to_limbs(detail::uabs(y));
+        r.add_in_place(detail::to_fixed_span(y_limbs), !detail::integer_signbit(y));
         return r;
     } else {
-        // (4) lhs is primitive; rhs must be an lvalue `basic_big_int`. Copy rhs,
-        // negate it, then add `x` to compute `(-y) + x = x - y`.
+        // (6) primitive lhs, lvalue `basic_big_int` rhs: copy rhs, negate, add lhs.
         static_assert(detail::is_basic_big_int_v<RT>);
         Result r = y;
         r.negate();

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -1034,65 +1034,127 @@ compare_limb_magnitudes(const std::span<const uint_multiprecision_t, extent_a> a
 } // namespace detail
 
 // [big.int.binary]
+//
+// The shared pattern for `operator+` and `operator-` is: build `Result r` from one
+// operand (moving an rvalue `basic_big_int`'s storage, copying an lvalue, or
+// constructing from a primitive), then fold the other operand in via `add_in_place`.
+// `add_in_place` handles carry, borrow, trim, and sign normalization uniformly.
+//
+// Dispatch priority for the destination is:
+//   1. lhs is an rvalue `basic_big_int`   -> move-from lhs
+//   2. rhs is an rvalue `basic_big_int`   -> move-from rhs (addition is commutative;
+//                                             for subtraction we negate first)
+//   3. lhs is an lvalue `basic_big_int`   -> copy lhs
+//   4. otherwise lhs is a primitive and rhs must be an lvalue `basic_big_int`
+//                                          -> copy rhs (with negate for subtraction)
+//
+// `common_big_int_type` only yields a type when both `basic_big_int` operands are the
+// exact same `basic_big_int<b, A>` instantiation, so the operand type already matches
+// `Result` and no explicit type-equality guard is needed.
 template <class L, class R>
 constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y) {
     using Result = detail::common_big_int_type<L, R>;
     using LT     = std::remove_cvref_t<L>;
     using RT     = std::remove_cvref_t<R>;
 
-    if constexpr (detail::is_basic_big_int_v<LT> && detail::is_basic_big_int_v<RT>) {
-        return Result::make_sum_of_limbs(x.representation(),
-                                         x.is_negative(), //
-                                         y.representation(),
-                                         y.is_negative());
+    if constexpr (detail::is_basic_big_int_v<LT> && !std::is_reference_v<L>) {
+        // (1) rvalue lhs `basic_big_int`: steal its storage.
+        // `std::forward` and `std::move` are equivalent under this guard (L deduced
+        // as a non-reference); `forward` silences the forwarding-reference lint.
+        Result r = std::forward<L>(x);
+        if constexpr (detail::is_basic_big_int_v<RT>) {
+            r.add_in_place(y.representation(), y.is_negative());
+        } else {
+            const auto y_limbs = detail::to_limbs(detail::uabs(y));
+            r.add_in_place(detail::to_fixed_span(y_limbs), detail::integer_signbit(y));
+        }
+        return r;
+    } else if constexpr (detail::is_basic_big_int_v<RT> && !std::is_reference_v<R>) {
+        // (2) rvalue rhs `basic_big_int`; addition is commutative, so reuse it.
+        Result r = std::forward<R>(y);
+        if constexpr (detail::is_basic_big_int_v<LT>) {
+            r.add_in_place(x.representation(), x.is_negative());
+        } else {
+            const auto x_limbs = detail::to_limbs(detail::uabs(x));
+            r.add_in_place(detail::to_fixed_span(x_limbs), detail::integer_signbit(x));
+        }
+        return r;
     } else if constexpr (detail::is_basic_big_int_v<LT>) {
-        // `y` is a primitive integer; materialize it as a fixed-extent limb array
-        // so the span we pass to the helper stays valid for the call.
-        const auto y_limbs = detail::to_limbs(detail::uabs(y));
-        return Result::make_sum_of_limbs(x.representation(),
-                                         x.is_negative(),
-                                         detail::to_fixed_span(y_limbs),
-                                         detail::integer_signbit(y));
+        // (3) lvalue lhs `basic_big_int`: copy into the result, then fold rhs in.
+        Result r = x;
+        if constexpr (detail::is_basic_big_int_v<RT>) {
+            r.add_in_place(y.representation(), y.is_negative());
+        } else {
+            const auto y_limbs = detail::to_limbs(detail::uabs(y));
+            r.add_in_place(detail::to_fixed_span(y_limbs), detail::integer_signbit(y));
+        }
+        return r;
     } else {
-        // `x` is a primitive integer
+        // (4) lhs is primitive; rhs must be an lvalue `basic_big_int` (any rvalue rhs
+        // would have been caught by branch (2), and primitive+primitive is forbidden
+        // by `common_big_int_type`).
         static_assert(detail::is_basic_big_int_v<RT>);
+        Result     r       = y;
         const auto x_limbs = detail::to_limbs(detail::uabs(x));
-        return Result::make_sum_of_limbs(detail::to_fixed_span(x_limbs),
-                                         detail::integer_signbit(x),
-                                         y.representation(),
-                                         y.is_negative());
+        r.add_in_place(detail::to_fixed_span(x_limbs), detail::integer_signbit(x));
+        return r;
     }
 }
 
 // `x - y` is implemented as `x + (-y)`: we flip the sign of the right-hand operand
 // (without materializing a negated value) and dispatch through the same magnitude
-// add/subtract path as `operator+`.
+// add/subtract core as `operator+`.
+// Dispatch follows the same 4-way pattern as `operator+` (rvalue lhs / rvalue rhs / lvalue lhs / primitive lhs).
+// The only difference is how the "not reused" side is signed:
+//   - lhs-destination paths: pass the other side's span with sign `!rhs_neg`
+//   - rhs-destination paths: `r.negate()` first (cheap XOR), then add the lhs side
+//     with its own sign so the result is `(-y) + x = x - y`
 template <class L, class R>
 constexpr detail::common_big_int_type<L, R> operator-(L&& x, R&& y) {
     using Result = detail::common_big_int_type<L, R>;
     using LT     = std::remove_cvref_t<L>;
     using RT     = std::remove_cvref_t<R>;
 
-    if constexpr (detail::is_basic_big_int_v<LT> && detail::is_basic_big_int_v<RT>) {
-        return Result::make_sum_of_limbs(x.representation(),
-                                         x.is_negative(), //
-                                         y.representation(),
-                                         !y.is_negative());
+    if constexpr (detail::is_basic_big_int_v<LT> && !std::is_reference_v<L>) {
+        // (1) rvalue lhs: `r = x; r += (-y)`.
+        Result r = std::forward<L>(x);
+        if constexpr (detail::is_basic_big_int_v<RT>) {
+            r.add_in_place(y.representation(), !y.is_negative());
+        } else {
+            const auto y_limbs = detail::to_limbs(detail::uabs(y));
+            r.add_in_place(detail::to_fixed_span(y_limbs), !detail::integer_signbit(y));
+        }
+        return r;
+    } else if constexpr (detail::is_basic_big_int_v<RT> && !std::is_reference_v<R>) {
+        // (2) rvalue rhs: `r = -y; r += x` gives `x - y`.
+        Result r = std::forward<R>(y);
+        r.negate();
+        if constexpr (detail::is_basic_big_int_v<LT>) {
+            r.add_in_place(x.representation(), x.is_negative());
+        } else {
+            const auto x_limbs = detail::to_limbs(detail::uabs(x));
+            r.add_in_place(detail::to_fixed_span(x_limbs), detail::integer_signbit(x));
+        }
+        return r;
     } else if constexpr (detail::is_basic_big_int_v<LT>) {
-        // `y` is a primitive integer
-        const auto y_limbs = detail::to_limbs(detail::uabs(y));
-        return Result::make_sum_of_limbs(x.representation(),
-                                         x.is_negative(), //
-                                         detail::to_fixed_span(y_limbs),
-                                         !detail::integer_signbit(y));
+        // (3) lvalue lhs `basic_big_int`: copy, then fold in `-y`.
+        Result r = x;
+        if constexpr (detail::is_basic_big_int_v<RT>) {
+            r.add_in_place(y.representation(), !y.is_negative());
+        } else {
+            const auto y_limbs = detail::to_limbs(detail::uabs(y));
+            r.add_in_place(detail::to_fixed_span(y_limbs), !detail::integer_signbit(y));
+        }
+        return r;
     } else {
-        // `x` is a primitive integer
+        // (4) lhs is primitive; rhs must be an lvalue `basic_big_int`. Copy rhs,
+        // negate it, then add `x` to compute `(-y) + x = x - y`.
         static_assert(detail::is_basic_big_int_v<RT>);
+        Result r = y;
+        r.negate();
         const auto x_limbs = detail::to_limbs(detail::uabs(x));
-        return Result::make_sum_of_limbs(detail::to_fixed_span(x_limbs),
-                                         detail::integer_signbit(x), //
-                                         y.representation(),
-                                         !y.is_negative());
+        r.add_in_place(detail::to_fixed_span(x_limbs), detail::integer_signbit(x));
+        return r;
     }
 }
 

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -365,15 +365,14 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     [[nodiscard]] constexpr std::strong_ordering compare_limbs(std::span<const uint_multiprecision_t, extent> limbs,
                                                                bool limbs_negative) const noexcept;
 
-    // Returns the sum `(lhs, lhs_neg) + (rhs, rhs_neg)` as a fresh `basic_big_int`.
-    // Only allocates heap storage if the final result is certain to exceed the inline limb capacity
-    // (a speculative top-limb carry only triggers a grow after the carry actually occurs).
-    template <std::size_t extent_a, std::size_t extent_b>
-    [[nodiscard]] static constexpr basic_big_int
-    make_sum_of_limbs(std::span<const uint_multiprecision_t, extent_a> lhs,
-                      bool                                             lhs_neg,
-                      std::span<const uint_multiprecision_t, extent_b> rhs,
-                      bool                                             rhs_neg);
+    // Adds `(other, other_neg)` into `*this` in place. Shared core for `operator+`
+    // and `operator-`: the caller chooses the destination (an rvalue operand's
+    // storage or a copy of an lvalue operand) and supplies the other side as a limb
+    // span + sign. Only allocates when the result genuinely requires more limbs
+    // than the current capacity. Preserves the no-negative-zero and trimmed-top-limb
+    // invariants.
+    template <std::size_t extent_other>
+    constexpr void add_in_place(std::span<const uint_multiprecision_t, extent_other> other, bool other_neg);
 
     static constexpr bool        has_inplace_to_bit_uint = inplace_bits <= BEMAN_BIG_INT_BITINT_MAXWIDTH;
     [[nodiscard]] constexpr auto inplace_to_bit_uint() const noexcept
@@ -1221,91 +1220,117 @@ basic_big_int<b, A>::compare_limbs(const std::span<const uint_multiprecision_t, 
     return is_negative() ? detail::invert(magnitude_ordering) : magnitude_ordering;
 }
 
-// Builds the sum or difference of two limb spans and returns it as a fresh `basic_big_int`.
+// Adds `(other, other_neg)` into `*this` in place. Shared core for `operator+` and
+// `operator-`: the caller chooses the destination (an rvalue operand's storage or a
+// copy of an lvalue operand) and supplies the other side as a limb span + sign.
 template <std::size_t b, class A>
-template <std::size_t extent_a, std::size_t extent_b>
-constexpr basic_big_int<b, A>
-basic_big_int<b, A>::make_sum_of_limbs(const std::span<const uint_multiprecision_t, extent_a> lhs,
-                                       const bool                                             lhs_neg,
-                                       const std::span<const uint_multiprecision_t, extent_b> rhs,
-                                       const bool                                             rhs_neg) {
-    basic_big_int result;
+template <std::size_t extent_other>
+constexpr void
+basic_big_int<b, A>::add_in_place(const std::span<const uint_multiprecision_t, extent_other> other,
+                                  const bool                                                 other_neg) {
+    const bool this_neg = is_negative();
 
-    if (lhs_neg == rhs_neg) {
-        // Same sign: add magnitudes limb-by-limb using carrying_add.
-        const std::size_t big = std::max(lhs.size(), rhs.size());
+    if (this_neg == other_neg) {
+        // Same sign: add magnitudes limb-by-limb. Target sign stays `this_neg`.
+        const std::uint32_t old_count = limb_count();
+        const std::size_t   big       = std::max<std::size_t>(old_count, other.size());
 
-        // `grow(big)` only allocates if `big > inplace_limbs`; otherwise it's a no-op
-        // and we stay in inline storage.
-        result.grow(big);
-        limb_type* const limbs = result.limb_ptr();
+        // `grow(big)` only allocates when `big` exceeds our current capacity;
+        // otherwise it's a no-op and we stay in our existing buffer.
+        grow(big);
+        limb_type* limbs = limb_ptr();
 
         bool carry = false;
         for (std::size_t i = 0; i < big; ++i) {
-            const limb_type li            = i < lhs.size() ? lhs[i] : limb_type{0};
-            const limb_type ri            = i < rhs.size() ? rhs[i] : limb_type{0};
+            const limb_type li            = i < old_count ? limbs[i] : limb_type{0};
+            const limb_type ri            = i < other.size() ? other[i] : limb_type{0};
             const auto [r_value, r_carry] = detail::carrying_add(li, ri, carry);
             limbs[i]                      = r_value;
             carry                         = r_carry;
         }
-        result.set_limb_count(static_cast<std::uint32_t>(big));
+        set_limb_count(static_cast<std::uint32_t>(big));
 
-        // If the ripple carry has actually produced an out-of-range carry, we allocate the extra limb.
-        // We want to avoid allocation or leaving inline storage as much as possible
+        // Only allocate for the extra top limb if the ripple carry has actually escaped.
         if (carry) {
-            result.grow(big + 1);
-            result.limb_ptr()[big] = limb_type{1};
-            result.set_limb_count(static_cast<std::uint32_t>(big + 1));
+            grow(big + 1);
+            limb_ptr()[big] = limb_type{1};
+            set_limb_count(static_cast<std::uint32_t>(big + 1));
         }
 
-        // Preserve the "no negative zero" invariant
-        if (!result.is_zero()) {
-            result.set_sign(lhs_neg);
+        // Preserve the "no negative zero" invariant. Clear the sign first so that
+        // `is_zero()` reflects the magnitude regardless of what our sign was on entry.
+        set_sign(false);
+        if (!is_zero()) {
+            set_sign(this_neg);
         }
-        return result;
+        return;
     }
 
-    // Differing signs: subtract the smaller magnitude from the larger,
-    // and take the sign of the larger-magnitude operand.
-    const auto magnitude_order = detail::compare_limb_magnitudes(lhs, rhs);
+    // Differing signs: subtract smaller magnitude from larger; take the sign of the
+    // larger-magnitude operand.
+    const auto magnitude_order = detail::compare_limb_magnitudes(representation(), other);
 
-    // When `lhs >= rhs` (in magnitude) compute `lhs - rhs` and take sign `lhs_neg`; otherwise
-    // compute `rhs - lhs` with sign `rhs_neg`. Equal magnitudes fall into the first branch
-    // and produce a normalized `+0`.
-    const std::span<const uint_multiprecision_t> larger      = std::is_gteq(magnitude_order)
-                                                                   ? std::span<const uint_multiprecision_t>(lhs)
-                                                                   : std::span<const uint_multiprecision_t>(rhs);
-    const std::span<const uint_multiprecision_t> smaller     = std::is_gteq(magnitude_order)
-                                                                   ? std::span<const uint_multiprecision_t>(rhs)
-                                                                   : std::span<const uint_multiprecision_t>(lhs);
-    const bool                                   result_sign = std::is_gteq(magnitude_order) ? lhs_neg : rhs_neg;
+    if (std::is_gteq(magnitude_order)) {
+        // `|*this| >= |other|`: compute `*this - other` in place. Target sign is `this_neg`.
+        const std::uint32_t n     = limb_count();
+        limb_type* const    limbs = limb_ptr();
 
-    const std::size_t n = larger.size();
+        bool borrow = false;
+        for (std::size_t i = 0; i < n; ++i) {
+            const limb_type li             = limbs[i];
+            const limb_type si             = i < other.size() ? other[i] : limb_type{0};
+            const auto [r_value, r_borrow] = detail::borrowing_sub(li, si, borrow);
+            limbs[i]                       = r_value;
+            borrow                         = r_borrow;
+        }
+        // Having picked `*this` as the larger operand, the final borrow must be zero.
+        BEMAN_BIG_INT_DEBUG_ASSERT(!borrow);
+
+        // Trim leading zero limbs to maintain the "top limb non-zero unless value is zero" invariant.
+        while (limb_count() > 1 && limbs[limb_count() - 1] == 0) {
+            set_limb_count(limb_count() - 1);
+        }
+
+        set_sign(false);
+        if (!is_zero()) {
+            set_sign(this_neg);
+        }
+        return;
+    }
+
+    // `|other| > |*this|`: compute `other - *this` into our buffer. Target sign is `other_neg`.
+    const std::uint32_t old_count = limb_count();
+    const std::size_t   n         = other.size();
+
     // Subtraction can never produce more limbs than the larger operand, so this grow is tight.
-    result.grow(n);
-    limb_type* const limbs = result.limb_ptr();
+    grow(n);
+    limb_type* const limbs = limb_ptr();
 
     bool borrow = false;
     for (std::size_t i = 0; i < n; ++i) {
-        const limb_type li             = larger[i];
-        const limb_type si             = i < smaller.size() ? smaller[i] : limb_type{0};
-        const auto [r_value, r_borrow] = detail::borrowing_sub(li, si, borrow);
+        // Read our old limb at index `i` *before* overwriting it, so this loop is
+        // aliasing-safe if `other` happens to point into our own limb buffer.
+        const limb_type si             = i < old_count ? limbs[i] : limb_type{0};
+        const limb_type oi             = other[i];
+        const auto [r_value, r_borrow] = detail::borrowing_sub(oi, si, borrow);
         limbs[i]                       = r_value;
         borrow                         = r_borrow;
     }
-    // Having picked `larger` correctly, the final borrow must be zero.
+    // Having picked `other` as the larger operand, the final borrow must be zero.
     BEMAN_BIG_INT_DEBUG_ASSERT(!borrow);
-    result.set_limb_count(static_cast<std::uint32_t>(n));
+    set_limb_count(static_cast<std::uint32_t>(n));
 
-    // Trim leading zero limbs to maintain the "top limb non-zero unless value is zero" invariant.
-    while (result.limb_count() > 1 && limbs[result.limb_count() - 1] == 0) {
-        result.set_limb_count(result.limb_count() - 1);
+    // Trim leading zero limbs.
+    while (limb_count() > 1 && limbs[limb_count() - 1] == 0) {
+        set_limb_count(limb_count() - 1);
     }
 
-    if (!result.is_zero()) {
-        result.set_sign(result_sign);
+    // `|other| > |*this|` strictly, so the magnitude is guaranteed nonzero; the
+    // `set_sign(false)` + `is_zero()` dance is defensive belt-and-braces.
+    set_sign(false);
+    if (!is_zero()) {
+        set_sign(other_neg);
     }
-    return result;
 }
 
 // private helpers

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -26,6 +26,7 @@
 BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
 BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Warray-bounds") // This causes way too many problems.
 BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Wstringop-overflow")
+BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Wstringop-overread")
 
 namespace beman::big_int {
 

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -1126,8 +1126,8 @@ constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y) {
     // In the case that we are using inline storage we do not request an extra limb,
     // we defer that decision till as late as possible in case the addition result fits
     // into the static storage rather than having to allocate for no reason
-    if constexpr (detail::is_basic_big_int_v<LT> && !std::is_reference_v<L>
-                  && detail::is_basic_big_int_v<RT> && !std::is_reference_v<R>) {
+    if constexpr (detail::is_basic_big_int_v<LT> && !std::is_reference_v<L> && detail::is_basic_big_int_v<RT> &&
+                  !std::is_reference_v<R>) {
         // 1) both rvalue `basic_big_int`s: move the larger
         if (x.limb_count() >= y.limb_count()) {
             Result r = std::forward<L>(x);
@@ -1201,8 +1201,8 @@ constexpr detail::common_big_int_type<L, R> operator-(L&& x, R&& y) {
     using RT     = std::remove_cvref_t<R>;
 
     // See `operator+` description of logic, as it is the same
-    if constexpr (detail::is_basic_big_int_v<LT> && !std::is_reference_v<L>
-                  && detail::is_basic_big_int_v<RT> && !std::is_reference_v<R>) {
+    if constexpr (detail::is_basic_big_int_v<LT> && !std::is_reference_v<L> && detail::is_basic_big_int_v<RT> &&
+                  !std::is_reference_v<R>) {
         // 1) both rvalue `basic_big_int`s: move the larger-limb-count source.
         if (x.limb_count() >= y.limb_count()) {
             Result r = std::forward<L>(x);
@@ -1394,9 +1394,8 @@ basic_big_int<b, A>::compare_limbs(const std::span<const uint_multiprecision_t, 
 // copy of an lvalue operand) and supplies the other side as a limb span + sign.
 template <std::size_t b, class A>
 template <std::size_t extent_other>
-constexpr void
-basic_big_int<b, A>::add_in_place(const std::span<const uint_multiprecision_t, extent_other> other,
-                                  const bool                                                 other_neg) {
+constexpr void basic_big_int<b, A>::add_in_place(const std::span<const uint_multiprecision_t, extent_other> other,
+                                                 const bool other_neg) {
     const bool this_neg = is_negative();
 
     if (this_neg == other_neg) {

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -419,9 +419,7 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
             }
             limb_type* const       dst_limbs = dst.limb_ptr();
             const limb_type* const src_limbs = src.limb_ptr();
-            for (std::size_t i = 0; i < src_count; ++i) {
-                dst_limbs[i] = src_limbs[i];
-            }
+            std::copy_n(src_limbs, src_count, dst_limbs);
             // Preserve the "limbs[limb_count..inplace_capacity) == 0" invariant that
             // `inplace_to_bit_uint` relies on. Only relevant for inline storage.
             if (dst.is_storage_static()) {

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -1122,7 +1122,7 @@ constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y) {
 
     // In each of these branches we try to take the largest storage available
     // In the case that we do have to allocate, we automatically add in an extra limb,
-    // otherwise we run the risk of a second allocation occuring a the end of addition
+    // otherwise we run the risk of a second allocation occurring a the end of addition
     // In the case that we are using inline storage we do not request an extra limb,
     // we defer that decision till as late as possible in case the addition result fits
     // into the static storage rather than having to allocate for no reason

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -375,15 +375,6 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     template <std::size_t extent_other>
     constexpr void add_in_place(std::span<const uint_multiprecision_t, extent_other> other, bool other_neg);
 
-    // Used by the lvalue copy branches of `operator+` / `operator-` to decide
-    // whether to request one limb of carry-headroom when setting up the result.
-    // Returns 1 unless `x` sits exactly on the inline/heap boundary
-    // (`limb_count == inplace_capacity`), in which case reserving the extra limb
-    // would force an otherwise-inline result onto the heap.
-    [[nodiscard]] static constexpr std::size_t carry_headroom(const basic_big_int& x) noexcept {
-        return x.limb_count() == inplace_capacity ? 0 : 1;
-    }
-
     // Shared implementation behind copy-assign and move-assign.
     // Sets `dst` to a copy of `src`, reusing `dst`'s existing allocation whenever its effective
     // capacity already fits `src.limb_count() + extra_space` limbs.
@@ -1157,21 +1148,22 @@ constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y) {
         }
         return r;
     } else if constexpr (detail::is_basic_big_int_v<LT> && detail::is_basic_big_int_v<RT>) {
-        // 4) both lvalue `basic_big_int`s: `copy_value` folds the copy of the
-        // larger operand and the carry-headroom reservation into one allocation
+        // 4) both lvalue `basic_big_int`s: copy the larger operand, then add the smaller.
+        // For inline sources no extra space is requested, so the copy stays inline
+        // The move to heap storage is deferred to add_in_place if required
         Result r;
         if (x.limb_count() >= y.limb_count()) {
-            copy_value(r, x, Result::carry_headroom(x));
+            copy_value(r, x, !x.is_storage_static());
             r.add_in_place(y.representation(), y.is_negative());
             return r;
         }
-        copy_value(r, y, Result::carry_headroom(y));
+        copy_value(r, y, !y.is_storage_static());
         r.add_in_place(x.representation(), x.is_negative());
         return r;
     } else if constexpr (detail::is_basic_big_int_v<LT>) {
         // 5) lvalue `basic_big_int` lhs, primitive rhs.
         Result r;
-        copy_value(r, x, Result::carry_headroom(x));
+        copy_value(r, x, !x.is_storage_static());
         const auto y_limbs = detail::to_limbs(detail::uabs(y));
         r.add_in_place(detail::to_fixed_span(y_limbs), detail::integer_signbit(y));
         return r;
@@ -1180,7 +1172,7 @@ constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y) {
         // forbidden by `common_big_int_type`; rvalue rhs was caught in (3)).
         static_assert(detail::is_basic_big_int_v<RT>);
         Result r;
-        copy_value(r, y, Result::carry_headroom(y));
+        copy_value(r, y, !y.is_storage_static());
         const auto x_limbs = detail::to_limbs(detail::uabs(x));
         r.add_in_place(detail::to_fixed_span(x_limbs), detail::integer_signbit(x));
         return r;
@@ -1235,20 +1227,21 @@ constexpr detail::common_big_int_type<L, R> operator-(L&& x, R&& y) {
         return r;
     } else if constexpr (detail::is_basic_big_int_v<LT> && detail::is_basic_big_int_v<RT>) {
         // 4) both lvalue `basic_big_int`s: copy the larger, then subtract the smaller.
+        // For inline sources no extra space is requested, so the copy stays inline
         Result r;
         if (x.limb_count() >= y.limb_count()) {
-            copy_value(r, x, Result::carry_headroom(x));
+            copy_value(r, x, !x.is_storage_static());
             r.add_in_place(y.representation(), !y.is_negative());
             return r;
         }
-        copy_value(r, y, Result::carry_headroom(y));
+        copy_value(r, y, !y.is_storage_static());
         r.negate();
         r.add_in_place(x.representation(), x.is_negative());
         return r;
     } else if constexpr (detail::is_basic_big_int_v<LT>) {
         // 5) lvalue `basic_big_int` lhs, primitive rhs.
         Result r;
-        copy_value(r, x, Result::carry_headroom(x));
+        copy_value(r, x, !x.is_storage_static());
         const auto y_limbs = detail::to_limbs(detail::uabs(y));
         r.add_in_place(detail::to_fixed_span(y_limbs), !detail::integer_signbit(y));
         return r;
@@ -1256,7 +1249,7 @@ constexpr detail::common_big_int_type<L, R> operator-(L&& x, R&& y) {
         // 6) primitive lhs, lvalue `basic_big_int` rhs: copy rhs, negate, add lhs.
         static_assert(detail::is_basic_big_int_v<RT>);
         Result r;
-        copy_value(r, y, Result::carry_headroom(y));
+        copy_value(r, y, !y.is_storage_static());
         r.negate();
         const auto x_limbs = detail::to_limbs(detail::uabs(x));
         r.add_in_place(detail::to_fixed_span(x_limbs), detail::integer_signbit(x));

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -375,21 +375,18 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     template <std::size_t extent_other>
     constexpr void add_in_place(std::span<const uint_multiprecision_t, extent_other> other, bool other_neg);
 
-    // Shared implementation behind copy-assign and move-assign.
-    // Sets `dst` to a copy of `src`, reusing `dst`'s existing allocation whenever its effective
-    // capacity already fits `src.limb_count() + extra_space` limbs.
-    // Allow extra space to be stated upfront so that functions that know they are
-    // about to grow by a fixed amount (e.g., a carry-out of one
-    // limb in addition) can ask for that space up front.
-    //
-    // Defined inline because the friend template declaration matches the enclosing
-    // class by name, which is tidier than reconstructing the template parameters
-    // out-of-class.
+    // Shared implementation behind copy-assign, move-assign, and the lvalue
+    // branches of `operator+` / `operator-`.
+    // Sets `*this` to a copy of `src`, reusing the existing allocation whenever
+    // the effective capacity already fits `src.limb_count() + extra_space` limbs.
+    // `extra_space` lets callers that know they are about to grow by a fixed
+    // amount (e.g., a carry-out of one limb in addition) reserve that space
+    // up front so that a subsequent grow is not needed.
     template <class Src>
         requires std::same_as<std::remove_cvref_t<Src>, basic_big_int>
-    friend constexpr void copy_value(basic_big_int& dst, Src&& src, const std::size_t extra_space = 0) {
-        if (std::addressof(dst) == std::addressof(src)) {
-            // `copy_value(a, std::move(a), ...)` is a no-op. Also guards the extra
+    constexpr void assign_value(Src&& src, const std::size_t extra_space = 0) {
+        if (std::addressof(*this) == std::addressof(src)) {
+            // `assign_value(std::move(*this), ...)` is a no-op. Also guards the
             // self-aliasing the existing `operator=` overloads protected against.
             return;
         }
@@ -397,23 +394,23 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
         constexpr bool    is_move   = !std::is_lvalue_reference_v<Src>;
         const std::size_t src_count = src.limb_count();
         const std::size_t needed    = src_count + extra_space;
-        const std::size_t eff_cap   = dst.is_storage_static() ? inplace_capacity : dst.m_capacity;
+        const std::size_t eff_cap   = is_storage_static() ? inplace_capacity : m_capacity;
 
         if (needed <= eff_cap) {
-            // Fast path: `dst`'s current buffer is already big enough
-            const auto old_count = dst.limb_count();
-            dst.m_size_and_sign  = src.m_size_and_sign;
+            // Fast path: current buffer is already big enough
+            const auto old_count = limb_count();
+            m_size_and_sign      = src.m_size_and_sign;
             if constexpr (is_move) {
-                dst.m_alloc = std::move(src.m_alloc);
+                m_alloc = std::move(src.m_alloc);
             } else {
-                dst.m_alloc = src.m_alloc;
+                m_alloc = src.m_alloc;
             }
-            limb_type* const       dst_limbs = dst.limb_ptr();
+            limb_type* const       dst_limbs = limb_ptr();
             const limb_type* const src_limbs = src.limb_ptr();
             std::copy_n(src_limbs, src_count, dst_limbs);
             // Preserve the "limbs[limb_count..inplace_capacity) == 0" invariant that
             // `inplace_to_bit_uint` relies on. Only relevant for inline storage.
-            if (dst.is_storage_static()) {
+            if (is_storage_static()) {
                 for (std::size_t i = src_count; i < old_count; ++i) {
                     dst_limbs[i] = limb_type{0};
                 }
@@ -421,21 +418,21 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
             return;
         }
 
-        // Slow path: `dst`'s buffer is too small.
+        // Slow path: current buffer is too small.
         // Release it and get a new allocation
-        dst.free_storage();
-        dst.m_size_and_sign = src.m_size_and_sign;
+        free_storage();
+        m_size_and_sign = src.m_size_and_sign;
         if constexpr (is_move) {
-            dst.m_alloc = std::move(src.m_alloc);
+            m_alloc = std::move(src.m_alloc);
         } else {
-            dst.m_alloc = src.m_alloc;
+            m_alloc = src.m_alloc;
         }
 
         if (src.is_storage_static() && needed <= inplace_capacity) {
             // Both src and the requested headroom fit inline.
-            dst.m_capacity = 0;
+            m_capacity = 0;
             for (std::size_t i = 0; i < inplace_capacity; ++i) {
-                dst.m_storage.limbs[i] = src.m_storage.limbs[i];
+                m_storage.limbs[i] = src.m_storage.limbs[i];
             }
             return;
         }
@@ -444,12 +441,12 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
             // For a heap `src`, adopt its pointer unconditionally and then grow
             // if the stolen capacity doesn't cover `needed`.
             if (!src.is_storage_static()) {
-                dst.m_capacity      = src.m_capacity;
-                dst.m_storage.data  = src.m_storage.data;
+                m_capacity      = src.m_capacity;
+                m_storage.data  = src.m_storage.data;
                 src.m_capacity      = 0;
                 src.m_size_and_sign = 1;
-                if (dst.m_capacity < needed) {
-                    dst.grow(needed);
+                if (m_capacity < needed) {
+                    grow(needed);
                 }
                 return;
             }
@@ -457,10 +454,10 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
         }
 
         // Fall back to a fresh allocation of `needed` limbs.
-        const alloc_result allocation = dst.alloc_limbs(needed);
-        dst.copy_n_to_allocation(src.limb_ptr(), src_count, allocation);
-        dst.m_capacity     = static_cast<std::uint32_t>(allocation.count);
-        dst.m_storage.data = allocation.ptr;
+        const alloc_result allocation = alloc_limbs(needed);
+        copy_n_to_allocation(src.limb_ptr(), src_count, allocation);
+        m_capacity     = static_cast<std::uint32_t>(allocation.count);
+        m_storage.data = allocation.ptr;
     }
 
     static constexpr bool        has_inplace_to_bit_uint = inplace_bits <= BEMAN_BIG_INT_BITINT_MAXWIDTH;
@@ -588,17 +585,18 @@ constexpr basic_big_int<b, A>::basic_big_int(basic_big_int&& x) noexcept
 
 template <std::size_t b, class A>
 constexpr basic_big_int<b, A>& basic_big_int<b, A>::operator=(const basic_big_int& x) {
-    copy_value(*this, x);
+    assign_value(x);
     return *this;
 }
 
 template <std::size_t b, class A>
 constexpr basic_big_int<b, A>& basic_big_int<b, A>::operator=(basic_big_int&& x) noexcept {
-    // Invariant: `copy_value` with `extra_space == 0` and an rvalue `src` never
-    // allocates -- either `*this` already fits `x.limb_count()`, or we steal `x`'s
-    // heap buffer, or `x` is inline and fits inline in `*this`. So the `noexcept`
-    // contract holds even though `copy_value` itself is not marked `noexcept`.
-    copy_value(*this, std::move(x));
+    // Invariant: `assign_value` with `extra_space == 0` and an rvalue `src`
+    // never allocates -- either `*this` already fits `x.limb_count()`, or we
+    // steal `x`'s heap buffer, or `x` is inline and fits inline in `*this`.
+    // So the `noexcept` contract holds even though `assign_value` itself is
+    // not marked `noexcept`.
+    assign_value(std::move(x));
     return *this;
 }
 
@@ -1153,17 +1151,17 @@ constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y) {
         // The move to heap storage is deferred to add_in_place if required
         Result r;
         if (x.limb_count() >= y.limb_count()) {
-            copy_value(r, x, !x.is_storage_static());
+            r.assign_value(x, !x.is_storage_static());
             r.add_in_place(y.representation(), y.is_negative());
             return r;
         }
-        copy_value(r, y, !y.is_storage_static());
+        r.assign_value(y, !y.is_storage_static());
         r.add_in_place(x.representation(), x.is_negative());
         return r;
     } else if constexpr (detail::is_basic_big_int_v<LT>) {
         // 5) lvalue `basic_big_int` lhs, primitive rhs.
         Result r;
-        copy_value(r, x, !x.is_storage_static());
+        r.assign_value(x, !x.is_storage_static());
         const auto y_limbs = detail::to_limbs(detail::uabs(y));
         r.add_in_place(detail::to_fixed_span(y_limbs), detail::integer_signbit(y));
         return r;
@@ -1172,7 +1170,7 @@ constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y) {
         // forbidden by `common_big_int_type`; rvalue rhs was caught in (3)).
         static_assert(detail::is_basic_big_int_v<RT>);
         Result r;
-        copy_value(r, y, !y.is_storage_static());
+        r.assign_value(y, !y.is_storage_static());
         const auto x_limbs = detail::to_limbs(detail::uabs(x));
         r.add_in_place(detail::to_fixed_span(x_limbs), detail::integer_signbit(x));
         return r;
@@ -1230,18 +1228,18 @@ constexpr detail::common_big_int_type<L, R> operator-(L&& x, R&& y) {
         // For inline sources no extra space is requested, so the copy stays inline
         Result r;
         if (x.limb_count() >= y.limb_count()) {
-            copy_value(r, x, !x.is_storage_static());
+            r.assign_value(x, !x.is_storage_static());
             r.add_in_place(y.representation(), !y.is_negative());
             return r;
         }
-        copy_value(r, y, !y.is_storage_static());
+        r.assign_value(y, !y.is_storage_static());
         r.negate();
         r.add_in_place(x.representation(), x.is_negative());
         return r;
     } else if constexpr (detail::is_basic_big_int_v<LT>) {
         // 5) lvalue `basic_big_int` lhs, primitive rhs.
         Result r;
-        copy_value(r, x, !x.is_storage_static());
+        r.assign_value(x, !x.is_storage_static());
         const auto y_limbs = detail::to_limbs(detail::uabs(y));
         r.add_in_place(detail::to_fixed_span(y_limbs), !detail::integer_signbit(y));
         return r;
@@ -1249,7 +1247,7 @@ constexpr detail::common_big_int_type<L, R> operator-(L&& x, R&& y) {
         // 6) primitive lhs, lvalue `basic_big_int` rhs: copy rhs, negate, add lhs.
         static_assert(detail::is_basic_big_int_v<RT>);
         Result r;
-        copy_value(r, y, !y.is_storage_static());
+        r.assign_value(y, !y.is_storage_static());
         r.negate();
         const auto x_limbs = detail::to_limbs(detail::uabs(x));
         r.add_in_place(detail::to_fixed_span(x_limbs), detail::integer_signbit(x));

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -1051,7 +1051,7 @@ constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y) {
         // so the span we pass to the helper stays valid for the call.
         const auto y_limbs = detail::to_limbs(detail::uabs(y));
         return Result::make_sum_of_limbs(x.representation(),
-                                         x.is_negative(), //
+                                         x.is_negative(),
                                          detail::to_fixed_span(y_limbs),
                                          detail::integer_signbit(y));
     } else {
@@ -1059,7 +1059,7 @@ constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y) {
         static_assert(detail::is_basic_big_int_v<RT>);
         const auto x_limbs = detail::to_limbs(detail::uabs(x));
         return Result::make_sum_of_limbs(detail::to_fixed_span(x_limbs),
-                                         detail::integer_signbit(x), //
+                                         detail::integer_signbit(x),
                                          y.representation(),
                                          y.is_negative());
     }

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -374,6 +374,94 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     template <std::size_t extent_other>
     constexpr void add_in_place(std::span<const uint_multiprecision_t, extent_other> other, bool other_neg);
 
+    // Shared implementation behind copy-assign and move-assign.
+    // Sets `dst` to a copy of `src`, reusing `dst`'s existing allocation whenever its effective
+    // capacity already fits `src.limb_count() + extra_space` limbs.
+    // Allow extra space to be stated upfront so that functions that know they are
+    // about to grow by a fixed amount (e.g., a carry-out of one
+    // limb in addition) can ask for that space up front.
+    //
+    // Defined inline because the friend template declaration matches the enclosing
+    // class by name, which is tidier than reconstructing the template parameters
+    // out-of-class.
+    template <class Src>
+        requires std::same_as<std::remove_cvref_t<Src>, basic_big_int>
+    friend constexpr void copy_value(basic_big_int& dst, Src&& src, const std::size_t extra_space = 0) {
+        if (std::addressof(dst) == std::addressof(src)) {
+            // `copy_value(a, std::move(a), ...)` is a no-op. Also guards the extra
+            // self-aliasing the existing `operator=` overloads protected against.
+            return;
+        }
+
+        constexpr bool    is_move   = !std::is_lvalue_reference_v<Src>;
+        const std::size_t src_count = src.limb_count();
+        const std::size_t needed    = src_count + extra_space;
+        const std::size_t eff_cap   = dst.is_storage_static() ? inplace_limbs : dst.m_capacity;
+
+        if (needed <= eff_cap) {
+            // Fast path: `dst`'s current buffer is already big enough
+            const auto old_count = dst.limb_count();
+            dst.m_size_and_sign  = src.m_size_and_sign;
+            if constexpr (is_move) {
+                dst.m_alloc = std::move(src.m_alloc);
+            } else {
+                dst.m_alloc = src.m_alloc;
+            }
+            limb_type* const       dst_limbs = dst.limb_ptr();
+            const limb_type* const src_limbs = src.limb_ptr();
+            for (std::size_t i = 0; i < src_count; ++i) {
+                dst_limbs[i] = src_limbs[i];
+            }
+            // Preserve the "limbs[limb_count..inplace_limbs) == 0" invariant that
+            // `inplace_to_bit_uint` relies on. Only relevant for inline storage.
+            if (dst.is_storage_static()) {
+                for (std::size_t i = src_count; i < old_count; ++i) {
+                    dst_limbs[i] = limb_type{0};
+                }
+            }
+            return;
+        }
+
+        // Slow path: `dst`'s buffer is too small.
+        // Release it and get a new allocation
+        dst.free_storage();
+        dst.m_size_and_sign = src.m_size_and_sign;
+        if constexpr (is_move) {
+            dst.m_alloc = std::move(src.m_alloc);
+        } else {
+            dst.m_alloc = src.m_alloc;
+        }
+
+        if (src.is_storage_static() && needed <= inplace_limbs) {
+            // Both src and the requested headroom fit inline.
+            dst.m_capacity = 0;
+            for (std::size_t i = 0; i < inplace_limbs; ++i) {
+                dst.m_storage.limbs[i] = src.m_storage.limbs[i];
+            }
+            return;
+        }
+
+        if constexpr (is_move) {
+            // If `src` has a heap buffer that's large enough, stealing it is
+            // cheaper than allocating. `src.m_capacity >= src_count` always, so
+            // when `extra_space == 0` this branch fires for every heap `src`
+            // and keeps `operator=(&&)` allocation-free.
+            if (!src.is_storage_static() && src.m_capacity >= needed) {
+                dst.m_capacity      = src.m_capacity;
+                dst.m_storage.data  = src.m_storage.data;
+                src.m_capacity      = 0;
+                src.m_size_and_sign = 1;
+                return;
+            }
+        }
+
+        // Fall back to a fresh allocation of `needed` limbs.
+        const alloc_result allocation = dst.alloc_limbs(needed);
+        dst.copy_n_to_allocation(src.limb_ptr(), src_count, allocation);
+        dst.m_capacity     = static_cast<std::uint32_t>(allocation.count);
+        dst.m_storage.data = allocation.ptr;
+    }
+
     static constexpr bool        has_inplace_to_bit_uint = inplace_bits <= BEMAN_BIG_INT_BITINT_MAXWIDTH;
     [[nodiscard]] constexpr auto inplace_to_bit_uint() const noexcept
 #ifdef BEMAN_BIG_INT_HAS_BITINT
@@ -499,51 +587,17 @@ constexpr basic_big_int<b, A>::basic_big_int(basic_big_int&& x) noexcept
 
 template <std::size_t b, class A>
 constexpr basic_big_int<b, A>& basic_big_int<b, A>::operator=(const basic_big_int& x) {
-    if (this == &x) {
-        return *this;
-    }
-
-    free_storage();
-    m_size_and_sign = x.m_size_and_sign;
-    m_alloc         = x.m_alloc;
-
-    if (x.is_storage_static()) {
-        m_capacity = 0;
-        for (size_type i = 0; i < inplace_capacity; ++i) {
-            m_storage.limbs[i] = x.m_storage.limbs[i];
-        }
-    } else {
-        const alloc_result allocation = alloc_limbs(x.limb_count());
-        copy_n_to_allocation(x.m_storage.data, x.limb_count(), allocation);
-        m_capacity     = static_cast<std::uint32_t>(allocation.count);
-        m_storage.data = allocation.ptr;
-    }
-
+    copy_value(*this, x);
     return *this;
 }
 
 template <std::size_t b, class A>
 constexpr basic_big_int<b, A>& basic_big_int<b, A>::operator=(basic_big_int&& x) noexcept {
-    if (this == &x) {
-        return *this;
-    }
-
-    free_storage();
-    m_size_and_sign = x.m_size_and_sign;
-    m_alloc         = std::move(x.m_alloc);
-
-    if (x.is_storage_static()) {
-        m_capacity = 0;
-        for (size_type i = 0; i < inplace_capacity; ++i) {
-            m_storage.limbs[i] = x.m_storage.limbs[i];
-        }
-    } else {
-        m_capacity        = x.m_capacity;
-        m_storage.data    = x.m_storage.data;
-        x.m_capacity      = 0;
-        x.m_size_and_sign = 1;
-    }
-
+    // Invariant: `copy_value` with `extra_space == 0` and an rvalue `src` never
+    // allocates -- either `*this` already fits `x.limb_count()`, or we steal `x`'s
+    // heap buffer, or `x` is inline and fits inline in `*this`. So the `noexcept`
+    // contract holds even though `copy_value` itself is not marked `noexcept`.
+    copy_value(*this, std::move(x));
     return *this;
 }
 

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -441,8 +441,8 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
             // For a heap `src`, adopt its pointer unconditionally and then grow
             // if the stolen capacity doesn't cover `needed`.
             if (!src.is_storage_static()) {
-                m_capacity      = src.m_capacity;
-                m_storage.data  = src.m_storage.data;
+                m_capacity          = src.m_capacity;
+                m_storage.data      = src.m_storage.data;
                 src.m_capacity      = 0;
                 src.m_size_and_sign = 1;
                 if (m_capacity < needed) {

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -377,10 +377,10 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     // Used by the lvalue copy branches of `operator+` / `operator-` to decide
     // whether to request one limb of carry-headroom when setting up the result.
     // Returns 1 unless `x` sits exactly on the inline/heap boundary
-    // (`limb_count == inplace_limbs`), in which case reserving the extra limb
+    // (`limb_count == inplace_capacity`), in which case reserving the extra limb
     // would force an otherwise-inline result onto the heap.
     [[nodiscard]] static constexpr std::size_t carry_headroom(const basic_big_int& x) noexcept {
-        return x.limb_count() == inplace_limbs ? 0 : 1;
+        return x.limb_count() == inplace_capacity ? 0 : 1;
     }
 
     // Shared implementation behind copy-assign and move-assign.
@@ -405,7 +405,7 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
         constexpr bool    is_move   = !std::is_lvalue_reference_v<Src>;
         const std::size_t src_count = src.limb_count();
         const std::size_t needed    = src_count + extra_space;
-        const std::size_t eff_cap   = dst.is_storage_static() ? inplace_limbs : dst.m_capacity;
+        const std::size_t eff_cap   = dst.is_storage_static() ? inplace_capacity : dst.m_capacity;
 
         if (needed <= eff_cap) {
             // Fast path: `dst`'s current buffer is already big enough
@@ -421,7 +421,7 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
             for (std::size_t i = 0; i < src_count; ++i) {
                 dst_limbs[i] = src_limbs[i];
             }
-            // Preserve the "limbs[limb_count..inplace_limbs) == 0" invariant that
+            // Preserve the "limbs[limb_count..inplace_capacity) == 0" invariant that
             // `inplace_to_bit_uint` relies on. Only relevant for inline storage.
             if (dst.is_storage_static()) {
                 for (std::size_t i = src_count; i < old_count; ++i) {
@@ -441,10 +441,10 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
             dst.m_alloc = src.m_alloc;
         }
 
-        if (src.is_storage_static() && needed <= inplace_limbs) {
+        if (src.is_storage_static() && needed <= inplace_capacity) {
             // Both src and the requested headroom fit inline.
             dst.m_capacity = 0;
-            for (std::size_t i = 0; i < inplace_limbs; ++i) {
+            for (std::size_t i = 0; i < inplace_capacity; ++i) {
                 dst.m_storage.limbs[i] = src.m_storage.limbs[i];
             }
             return;

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -374,6 +374,15 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     template <std::size_t extent_other>
     constexpr void add_in_place(std::span<const uint_multiprecision_t, extent_other> other, bool other_neg);
 
+    // Used by the lvalue copy branches of `operator+` / `operator-` to decide
+    // whether to request one limb of carry-headroom when setting up the result.
+    // Returns 1 unless `x` sits exactly on the inline/heap boundary
+    // (`limb_count == inplace_limbs`), in which case reserving the extra limb
+    // would force an otherwise-inline result onto the heap.
+    [[nodiscard]] static constexpr std::size_t carry_headroom(const basic_big_int& x) noexcept {
+        return x.limb_count() == inplace_limbs ? 0 : 1;
+    }
+
     // Shared implementation behind copy-assign and move-assign.
     // Sets `dst` to a copy of `src`, reusing `dst`'s existing allocation whenever its effective
     // capacity already fits `src.limb_count() + extra_space` limbs.
@@ -442,17 +451,19 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
         }
 
         if constexpr (is_move) {
-            // If `src` has a heap buffer that's large enough, stealing it is
-            // cheaper than allocating. `src.m_capacity >= src_count` always, so
-            // when `extra_space == 0` this branch fires for every heap `src`
-            // and keeps `operator=(&&)` allocation-free.
-            if (!src.is_storage_static() && src.m_capacity >= needed) {
+            // For a heap `src`, adopt its pointer unconditionally and then grow
+            // if the stolen capacity doesn't cover `needed`.
+            if (!src.is_storage_static()) {
                 dst.m_capacity      = src.m_capacity;
                 dst.m_storage.data  = src.m_storage.data;
                 src.m_capacity      = 0;
                 src.m_size_and_sign = 1;
+                if (dst.m_capacity < needed) {
+                    dst.grow(needed);
+                }
                 return;
             }
+            // `src` is inline, fall through to the allocate-and-copy path below.
         }
 
         // Fall back to a fresh allocation of `needed` limbs.
@@ -1109,13 +1120,15 @@ constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y) {
     using LT     = std::remove_cvref_t<L>;
     using RT     = std::remove_cvref_t<R>;
 
-    if constexpr (detail::is_basic_big_int_v<LT> && !std::is_reference_v<L> //
+    // In each of these branches we try to take the largest storage available
+    // In the case that we do have to allocate, we automatically add in an extra limb,
+    // otherwise we run the risk of a second allocation occuring a the end of addition
+    // In the case that we are using inline storage we do not request an extra limb,
+    // we defer that decision till as late as possible in case the addition result fits
+    // into the static storage rather than having to allocate for no reason
+    if constexpr (detail::is_basic_big_int_v<LT> && !std::is_reference_v<L>
                   && detail::is_basic_big_int_v<RT> && !std::is_reference_v<R>) {
-        // (1) both rvalue `basic_big_int`s: move the larger. Whichever we don't
-        // pick is freed at scope exit anyway, so we might as well take the one
-        // whose existing capacity already covers the result. `std::forward` and
-        // `std::move` are equivalent under the non-reference guard; `forward`
-        // silences the forwarding-reference lint.
+        // 1) both rvalue `basic_big_int`s: move the larger
         if (x.limb_count() >= y.limb_count()) {
             Result r = std::forward<L>(x);
             r.add_in_place(y.representation(), y.is_negative());
@@ -1125,7 +1138,7 @@ constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y) {
         r.add_in_place(x.representation(), x.is_negative());
         return r;
     } else if constexpr (detail::is_basic_big_int_v<LT> && !std::is_reference_v<L>) {
-        // (2) rvalue lhs only: steal its storage.
+        // 2) rvalue lhs only: adopt its storage.
         Result r = std::forward<L>(x);
         if constexpr (detail::is_basic_big_int_v<RT>) {
             r.add_in_place(y.representation(), y.is_negative());
@@ -1135,7 +1148,7 @@ constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y) {
         }
         return r;
     } else if constexpr (detail::is_basic_big_int_v<RT> && !std::is_reference_v<R>) {
-        // (3) rvalue rhs only (addition is commutative, so we reuse rhs).
+        // 3) rvalue rhs only (addition is commutative, so we reuse rhs).
         Result r = std::forward<R>(y);
         if constexpr (detail::is_basic_big_int_v<LT>) {
             r.add_in_place(x.representation(), x.is_negative());
@@ -1145,28 +1158,30 @@ constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y) {
         }
         return r;
     } else if constexpr (detail::is_basic_big_int_v<LT> && detail::is_basic_big_int_v<RT>) {
-        // (4) both lvalue `basic_big_int`s: copy the larger-limb-count source so
-        // that `add_in_place`'s subsequent `grow(max(|x|,|y|))` is a no-op. Only
-        // a top-limb carry-out can force a further allocation.
+        // 4) both lvalue `basic_big_int`s: `copy_value` folds the copy of the
+        // larger operand and the carry-headroom reservation into one allocation
+        Result r;
         if (x.limb_count() >= y.limb_count()) {
-            Result r = x;
+            copy_value(r, x, Result::carry_headroom(x));
             r.add_in_place(y.representation(), y.is_negative());
             return r;
         }
-        Result r = y;
+        copy_value(r, y, Result::carry_headroom(y));
         r.add_in_place(x.representation(), x.is_negative());
         return r;
     } else if constexpr (detail::is_basic_big_int_v<LT>) {
-        // (5) lvalue `basic_big_int` lhs, primitive rhs.
-        Result     r       = x;
+        // 5) lvalue `basic_big_int` lhs, primitive rhs.
+        Result r;
+        copy_value(r, x, Result::carry_headroom(x));
         const auto y_limbs = detail::to_limbs(detail::uabs(y));
         r.add_in_place(detail::to_fixed_span(y_limbs), detail::integer_signbit(y));
         return r;
     } else {
-        // (6) primitive lhs, lvalue `basic_big_int` rhs (primitive+primitive is
+        // 6) primitive lhs, lvalue `basic_big_int` rhs (primitive+primitive is
         // forbidden by `common_big_int_type`; rvalue rhs was caught in (3)).
         static_assert(detail::is_basic_big_int_v<RT>);
-        Result     r       = y;
+        Result r;
+        copy_value(r, y, Result::carry_headroom(y));
         const auto x_limbs = detail::to_limbs(detail::uabs(x));
         r.add_in_place(detail::to_fixed_span(x_limbs), detail::integer_signbit(x));
         return r;
@@ -1185,20 +1200,21 @@ constexpr detail::common_big_int_type<L, R> operator-(L&& x, R&& y) {
     using LT     = std::remove_cvref_t<L>;
     using RT     = std::remove_cvref_t<R>;
 
-    if constexpr (detail::is_basic_big_int_v<LT> && !std::is_reference_v<L> //
+    // See `operator+` description of logic, as it is the same
+    if constexpr (detail::is_basic_big_int_v<LT> && !std::is_reference_v<L>
                   && detail::is_basic_big_int_v<RT> && !std::is_reference_v<R>) {
-        // (1) both rvalue `basic_big_int`s: move the larger-limb-count source.
+        // 1) both rvalue `basic_big_int`s: move the larger-limb-count source.
         if (x.limb_count() >= y.limb_count()) {
             Result r = std::forward<L>(x);
             r.add_in_place(y.representation(), !y.is_negative()); // r + (-y)
             return r;
         }
         Result r = std::forward<R>(y);
-        r.negate();                                               // r = -y
-        r.add_in_place(x.representation(), x.is_negative());      // (-y) + x = x - y
+        r.negate();                                          // r = -y
+        r.add_in_place(x.representation(), x.is_negative()); // (-y) + x = x - y
         return r;
     } else if constexpr (detail::is_basic_big_int_v<LT> && !std::is_reference_v<L>) {
-        // (2) rvalue lhs only: `r = x; r += (-y)`.
+        // 2) rvalue lhs only: `r = x; r += (-y)`.
         Result r = std::forward<L>(x);
         if constexpr (detail::is_basic_big_int_v<RT>) {
             r.add_in_place(y.representation(), !y.is_negative());
@@ -1208,7 +1224,7 @@ constexpr detail::common_big_int_type<L, R> operator-(L&& x, R&& y) {
         }
         return r;
     } else if constexpr (detail::is_basic_big_int_v<RT> && !std::is_reference_v<R>) {
-        // (3) rvalue rhs only: `r = -y; r += x` gives `x - y`.
+        // 3) rvalue rhs only: `r = -y; r += x` gives `x - y`.
         Result r = std::forward<R>(y);
         r.negate();
         if constexpr (detail::is_basic_big_int_v<LT>) {
@@ -1219,26 +1235,29 @@ constexpr detail::common_big_int_type<L, R> operator-(L&& x, R&& y) {
         }
         return r;
     } else if constexpr (detail::is_basic_big_int_v<LT> && detail::is_basic_big_int_v<RT>) {
-        // (4) both lvalue `basic_big_int`s: copy the larger, then subtract the smaller.
+        // 4) both lvalue `basic_big_int`s: copy the larger, then subtract the smaller.
+        Result r;
         if (x.limb_count() >= y.limb_count()) {
-            Result r = x;
+            copy_value(r, x, Result::carry_headroom(x));
             r.add_in_place(y.representation(), !y.is_negative());
             return r;
         }
-        Result r = y;
+        copy_value(r, y, Result::carry_headroom(y));
         r.negate();
         r.add_in_place(x.representation(), x.is_negative());
         return r;
     } else if constexpr (detail::is_basic_big_int_v<LT>) {
-        // (5) lvalue `basic_big_int` lhs, primitive rhs.
-        Result     r       = x;
+        // 5) lvalue `basic_big_int` lhs, primitive rhs.
+        Result r;
+        copy_value(r, x, Result::carry_headroom(x));
         const auto y_limbs = detail::to_limbs(detail::uabs(y));
         r.add_in_place(detail::to_fixed_span(y_limbs), !detail::integer_signbit(y));
         return r;
     } else {
-        // (6) primitive lhs, lvalue `basic_big_int` rhs: copy rhs, negate, add lhs.
+        // 6) primitive lhs, lvalue `basic_big_int` rhs: copy rhs, negate, add lhs.
         static_assert(detail::is_basic_big_int_v<RT>);
-        Result r = y;
+        Result r;
+        copy_value(r, y, Result::carry_headroom(y));
         r.negate();
         const auto x_limbs = detail::to_limbs(detail::uabs(x));
         r.add_in_place(detail::to_fixed_span(x_limbs), detail::integer_signbit(x));

--- a/tests/beman/big_int/addition.test.cpp
+++ b/tests/beman/big_int/addition.test.cpp
@@ -322,6 +322,47 @@ TEST(Addition, LvalueFallbackUnchanged) {
     EXPECT_EQ(b.representation().size(), 2u);
 }
 
+TEST(Addition, LvalueReservesCarryHeadroomInCopy) {
+    // `a + b` with two lvalue heap operands goes through `copy_value(r, larger, 1)`,
+    // which allocates `|larger| + 1` limbs in one shot. The result's capacity
+    // must reflect that reservation, demonstrating that a subsequent carry-out
+    // grow would not require a second allocation.
+    const big_int a = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1}; // 2^64, 2 limbs
+    const big_int b = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    ASSERT_EQ(a.representation().size(), 2U);
+    ASSERT_EQ(b.representation().size(), 2U);
+
+    const big_int r = a + b; // 2 * 2^64 -- limbs [0, 2], still 2 limbs but room for 3.
+    ASSERT_EQ(r.representation().size(), 2U);
+    EXPECT_GE(r.capacity(), 3U);
+}
+
+TEST(Addition, InlineInlineNoCarryStaysInline) {
+    // When both lvalue operands fit inline and the ripple-carry doesn't
+    // overflow, the result must stay in inline storage. `carry_headroom()`
+    // drops the +1 for inline-boundary sources so we don't pre-allocate a
+    // heap buffer speculatively.
+    using big_int_256 = basic_big_int<256>;
+    const big_int_256 a{5};
+    const big_int_256 b{7};
+    ASSERT_EQ(a.capacity(), 0u);
+    ASSERT_EQ(b.capacity(), 0u);
+    const big_int_256 r = a + b;
+    EXPECT_EQ(r, 12);
+    EXPECT_EQ(r.capacity(), 0u); // still inline -- no speculative heap allocation
+
+    // Boundary case for the default `big_int` (basic_big_int<64>, inplace_limbs=1):
+    // both inline, no carry => stays inline. This is the specific pessimization
+    // that would appear if copy_value(..., 1) were called unconditionally.
+    const big_int c{5};
+    const big_int d{7};
+    ASSERT_EQ(c.capacity(), 0u);
+    ASSERT_EQ(d.capacity(), 0u);
+    const big_int r2 = c + d;
+    EXPECT_EQ(r2, 12);
+    EXPECT_EQ(r2.capacity(), 0u); // still inline
+}
+
 TEST(Addition, LvalueCopiesLargerOperand) {
     // When both operands are lvalues, the implementation should copy whichever
     // has more limbs so that add_in_place does not need to grow. We can't peek

--- a/tests/beman/big_int/addition.test.cpp
+++ b/tests/beman/big_int/addition.test.cpp
@@ -309,7 +309,8 @@ TEST(Addition, RvaluePrimitiveMix) {
 }
 
 TEST(Addition, LvalueFallbackUnchanged) {
-    // Pure lvalue/lvalue dispatch must still work via `make_sum_of_limbs`.
+    // Pure lvalue/lvalue dispatch: correctness only (destination selection is
+    // covered by LvalueCopiesLargerOperand).
     const big_int a = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
     const big_int b = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
     const big_int r = a + b;
@@ -319,6 +320,29 @@ TEST(Addition, LvalueFallbackUnchanged) {
     // Operands untouched.
     EXPECT_EQ(a.representation().size(), 2u);
     EXPECT_EQ(b.representation().size(), 2u);
+}
+
+TEST(Addition, LvalueCopiesLargerOperand) {
+    // When both operands are lvalues, the implementation should copy whichever
+    // has more limbs so that add_in_place does not need to grow. We can't peek
+    // at the source of the copy directly, but we can observe that the result's
+    // allocated capacity matches the larger operand's limb count (heap copy
+    // allocates exactly `source.limb_count()` limbs).
+    const big_int small{7};                                                              // 1 limb, inline
+    const big_int big = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1}; // 2 limbs, heap
+    ASSERT_EQ(small.representation().size(), 1u);
+    ASSERT_EQ(big.representation().size(), 2u);
+
+    // `small + big` must copy `big` (not `small`); the result should already
+    // have room for the two-limb value without growing.
+    const big_int r1 = small + big;
+    EXPECT_EQ(r1, big + small);
+    EXPECT_GE(r1.capacity(), 2u);
+
+    // Symmetric case: `big + small` copies `big` too.
+    const big_int r2 = big + small;
+    EXPECT_EQ(r2, big + small);
+    EXPECT_GE(r2.capacity(), 2u);
 }
 
 } // namespace

--- a/tests/beman/big_int/addition.test.cpp
+++ b/tests/beman/big_int/addition.test.cpp
@@ -209,4 +209,116 @@ TEST(Addition, UnequalLengthMultiLimb) {
     EXPECT_EQ(r2.representation()[1], uint_multiprecision_t{1});
 }
 
+// ----- rvalue storage-reuse tests -----
+// When either operand is an rvalue `basic_big_int`, `operator+` should steal its
+// storage instead of allocating a new result buffer. Correctness is checked across
+// all (lvalue, rvalue) combinations; heap reuse is verified by comparing the data
+// pointer before and after the sum.
+
+TEST(Addition, RvalueLhsReusesStorage) {
+    // Heap-allocated `a`; `std::move(a) + small` must write the result into `a`'s buffer.
+    big_int a          = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1}; // 2^64, two limbs
+    const auto* a_data = a.representation().data();
+    ASSERT_GT(a.capacity(), 0u); // heap-allocated
+    const big_int r = std::move(a) + big_int{5};
+    EXPECT_EQ(r.representation().data(), a_data);
+    ASSERT_EQ(r.representation().size(), 2u);
+    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{5});
+    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+}
+
+TEST(Addition, RvalueRhsReusesStorage) {
+    // Commutative path: lhs is lvalue, rhs is rvalue; rhs's buffer should be reused.
+    const big_int small{5};
+    big_int       b    = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const auto* b_data = b.representation().data();
+    ASSERT_GT(b.capacity(), 0u);
+    const big_int r = small + std::move(b);
+    EXPECT_EQ(r.representation().data(), b_data);
+    ASSERT_EQ(r.representation().size(), 2u);
+    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{5});
+    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+}
+
+TEST(Addition, BothRvaluesReusesLhsStorage) {
+    // When both operands are rvalues, lhs is preferred per dispatch order.
+    big_int a          = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    big_int b          = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const auto* a_data = a.representation().data();
+    ASSERT_GT(a.capacity(), 0u);
+    ASSERT_GT(b.capacity(), 0u);
+    const big_int r = std::move(a) + std::move(b);
+    EXPECT_EQ(r.representation().data(), a_data);
+    // 2 * 2^64 = 2^65 → [0, 2]
+    ASSERT_EQ(r.representation().size(), 2u);
+    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
+    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{2});
+}
+
+TEST(Addition, RvalueCarryGrowsStorage) {
+    // Same-sign add where the ripple carry forces one extra limb beyond the
+    // rvalue's current capacity. The helper's `grow(big+1)` path must handle this.
+    big_int a = big_int{std::numeric_limits<std::uint64_t>::max()}; // 1 limb, inline
+    EXPECT_EQ(a.capacity(), 0u);
+    const big_int r = std::move(a) + big_int{1}; // 2^64 requires 2 limbs
+    ASSERT_EQ(r.representation().size(), 2u);
+    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
+    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+}
+
+TEST(Addition, RvalueCancelToZeroIsPositive) {
+    // Differing-sign, equal-magnitude rvalue add: must produce +0, never -0.
+    big_int       a = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1}; // 2^64
+    const big_int b = -a;                                                              // -2^64
+    const big_int r = std::move(a) + b;
+    EXPECT_EQ(r, 0);
+    EXPECT_FALSE(r < 0);
+    ASSERT_EQ(r.representation().size(), 1u);
+    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
+}
+
+TEST(Addition, RvalueLhsSmallerMagnitudeThanRhs) {
+    // Differing-sign, `|lhs| < |rhs|`: exercises `add_in_place`'s third branch,
+    // which must rewrite lhs's buffer as `other - this` and adopt rhs's sign.
+    big_int       a          = big_int{5};                                                // 1 limb
+    const big_int b          = -(big_int{std::numeric_limits<std::uint64_t>::max()} + 1); // -2^64
+    const big_int r          = std::move(a) + b;                                          // 5 + (-2^64) = -(2^64 - 5)
+    const big_int expected   = -(big_int{std::numeric_limits<std::uint64_t>::max()} + 1 - big_int{5});
+    EXPECT_EQ(r, expected);
+    EXPECT_TRUE(r < 0);
+}
+
+TEST(Addition, RvaluePrimitiveMix) {
+    // rvalue big_int + primitive: should reuse lhs.
+    big_int a          = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const auto* a_data = a.representation().data();
+    const big_int r    = std::move(a) + 5U;
+    EXPECT_EQ(r.representation().data(), a_data);
+    ASSERT_EQ(r.representation().size(), 2u);
+    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{5});
+    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+
+    // primitive + rvalue big_int: should reuse rhs.
+    big_int b          = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const auto* b_data = b.representation().data();
+    const big_int r2   = 7 + std::move(b);
+    EXPECT_EQ(r2.representation().data(), b_data);
+    ASSERT_EQ(r2.representation().size(), 2u);
+    EXPECT_EQ(r2.representation()[0], uint_multiprecision_t{7});
+    EXPECT_EQ(r2.representation()[1], uint_multiprecision_t{1});
+}
+
+TEST(Addition, LvalueFallbackUnchanged) {
+    // Pure lvalue/lvalue dispatch must still work via `make_sum_of_limbs`.
+    const big_int a = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const big_int b = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const big_int r = a + b;
+    ASSERT_EQ(r.representation().size(), 2u);
+    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
+    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{2});
+    // Operands untouched.
+    EXPECT_EQ(a.representation().size(), 2u);
+    EXPECT_EQ(b.representation().size(), 2u);
+}
+
 } // namespace

--- a/tests/beman/big_int/addition.test.cpp
+++ b/tests/beman/big_int/addition.test.cpp
@@ -322,11 +322,10 @@ TEST(Addition, LvalueFallbackUnchanged) {
     EXPECT_EQ(b.representation().size(), 2u);
 }
 
-TEST(Addition, LvalueReservesCarryHeadroomInCopy) {
-    // `a + b` with two lvalue heap operands goes through `copy_value(r, larger, 1)`,
-    // which allocates `|larger| + 1` limbs in one shot. The result's capacity
-    // must reflect that reservation, demonstrating that a subsequent carry-out
-    // grow would not require a second allocation.
+TEST(Addition, LvalueHeapReservesCarryHeadroom) {
+    // `a + b` with two lvalue heap operands copies the larger operand with one
+    // extra limb of headroom so that a carry-out never triggers a second
+    // allocation.
     const big_int a = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1}; // 2^64, 2 limbs
     const big_int b = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
     ASSERT_EQ(a.representation().size(), 2U);
@@ -339,9 +338,9 @@ TEST(Addition, LvalueReservesCarryHeadroomInCopy) {
 
 TEST(Addition, InlineInlineNoCarryStaysInline) {
     // When both lvalue operands fit inline and the ripple-carry doesn't
-    // overflow, the result must stay in inline storage. `carry_headroom()`
-    // drops the +1 for inline-boundary sources so we don't pre-allocate a
-    // heap buffer speculatively.
+    // overflow, the result must stay in inline storage. `copy_value` without
+    // extra headroom keeps the copy inline; `add_in_place` only allocates
+    // if a carry actually escapes.
     using big_int_256 = basic_big_int<256>;
     const big_int_256 a{5};
     const big_int_256 b{7};

--- a/tests/beman/big_int/addition.test.cpp
+++ b/tests/beman/big_int/addition.test.cpp
@@ -217,7 +217,7 @@ TEST(Addition, UnequalLengthMultiLimb) {
 
 TEST(Addition, RvalueLhsReusesStorage) {
     // Heap-allocated `a`; `std::move(a) + small` must write the result into `a`'s buffer.
-    big_int a          = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1}; // 2^64, two limbs
+    big_int     a      = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1}; // 2^64, two limbs
     const auto* a_data = a.representation().data();
     ASSERT_GT(a.capacity(), 0u); // heap-allocated
     const big_int r = std::move(a) + big_int{5};
@@ -230,8 +230,8 @@ TEST(Addition, RvalueLhsReusesStorage) {
 TEST(Addition, RvalueRhsReusesStorage) {
     // Commutative path: lhs is lvalue, rhs is rvalue; rhs's buffer should be reused.
     const big_int small{5};
-    big_int       b    = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
-    const auto* b_data = b.representation().data();
+    big_int       b      = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const auto*   b_data = b.representation().data();
     ASSERT_GT(b.capacity(), 0u);
     const big_int r = small + std::move(b);
     EXPECT_EQ(r.representation().data(), b_data);
@@ -242,8 +242,8 @@ TEST(Addition, RvalueRhsReusesStorage) {
 
 TEST(Addition, BothRvaluesReusesLhsStorage) {
     // When both operands are rvalues, lhs is preferred per dispatch order.
-    big_int a          = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
-    big_int b          = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    big_int     a      = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    big_int     b      = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
     const auto* a_data = a.representation().data();
     ASSERT_GT(a.capacity(), 0u);
     ASSERT_GT(b.capacity(), 0u);
@@ -280,28 +280,28 @@ TEST(Addition, RvalueCancelToZeroIsPositive) {
 TEST(Addition, RvalueLhsSmallerMagnitudeThanRhs) {
     // Differing-sign, `|lhs| < |rhs|`: exercises `add_in_place`'s third branch,
     // which must rewrite lhs's buffer as `other - this` and adopt rhs's sign.
-    big_int       a          = big_int{5};                                                // 1 limb
-    const big_int b          = -(big_int{std::numeric_limits<std::uint64_t>::max()} + 1); // -2^64
-    const big_int r          = std::move(a) + b;                                          // 5 + (-2^64) = -(2^64 - 5)
-    const big_int expected   = -(big_int{std::numeric_limits<std::uint64_t>::max()} + 1 - big_int{5});
+    big_int       a        = big_int{5};                                                // 1 limb
+    const big_int b        = -(big_int{std::numeric_limits<std::uint64_t>::max()} + 1); // -2^64
+    const big_int r        = std::move(a) + b;                                          // 5 + (-2^64) = -(2^64 - 5)
+    const big_int expected = -(big_int{std::numeric_limits<std::uint64_t>::max()} + 1 - big_int{5});
     EXPECT_EQ(r, expected);
     EXPECT_TRUE(r < 0);
 }
 
 TEST(Addition, RvaluePrimitiveMix) {
     // rvalue big_int + primitive: should reuse lhs.
-    big_int a          = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
-    const auto* a_data = a.representation().data();
-    const big_int r    = std::move(a) + 5U;
+    big_int       a      = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const auto*   a_data = a.representation().data();
+    const big_int r      = std::move(a) + 5U;
     EXPECT_EQ(r.representation().data(), a_data);
     ASSERT_EQ(r.representation().size(), 2u);
     EXPECT_EQ(r.representation()[0], uint_multiprecision_t{5});
     EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
 
     // primitive + rvalue big_int: should reuse rhs.
-    big_int b          = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
-    const auto* b_data = b.representation().data();
-    const big_int r2   = 7 + std::move(b);
+    big_int       b      = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const auto*   b_data = b.representation().data();
+    const big_int r2     = 7 + std::move(b);
     EXPECT_EQ(r2.representation().data(), b_data);
     ASSERT_EQ(r2.representation().size(), 2u);
     EXPECT_EQ(r2.representation()[0], uint_multiprecision_t{7});

--- a/tests/beman/big_int/addition.test.cpp
+++ b/tests/beman/big_int/addition.test.cpp
@@ -338,7 +338,7 @@ TEST(Addition, LvalueHeapReservesCarryHeadroom) {
 
 TEST(Addition, InlineInlineNoCarryStaysInline) {
     // When both lvalue operands fit inline and the ripple-carry doesn't
-    // overflow, the result must stay in inline storage. `copy_value` without
+    // overflow, the result must stay in inline storage. `assign_value` without
     // extra headroom keeps the copy inline; `add_in_place` only allocates
     // if a carry actually escapes.
     using big_int_256 = basic_big_int<256>;
@@ -352,7 +352,7 @@ TEST(Addition, InlineInlineNoCarryStaysInline) {
 
     // Boundary case for the default `big_int` (basic_big_int<64>, inplace_limbs=1):
     // both inline, no carry => stays inline. This is the specific pessimization
-    // that would appear if copy_value(..., 1) were called unconditionally.
+    // that would appear if assign_value(..., 1) were called unconditionally.
     const big_int c{5};
     const big_int d{7};
     ASSERT_EQ(c.capacity(), 0u);

--- a/tests/beman/big_int/allocation.test.cpp
+++ b/tests/beman/big_int/allocation.test.cpp
@@ -237,7 +237,7 @@ TEST(Allocation, SelfAssignment) {
 }
 
 // ----- operator= storage reuse -----
-// The shared `copy_value` helper keeps the destination's allocation if its
+// The shared `assign_value` helper keeps the destination's allocation if its
 // effective capacity already fits the source. These tests verify the fast path
 // by checking that the destination's data pointer does not change.
 
@@ -258,7 +258,7 @@ TEST(Allocation, CopyAssignReusesDstStorage) {
 }
 
 TEST(Allocation, MoveAssignReusesDstStorageWhenLarger) {
-    // When dst's capacity already covers src's limb count, copy_value should
+    // When dst's capacity already covers src's limb count, assign_value should
     // copy src's limbs into dst's buffer rather than stealing src's (smaller)
     // buffer.
     beman::big_int::big_int dst{1U};

--- a/tests/beman/big_int/allocation.test.cpp
+++ b/tests/beman/big_int/allocation.test.cpp
@@ -301,7 +301,7 @@ TEST(Allocation, MoveAssignStealsSrcWhenDstTooSmall) {
 TEST(Allocation, CopyAssignAllocatesWhenDstTooSmall) {
     // When dst has no (heap) capacity and src is bigger than inline, copy-assign
     // must allocate a fresh buffer.
-    beman::big_int::big_int dst; // inline, capacity 0
+    beman::big_int::big_int       dst; // inline, capacity 0
     const beman::big_int::big_int src = beman::big_int::big_int{0xFFFFFFFFFFFFFFFFU} + beman::big_int::big_int{1};
     ASSERT_GT(src.capacity(), 0U);
 
@@ -320,8 +320,8 @@ TEST(Allocation, AssignPreservesInlineBitCastInvariant) {
     // constructed big_int.
     using big_int_256 = beman::big_int::basic_big_int<256>;
     big_int_256 dst{0xFFFFFFFFFFFFFFFFU};
-    dst      = dst + big_int_256{1}; // promote to 2 limbs inline
-    dst      = big_int_256{7};       // shrink back to 1 limb inline -- tail must be zeroed
+    dst = dst + big_int_256{1}; // promote to 2 limbs inline
+    dst = big_int_256{7};       // shrink back to 1 limb inline -- tail must be zeroed
     EXPECT_EQ(dst, 7);
     EXPECT_EQ(dst, big_int_256{7});
     EXPECT_EQ(dst.representation().size(), 1U);

--- a/tests/beman/big_int/allocation.test.cpp
+++ b/tests/beman/big_int/allocation.test.cpp
@@ -236,6 +236,97 @@ TEST(Allocation, SelfAssignment) {
     EXPECT_EQ(x.representation()[0], 42U);
 }
 
+// ----- operator= storage reuse -----
+// The shared `copy_value` helper keeps the destination's allocation if its
+// effective capacity already fits the source. These tests verify the fast path
+// by checking that the destination's data pointer does not change.
+
+TEST(Allocation, CopyAssignReusesDstStorage) {
+    beman::big_int::big_int dst{1U};
+    dst.reserve(8); // dst now on the heap with capacity >= 8
+    const auto* const dst_data = dst.representation().data();
+    const auto        dst_cap  = dst.capacity();
+
+    const beman::big_int::big_int src = beman::big_int::big_int{0xFFFFFFFFFFFFFFFFU} + beman::big_int::big_int{1};
+    ASSERT_EQ(src.representation().size(), 2U); // heap, 2 limbs -- fits in dst's capacity
+
+    dst = src;
+    EXPECT_EQ(dst.representation().data(), dst_data); // no reallocation
+    EXPECT_EQ(dst.capacity(), dst_cap);
+    ASSERT_EQ(dst.representation().size(), 2U);
+    EXPECT_EQ(dst, src);
+}
+
+TEST(Allocation, MoveAssignReusesDstStorageWhenLarger) {
+    // When dst's capacity already covers src's limb count, copy_value should
+    // copy src's limbs into dst's buffer rather than stealing src's (smaller)
+    // buffer.
+    beman::big_int::big_int dst{1U};
+    dst.reserve(16); // big dst buffer
+    const auto* const dst_data = dst.representation().data();
+    const auto        dst_cap  = dst.capacity();
+
+    beman::big_int::big_int src = beman::big_int::big_int{0xFFFFFFFFFFFFFFFFU} + beman::big_int::big_int{1};
+    ASSERT_EQ(src.representation().size(), 2U);
+    const auto src_cap = src.capacity();
+    ASSERT_LT(src_cap, dst_cap); // dst has more capacity than src
+
+    dst = std::move(src);
+    // dst retained its larger buffer rather than adopting src's smaller one.
+    EXPECT_EQ(dst.representation().data(), dst_data);
+    EXPECT_EQ(dst.capacity(), dst_cap);
+    ASSERT_EQ(dst.representation().size(), 2U);
+}
+
+TEST(Allocation, MoveAssignStealsSrcWhenDstTooSmall) {
+    // When dst's capacity is insufficient, move-assign must steal src's buffer
+    // (noexcept contract -- no allocation allowed).
+    beman::big_int::big_int dst; // inline, capacity 0
+    EXPECT_EQ(dst.capacity(), 0U);
+
+    beman::big_int::big_int src = beman::big_int::big_int{0xFFFFFFFFFFFFFFFFU} + beman::big_int::big_int{1};
+    ASSERT_GT(src.capacity(), 0U);
+    const auto* const src_data = src.representation().data();
+    const auto        src_cap  = src.capacity();
+
+    dst = std::move(src);
+    // dst adopted src's buffer wholesale.
+    EXPECT_EQ(dst.representation().data(), src_data);
+    EXPECT_EQ(dst.capacity(), src_cap);
+    // src released heap ownership (moved-from state; value is unspecified,
+    // matching the existing move-assign contract).
+    EXPECT_EQ(src.capacity(), 0U);
+}
+
+TEST(Allocation, CopyAssignAllocatesWhenDstTooSmall) {
+    // When dst has no (heap) capacity and src is bigger than inline, copy-assign
+    // must allocate a fresh buffer.
+    beman::big_int::big_int dst; // inline, capacity 0
+    const beman::big_int::big_int src = beman::big_int::big_int{0xFFFFFFFFFFFFFFFFU} + beman::big_int::big_int{1};
+    ASSERT_GT(src.capacity(), 0U);
+
+    dst = src;
+    ASSERT_EQ(dst.representation().size(), 2U);
+    EXPECT_GT(dst.capacity(), 0U);
+    EXPECT_NE(dst.representation().data(), src.representation().data());
+    EXPECT_EQ(dst, src);
+}
+
+TEST(Allocation, AssignPreservesInlineBitCastInvariant) {
+    // After assigning a shorter value into a destination that previously held
+    // a longer value in inline storage, the unused tail limbs must be zero so
+    // that `inplace_to_bit_uint` would still produce the correct bit pattern.
+    // We verify indirectly by checking that equality comparisons match a freshly
+    // constructed big_int.
+    using big_int_256 = beman::big_int::basic_big_int<256>;
+    big_int_256 dst{0xFFFFFFFFFFFFFFFFU};
+    dst      = dst + big_int_256{1}; // promote to 2 limbs inline
+    dst      = big_int_256{7};       // shrink back to 1 limb inline -- tail must be zeroed
+    EXPECT_EQ(dst, 7);
+    EXPECT_EQ(dst, big_int_256{7});
+    EXPECT_EQ(dst.representation().size(), 1U);
+}
+
 // ----- shrink_to_fit edge cases -----
 
 TEST(Allocation, ShrinkToFitBackToInline) {

--- a/tests/beman/big_int/subtraction.test.cpp
+++ b/tests/beman/big_int/subtraction.test.cpp
@@ -207,7 +207,7 @@ TEST(Subtraction, AgreesWithAdditionOfNegated) {
 // destination and add; for lhs reuse we add with the negated rhs sign.
 
 TEST(Subtraction, RvalueLhsReusesStorage) {
-    big_int a          = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1}; // 2^64
+    big_int     a      = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1}; // 2^64
     const auto* a_data = a.representation().data();
     ASSERT_GT(a.capacity(), 0u);
     const big_int r = std::move(a) - big_int{1}; // 2^64 - 1 trims to one limb
@@ -218,8 +218,8 @@ TEST(Subtraction, RvalueLhsReusesStorage) {
 
 TEST(Subtraction, RvalueRhsReusesStorage) {
     const big_int small{1};
-    big_int       b    = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1}; // 2^64
-    const auto* b_data = b.representation().data();
+    big_int       b      = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1}; // 2^64
+    const auto*   b_data = b.representation().data();
     ASSERT_GT(b.capacity(), 0u);
     const big_int r = small - std::move(b); // 1 - 2^64 = -(2^64 - 1)
     EXPECT_EQ(r.representation().data(), b_data);
@@ -229,10 +229,10 @@ TEST(Subtraction, RvalueRhsReusesStorage) {
 }
 
 TEST(Subtraction, BothRvaluesReusesLhsStorage) {
-    big_int a          = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
-    big_int b          = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
-    const auto* a_data = a.representation().data();
-    const big_int r    = std::move(a) - std::move(b);
+    big_int       a      = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    big_int       b      = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const auto*   a_data = a.representation().data();
+    const big_int r      = std::move(a) - std::move(b);
     EXPECT_EQ(r.representation().data(), a_data);
     EXPECT_EQ(r, 0);
     EXPECT_FALSE(r < 0); // no negative zero
@@ -258,9 +258,9 @@ TEST(Subtraction, RvalueRhsNegativeToNegateBranch) {
     // destination. Uses an lvalue lhs so the rvalue-lhs dispatch branch doesn't
     // short-circuit in first.
     const big_int three{3};
-    big_int       b    = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1}; // 2^64
-    const auto* b_data = b.representation().data();
-    const big_int r    = three - std::move(b); // 3 - 2^64 = -(2^64 - 3)
+    big_int       b      = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1}; // 2^64
+    const auto*   b_data = b.representation().data();
+    const big_int r      = three - std::move(b); // 3 - 2^64 = -(2^64 - 3)
     EXPECT_EQ(r.representation().data(), b_data);
     const big_int expected = -(big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1} - big_int{3});
     EXPECT_EQ(r, expected);
@@ -273,8 +273,8 @@ TEST(Subtraction, RvalueLhsSmallerMagnitudeTriggersGrow) {
     // fit the larger magnitude before computing `other - this`. Here the grow
     // is required to hold the intermediate two-limb subtraction; the final
     // result trims back to a single limb (`2^64 - 3 = 0xFFFF...FFFD`).
-    big_int       a        = big_int{3};                                                      // inline, 1 limb
-    const big_int b        = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1}; // 2^64
+    big_int       a = big_int{3};                                                      // inline, 1 limb
+    const big_int b = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1}; // 2^64
     EXPECT_EQ(a.capacity(), 0u);
     const big_int r        = std::move(a) - b; // 3 - 2^64 = -(2^64 - 3)
     const big_int expected = -(big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1} - big_int{3});
@@ -288,17 +288,17 @@ TEST(Subtraction, RvalueLhsSmallerMagnitudeTriggersGrow) {
 
 TEST(Subtraction, RvaluePrimitiveMix) {
     // rvalue big_int minus primitive: should reuse lhs.
-    big_int a          = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
-    const auto* a_data = a.representation().data();
-    const big_int r    = std::move(a) - 1U;
+    big_int       a      = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const auto*   a_data = a.representation().data();
+    const big_int r      = std::move(a) - 1U;
     EXPECT_EQ(r.representation().data(), a_data);
     ASSERT_EQ(r.representation().size(), 1u);
     EXPECT_EQ(r.representation()[0], std::numeric_limits<std::uint64_t>::max());
 
     // primitive minus rvalue big_int: should reuse rhs (via negate + add).
-    big_int b          = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
-    const auto* b_data = b.representation().data();
-    const big_int r2   = 1 - std::move(b); // 1 - 2^64 = -(2^64 - 1)
+    big_int       b      = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const auto*   b_data = b.representation().data();
+    const big_int r2     = 1 - std::move(b); // 1 - 2^64 = -(2^64 - 1)
     EXPECT_EQ(r2.representation().data(), b_data);
     ASSERT_EQ(r2.representation().size(), 1u);
     EXPECT_EQ(r2.representation()[0], std::numeric_limits<std::uint64_t>::max());

--- a/tests/beman/big_int/subtraction.test.cpp
+++ b/tests/beman/big_int/subtraction.test.cpp
@@ -201,4 +201,119 @@ TEST(Subtraction, AgreesWithAdditionOfNegated) {
     }
 }
 
+// ----- rvalue storage-reuse tests -----
+// When either operand is an rvalue `basic_big_int`, `operator-` should reuse its
+// storage rather than allocating a new result. For rhs reuse we cheaply negate the
+// destination and add; for lhs reuse we add with the negated rhs sign.
+
+TEST(Subtraction, RvalueLhsReusesStorage) {
+    big_int a          = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1}; // 2^64
+    const auto* a_data = a.representation().data();
+    ASSERT_GT(a.capacity(), 0u);
+    const big_int r = std::move(a) - big_int{1}; // 2^64 - 1 trims to one limb
+    EXPECT_EQ(r.representation().data(), a_data);
+    ASSERT_EQ(r.representation().size(), 1u);
+    EXPECT_EQ(r.representation()[0], std::numeric_limits<std::uint64_t>::max());
+}
+
+TEST(Subtraction, RvalueRhsReusesStorage) {
+    const big_int small{1};
+    big_int       b    = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1}; // 2^64
+    const auto* b_data = b.representation().data();
+    ASSERT_GT(b.capacity(), 0u);
+    const big_int r = small - std::move(b); // 1 - 2^64 = -(2^64 - 1)
+    EXPECT_EQ(r.representation().data(), b_data);
+    ASSERT_EQ(r.representation().size(), 1u);
+    EXPECT_EQ(r.representation()[0], std::numeric_limits<std::uint64_t>::max());
+    EXPECT_TRUE(r < 0);
+}
+
+TEST(Subtraction, BothRvaluesReusesLhsStorage) {
+    big_int a          = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    big_int b          = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const auto* a_data = a.representation().data();
+    const big_int r    = std::move(a) - std::move(b);
+    EXPECT_EQ(r.representation().data(), a_data);
+    EXPECT_EQ(r, 0);
+    EXPECT_FALSE(r < 0); // no negative zero
+}
+
+TEST(Subtraction, RvalueLhsCancelToZeroIsPositive) {
+    // `std::move(a) - copy-of-a` exercises the differing-sign branch within
+    // `add_in_place` where `|this| == |other|`; must normalize to +0 even though
+    // the destination's sign might momentarily imply "-0" under a naive impl.
+    big_int       a = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const big_int b = a;
+    const big_int r = std::move(a) - b;
+    EXPECT_EQ(r, 0);
+    EXPECT_FALSE(r < 0);
+    ASSERT_EQ(r.representation().size(), 1u);
+    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
+}
+
+TEST(Subtraction, RvalueRhsNegativeToNegateBranch) {
+    // `lvalue_small - std::move(big)` with `|small| < |big|`: rhs-reuse path
+    // negates `big` first (cheap XOR), then in-place adds `small`. The add then
+    // hits the differing-sign / `|this| > |other|` branch on the negated
+    // destination. Uses an lvalue lhs so the rvalue-lhs dispatch branch doesn't
+    // short-circuit in first.
+    const big_int three{3};
+    big_int       b    = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1}; // 2^64
+    const auto* b_data = b.representation().data();
+    const big_int r    = three - std::move(b); // 3 - 2^64 = -(2^64 - 3)
+    EXPECT_EQ(r.representation().data(), b_data);
+    const big_int expected = -(big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1} - big_int{3});
+    EXPECT_EQ(r, expected);
+    EXPECT_TRUE(r < 0);
+}
+
+TEST(Subtraction, RvalueLhsSmallerMagnitudeTriggersGrow) {
+    // `std::move(small) - big` with `|lhs| < |rhs|` exercises `add_in_place`'s
+    // `|other| > |this|` branch, which must grow the (inline) destination to
+    // fit the larger magnitude before computing `other - this`. Here the grow
+    // is required to hold the intermediate two-limb subtraction; the final
+    // result trims back to a single limb (`2^64 - 3 = 0xFFFF...FFFD`).
+    big_int       a        = big_int{3};                                                      // inline, 1 limb
+    const big_int b        = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1}; // 2^64
+    EXPECT_EQ(a.capacity(), 0u);
+    const big_int r        = std::move(a) - b; // 3 - 2^64 = -(2^64 - 3)
+    const big_int expected = -(big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1} - big_int{3});
+    EXPECT_EQ(r, expected);
+    EXPECT_TRUE(r < 0);
+    ASSERT_EQ(r.representation().size(), 1u);
+    EXPECT_EQ(r.representation()[0], std::numeric_limits<std::uint64_t>::max() - 2U);
+    // The grow left the destination on the heap, even after the trim.
+    EXPECT_GT(r.capacity(), 0u);
+}
+
+TEST(Subtraction, RvaluePrimitiveMix) {
+    // rvalue big_int minus primitive: should reuse lhs.
+    big_int a          = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const auto* a_data = a.representation().data();
+    const big_int r    = std::move(a) - 1U;
+    EXPECT_EQ(r.representation().data(), a_data);
+    ASSERT_EQ(r.representation().size(), 1u);
+    EXPECT_EQ(r.representation()[0], std::numeric_limits<std::uint64_t>::max());
+
+    // primitive minus rvalue big_int: should reuse rhs (via negate + add).
+    big_int b          = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const auto* b_data = b.representation().data();
+    const big_int r2   = 1 - std::move(b); // 1 - 2^64 = -(2^64 - 1)
+    EXPECT_EQ(r2.representation().data(), b_data);
+    ASSERT_EQ(r2.representation().size(), 1u);
+    EXPECT_EQ(r2.representation()[0], std::numeric_limits<std::uint64_t>::max());
+    EXPECT_TRUE(r2 < 0);
+}
+
+TEST(Subtraction, LvalueFallbackUnchanged) {
+    // Pure lvalue/lvalue dispatch must still work via `make_sum_of_limbs`.
+    const big_int a = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+    const big_int b = big_int{std::numeric_limits<std::uint64_t>::max()};
+    const big_int r = a - b; // 2^64 - (2^64 - 1) = 1
+    EXPECT_EQ(r, 1);
+    // Operands untouched.
+    EXPECT_EQ(a.representation().size(), 2u);
+    EXPECT_EQ(b.representation().size(), 1u);
+}
+
 } // namespace

--- a/tests/beman/big_int/subtraction.test.cpp
+++ b/tests/beman/big_int/subtraction.test.cpp
@@ -306,7 +306,7 @@ TEST(Subtraction, RvaluePrimitiveMix) {
 }
 
 TEST(Subtraction, LvalueFallbackUnchanged) {
-    // Pure lvalue/lvalue dispatch must still work via `make_sum_of_limbs`.
+    // Pure lvalue/lvalue dispatch: correctness only.
     const big_int a = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
     const big_int b = big_int{std::numeric_limits<std::uint64_t>::max()};
     const big_int r = a - b; // 2^64 - (2^64 - 1) = 1
@@ -314,6 +314,22 @@ TEST(Subtraction, LvalueFallbackUnchanged) {
     // Operands untouched.
     EXPECT_EQ(a.representation().size(), 2u);
     EXPECT_EQ(b.representation().size(), 1u);
+}
+
+TEST(Subtraction, LvalueCopiesLargerOperand) {
+    // When both operands are lvalues, copy whichever has more limbs. For
+    // subtraction this means the rhs-copy path (with negate) runs when
+    // `|rhs| > |lhs|`, exercising `negate() + add_in_place`.
+    const big_int small{7};                                                              // 1 limb
+    const big_int big = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1}; // 2 limbs
+
+    const big_int r1 = small - big; // rhs larger -> copy-and-negate-rhs path
+    EXPECT_EQ(r1, -(big - small));
+    EXPECT_GE(r1.capacity(), 2u);
+
+    const big_int r2 = big - small; // lhs larger -> copy-lhs path
+    EXPECT_EQ(r2, big - small);
+    EXPECT_GE(r2.capacity(), 2u);
 }
 
 } // namespace


### PR DESCRIPTION
This PR addresses the allocation issues in add, sub, and `operator=`. We now have a combined `copy_value` function that attempts to reuse storage if it's big enough, or allocates the correct amount as well as any amount of extra limbs. In the add case we request an extra limb each time, except for when we are already using both, or the maximum amount in the general case, of limbs of our in-place storage. In that case we defer that decision to the end of ripple carry at which point we either fit or we have no choice and have to allocate and move ourselves onto the heap.

Closes: #26 
Closes: #48 