### PR TITLE
Get rid of the last remaining C++23 artifact

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -56,7 +56,7 @@ jobs:
             },
             { "versions": ["14"],
               "tests": [
-                { "cxxversions": ["c++26", "c++23"],
+                { "cxxversions": ["c++26", "c++23", "c++20"],
                   "tests": [{ "stdlibs": ["libstdc++"], "tests": ["Release.Default"]}]
                 }
               ]
@@ -84,7 +84,7 @@ jobs:
             },
             { "versions": ["21", "20", "19"],
               "tests": [
-                { "cxxversions": ["c++26", "c++23"],
+                { "cxxversions": ["c++26", "c++23", "c++20"],
                   "tests": [
                     {"stdlibs": ["libstdc++", "libc++"], "tests": ["Release.Default"]}
                   ]
@@ -95,7 +95,7 @@ jobs:
           "appleclang": [
             { "versions": ["latest"],
               "tests": [
-                { "cxxversions": ["c++26", "c++23"],
+                { "cxxversions": ["c++26", "c++23", "c++20"],
                   "tests": [{ "stdlibs": ["libc++"], "tests": ["Release.Default"]}]
                 }
               ]
@@ -104,7 +104,7 @@ jobs:
           "msvc": [
             { "versions": ["latest"],
               "tests": [
-                { "cxxversions": ["c++23"],
+                { "cxxversions": ["c++23", "c++20"],
                   "tests": [
                     { "stdlibs": ["stl"],
                       "tests": ["Debug.Default", "Release.Default", "Release.MaxSan"]

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -1706,7 +1706,7 @@ basic_big_int<b, A>::copy_n_to_allocation(const limb_type* const p, const size_t
 // because we don't keep track of "requested" vs "received" capacity
 // (these may not be the same with allocate_at_least).
 #if !defined(__cpp_lib_raw_memory_algorithms) || __cpp_lib_raw_memory_algorithms < 202411L
-    if !consteval {
+    if BEMAN_BIG_INT_IS_NOT_CONSTEVAL {
 #endif
         std::uninitialized_copy_n(p, n, out.ptr);
         std::uninitialized_value_construct_n(out.ptr + n, out.count - n);


### PR DESCRIPTION
This PR removes the final remaining C++23 artifact and walks the lib back to C++20. The cleverly-defined standard-specific macro (`BEMAN_WHATEVER`) is now used instead of `if !consteval (whatever)`.