### PR TITLE
Implement operators << and >>

### DIFF
--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -350,6 +350,7 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     // Our max shift is then the number of bits represented in these blocks plus the theoretical 63 or 31
     // that are in the same limb.
     // E.g., 000...01 can be shifted 63 bits to the left before it moves to the next limb
+    // TODO : We discussed reducing the size of the encoding for 32-bit platforms so that this result fits in unsigned long (becomes the same type as the limbs)
     using shift_type                      = unsigned long long;
     static constexpr shift_type shift_max = ((1ULL << 31) - 1) * (sizeof(uint_multiprecision_t) * CHAR_BIT);
 

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -329,6 +329,9 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     template <class T, detail::signed_or_unsigned S>
         requires detail::is_basic_big_int_v<std::remove_cvref_t<T>>
     friend constexpr std::remove_cvref_t<T> operator<<(T&& x, S s);
+    template <class T, detail::signed_or_unsigned S>
+        requires detail::is_basic_big_int_v<std::remove_cvref_t<T>>
+    friend constexpr std::remove_cvref_t<T> operator>>(T&& x, S s);
 
   private:
     template <detail::unsigned_integer T>
@@ -1344,6 +1347,38 @@ constexpr std::remove_cvref_t<T> operator<<(T&& x, const S s) {
         Result r;
         r.assign_value(x, headroom);
         r.shift_left(shift);
+        return r;
+    }
+}
+
+template <class T, detail::signed_or_unsigned S>
+    requires detail::is_basic_big_int_v<std::remove_cvref_t<T>>
+constexpr std::remove_cvref_t<T> operator>>(T&& x, const S s) {
+    using Result     = std::remove_cvref_t<T>;
+    using shift_type = typename Result::shift_type;
+
+    if constexpr (std::is_signed_v<S>) {
+        BEMAN_BIG_INT_DEBUG_ASSERT(s >= 0);
+        BEMAN_BIG_INT_DEBUG_ASSERT(static_cast<std::make_unsigned_t<S>>(s) <= Result::shift_max);
+    } else {
+        BEMAN_BIG_INT_DEBUG_ASSERT(s <= Result::shift_max);
+    }
+    const auto shift = static_cast<shift_type>(s);
+
+    if constexpr (!std::is_reference_v<T>) {
+        // rvalue: shift in place, no copy needed.
+        Result r = std::forward<T>(x);
+        r.shift_right(shift);
+        return r;
+    } else {
+        // lvalue: copy then shift. No extra headroom needed since right-shift
+        // only shrinks. 
+        // The result keeps the source's heap buffer (if any) even if the shifted value fits inline.
+        // I don't see a reason to deallocate memory even if we now fit in static storage,
+        // we may need it later
+        Result r;
+        r.assign_value(x);
+        r.shift_right(shift);
         return r;
     }
 }

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -343,8 +343,12 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     constexpr void                       copy_n_to_allocation(const limb_type* p, size_type n, alloc_result out);
     constexpr void                       push_back_limb(limb_type limb);
 
+    // We are limited in our shifting to what we can encode into our control block, which is 30 bits of limbs
+    // Our max shift is then the number of bits represented in these blocks plus the theoretical 63 or 31
+    // that are in the same limb.
+    // E.g., 000...01 can be shifted 63 bits to the left before it moves to the next limb
     using shift_type                      = unsigned long long;
-    static constexpr shift_type shift_max = std::numeric_limits<shift_type>::max();
+    static constexpr shift_type shift_max = ((1ULL << 31) - 1) * (sizeof(uint_multiprecision_t) * CHAR_BIT);
 
     // Increases the magnitude by one, without affecting the sign bit.
     // Returns `true` on carry in the uppermost limb.

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -758,14 +758,22 @@ constexpr void basic_big_int<b, A>::shift_left(const shift_type s) {
         set_limb_count(static_cast<std::uint32_t>(current_count + shifted_limbs));
     }
     if (shifted_bits != 0) {
-        const auto current_count = limb_count();
-        limbs[current_count]     = 0;
-        for (shift_type i = current_count; i-- > shifted_limbs;) {
-            const detail::wide<limb_type> all_bits{.low_bits = limbs[i], .high_bits = limbs[i + 1]};
-            limbs[i + 1] = detail::funnel_shl(all_bits, static_cast<unsigned int>(shifted_bits));
+        const auto      current_count = limb_count();
+        const limb_type overflow      = limbs[current_count - 1] >> (bits_per_limb - shifted_bits);
+
+        // Shift all limbs in place, top to bottom.
+        // Each iteration reads limbs[i-1] (original) and limbs[i] (original), writes limbs[i].
+        // This avoids an out-of-bounds write
+        for (shift_type i = current_count - 1; i > shifted_limbs; --i) {
+            const detail::wide<limb_type> all_bits{.low_bits = limbs[i - 1], .high_bits = limbs[i]};
+            limbs[i] = detail::funnel_shl(all_bits, static_cast<unsigned int>(shifted_bits));
         }
         limbs[shifted_limbs] <<= shifted_bits;
-        set_limb_count(static_cast<std::uint32_t>(current_count + std::uint32_t(limbs[current_count] != 0)));
+
+        if (overflow != 0) {
+            limbs[current_count] = overflow;
+            set_limb_count(static_cast<std::uint32_t>(current_count + 1));
+        }
     }
 }
 

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -1321,8 +1321,9 @@ constexpr detail::common_big_int_type<L, R> operator-(L&& x, R&& y) {
 template <class T, detail::signed_or_unsigned S>
     requires detail::is_basic_big_int_v<std::remove_cvref_t<T>>
 constexpr std::remove_cvref_t<T> operator<<(T&& x, const S s) {
-    using Result     = std::remove_cvref_t<T>;
-    using shift_type = Result::shift_type;
+    using Result        = std::remove_cvref_t<T>;
+    using shift_type    = Result::shift_type;
+    constexpr auto form = detail::classify_form_v<T, S>;
 
     if constexpr (std::is_signed_v<S>) {
         BEMAN_BIG_INT_DEBUG_ASSERT(s >= 0);
@@ -1332,18 +1333,18 @@ constexpr std::remove_cvref_t<T> operator<<(T&& x, const S s) {
     }
     const auto shift = static_cast<shift_type>(s);
 
-    if constexpr (detail::is_basic_big_int_v<std::remove_cvref_t<T>> && !std::is_reference_v<T>) {
+    if constexpr (form == detail::binary_op_form::move_int) {
         // rvalue: shift in place, no copy needed.
-        Result r = std::forward<T>(x);
+        Result r = std::move(x);
         r.shift_left(shift);
         return r;
-    } else {
+    } else if constexpr (form == detail::binary_op_form::copy_int) {
         // lvalue: use assign_value with headroom so shift_left doesn't reallocate.
-        const shift_type shifted_limbs = shift / Result::bits_per_limb;
-        const shift_type shifted_bits  = shift % Result::bits_per_limb;
-        const bool       needs_extra   = shifted_bits != 0 &&
+        const shift_type  shifted_limbs = shift / Result::bits_per_limb;
+        const shift_type  shifted_bits  = shift % Result::bits_per_limb;
+        const bool        needs_extra   = shifted_bits != 0 &&
             static_cast<shift_type>(std::countl_zero(x.limb_ptr()[x.limb_count() - 1])) < shifted_bits;
-        const std::size_t headroom     = shifted_limbs + static_cast<std::size_t>(needs_extra);
+        const std::size_t headroom      = shifted_limbs + static_cast<std::size_t>(needs_extra);
 
         Result r;
         r.assign_value(x, headroom);
@@ -1355,8 +1356,9 @@ constexpr std::remove_cvref_t<T> operator<<(T&& x, const S s) {
 template <class T, detail::signed_or_unsigned S>
     requires detail::is_basic_big_int_v<std::remove_cvref_t<T>>
 constexpr std::remove_cvref_t<T> operator>>(T&& x, const S s) {
-    using Result     = std::remove_cvref_t<T>;
-    using shift_type = typename Result::shift_type;
+    using Result        = std::remove_cvref_t<T>;
+    using shift_type    = Result::shift_type;
+    constexpr auto form = detail::classify_form_v<T, S>;
 
     if constexpr (std::is_signed_v<S>) {
         BEMAN_BIG_INT_DEBUG_ASSERT(s >= 0);
@@ -1366,17 +1368,15 @@ constexpr std::remove_cvref_t<T> operator>>(T&& x, const S s) {
     }
     const auto shift = static_cast<shift_type>(s);
 
-    if constexpr (!std::is_reference_v<T>) {
+    if constexpr (form == detail::binary_op_form::move_int) {
         // rvalue: shift in place, no copy needed.
-        Result r = std::forward<T>(x);
+        Result r = std::move(x);
         r.shift_right(shift);
         return r;
-    } else {
+    } else if constexpr (form == detail::binary_op_form::copy_int) {
         // lvalue: copy then shift. No extra headroom needed since right-shift
-        // only shrinks. 
-        // The result keeps the source's heap buffer (if any) even if the shifted value fits inline.
-        // I don't see a reason to deallocate memory even if we now fit in static storage,
-        // we may need it later
+        // only shrinks. The result keeps the source's heap buffer (if any)
+        // even if the shifted value would fit inline.
         Result r;
         r.assign_value(x);
         r.shift_right(shift);

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -743,10 +743,12 @@ constexpr void basic_big_int<b, A>::shift_left(const shift_type s) {
     const shift_type shifted_limbs = s / bits_per_limb;
     const shift_type shifted_bits  = s % bits_per_limb;
 
-    // TODO(eisenwave): This is pessimistic and assumes that bit-shifting will require an extra limb,
-    //                  but that may not be the case.
-    //                  It depends on the bits of the uppermost limb.
-    reserve(limb_count() + shifted_limbs + size_type(shifted_bits != 0));
+    // Only reserve an extra limb for the bit-shift when the top limb doesn't enough leading zeros.
+    // `countl_zero` tells us exactly how many bits of headroom the current top limb provides.
+    const bool needs_extra_limb =
+        shifted_bits != 0 &&
+        static_cast<shift_type>(std::countl_zero(limb_ptr()[limb_count() - 1])) < shifted_bits;
+    reserve(limb_count() + shifted_limbs + static_cast<size_type>(needs_extra_limb));
     limb_type* const limbs = limb_ptr();
 
     if (shifted_limbs != 0) {

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -346,13 +346,11 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     constexpr void                       copy_n_to_allocation(const limb_type* p, size_type n, alloc_result out);
     constexpr void                       push_back_limb(limb_type limb);
 
-    // We are limited in our shifting to what we can encode into our control block, which is 30 bits of limbs
-    // Our max shift is then the number of bits represented in these blocks plus the theoretical 63 or 31
+    // We are limited in our shifting to what we can encode into our control block, which is 30 (or 27) bits of limbs
+    // Our max shift is then the number of bits represented in these blocks plus the theoretical 63 (or 31)
     // that are in the same limb.
-    // E.g., 000...01 can be shifted 63 bits to the left before it moves to the next limb
-    // TODO : We discussed reducing the size of the encoding for 32-bit platforms so that this result fits in unsigned long (becomes the same type as the limbs)
-    using shift_type                      = unsigned long long;
-    static constexpr shift_type shift_max = ((1ULL << 31) - 1) * (sizeof(uint_multiprecision_t) * CHAR_BIT);
+    using shift_type                      = uint_multiprecision_t;
+    static constexpr shift_type shift_max = static_cast<shift_type>(max_size()) * bits_per_limb;
 
     // Increases the magnitude by one, without affecting the sign bit.
     // Returns `true` on carry in the uppermost limb.
@@ -885,8 +883,10 @@ constexpr std::size_t basic_big_int<b, A>::size() const noexcept {
 
 template <std::size_t b, class A>
 constexpr std::size_t basic_big_int<b, A>::max_size() noexcept {
-    // We use the high bit to encode the sign, so we are limited to 2^31
-    return std::numeric_limits<std::uint32_t>::max() >> 1U;
+    // We use the high bit to encode the sign, so we are limited to 2^31 on 64-bit architectures
+    // On 32-bit architectures we reduce to 2^27 so that the number of bits can be represented by size_type
+    constexpr std::uint32_t offset = sizeof(size_type) == sizeof(std::uint64_t) ? 1U : 4U;
+    return std::numeric_limits<std::uint32_t>::max() >> offset;
 }
 
 template <std::size_t b, class A>

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -322,6 +322,12 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     friend constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y);
     template <class L, class R>
     friend constexpr detail::common_big_int_type<L, R> operator-(L&& x, R&& y);
+    // TODO : mul, div, mod
+
+    // TODO : and, or, xor
+
+    template <class T, detail::signed_or_unsigned S>
+    friend constexpr std::remove_cvref_t<T> operator<<(T&& x, S s);
 
   private:
     template <detail::unsigned_integer T>
@@ -1299,6 +1305,40 @@ constexpr detail::common_big_int_type<L, R> operator-(L&& x, R&& y) {
         r.negate();
         const auto x_limbs = detail::to_limbs(detail::uabs(x));
         r.add_in_place(detail::to_fixed_span(x_limbs), detail::integer_signbit(x));
+        return r;
+    }
+}
+
+template <class T, detail::signed_or_unsigned S>
+    requires detail::is_basic_big_int_v<std::remove_cvref_t<T>>
+constexpr std::remove_cvref_t<T> operator<<(T&& x, const S s) {
+    using Result     = std::remove_cvref_t<T>;
+    using shift_type = typename Result::shift_type;
+
+    if constexpr (std::is_signed_v<S>) {
+        BEMAN_BIG_INT_DEBUG_ASSERT(s >= 0);
+        BEMAN_BIG_INT_DEBUG_ASSERT(static_cast<std::make_unsigned_t<S>>(s) <= Result::shift_max);
+    } else {
+        BEMAN_BIG_INT_DEBUG_ASSERT(s <= Result::shift_max);
+    }
+    const auto shift = static_cast<shift_type>(s);
+
+    if constexpr (detail::is_basic_big_int_v<std::remove_cvref_t<T>> && !std::is_reference_v<T>) {
+        // rvalue: shift in place, no copy needed.
+        Result r = std::forward<T>(x);
+        r.shift_left(shift);
+        return r;
+    } else {
+        // lvalue: use assign_value with headroom so shift_left doesn't reallocate.
+        const shift_type shifted_limbs = shift / Result::bits_per_limb;
+        const shift_type shifted_bits  = shift % Result::bits_per_limb;
+        const bool       needs_extra   = shifted_bits != 0 &&
+            static_cast<shift_type>(std::countl_zero(x.limb_ptr()[x.limb_count() - 1])) < shifted_bits;
+        const std::size_t headroom     = shifted_limbs + static_cast<std::size_t>(needs_extra);
+
+        Result r;
+        r.assign_value(x, headroom);
+        r.shift_left(shift);
         return r;
     }
 }

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -1318,7 +1318,7 @@ template <class T, detail::signed_or_unsigned S>
     requires detail::is_basic_big_int_v<std::remove_cvref_t<T>>
 constexpr std::remove_cvref_t<T> operator<<(T&& x, const S s) {
     using Result     = std::remove_cvref_t<T>;
-    using shift_type = typename Result::shift_type;
+    using shift_type = Result::shift_type;
 
     if constexpr (std::is_signed_v<S>) {
         BEMAN_BIG_INT_DEBUG_ASSERT(s >= 0);

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -759,8 +759,7 @@ constexpr void basic_big_int<b, A>::shift_left(const shift_type s) {
     // Only reserve an extra limb for the bit-shift when the top limb doesn't enough leading zeros.
     // `countl_zero` tells us exactly how many bits of headroom the current top limb provides.
     const bool needs_extra_limb =
-        shifted_bits != 0 &&
-        static_cast<shift_type>(std::countl_zero(limb_ptr()[limb_count() - 1])) < shifted_bits;
+        shifted_bits != 0 && static_cast<shift_type>(std::countl_zero(limb_ptr()[limb_count() - 1])) < shifted_bits;
     reserve(limb_count() + shifted_limbs + static_cast<size_type>(needs_extra_limb));
     limb_type* const limbs = limb_ptr();
 
@@ -1340,11 +1339,12 @@ constexpr std::remove_cvref_t<T> operator<<(T&& x, const S s) {
         return r;
     } else if constexpr (form == detail::binary_op_form::copy_int) {
         // lvalue: use assign_value with headroom so shift_left doesn't reallocate.
-        const shift_type  shifted_limbs = shift / Result::bits_per_limb;
-        const shift_type  shifted_bits  = shift % Result::bits_per_limb;
-        const bool        needs_extra   = shifted_bits != 0 &&
+        const shift_type shifted_limbs = shift / Result::bits_per_limb;
+        const shift_type shifted_bits  = shift % Result::bits_per_limb;
+        const bool       needs_extra =
+            shifted_bits != 0 &&
             static_cast<shift_type>(std::countl_zero(x.limb_ptr()[x.limb_count() - 1])) < shifted_bits;
-        const std::size_t headroom      = shifted_limbs + static_cast<std::size_t>(needs_extra);
+        const std::size_t headroom = shifted_limbs + static_cast<std::size_t>(needs_extra);
 
         Result r;
         r.assign_value(x, headroom);

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -327,6 +327,7 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     // TODO : and, or, xor
 
     template <class T, detail::signed_or_unsigned S>
+        requires detail::is_basic_big_int_v<std::remove_cvref_t<T>>
     friend constexpr std::remove_cvref_t<T> operator<<(T&& x, S s);
 
   private:

--- a/tests/beman/big_int/bit_shift.test.cpp
+++ b/tests/beman/big_int/bit_shift.test.cpp
@@ -9,6 +9,7 @@
 
 namespace {
 
+using beman::big_int::basic_big_int;
 using beman::big_int::big_int;
 using beman::big_int::uint_multiprecision_t;
 using beman::big_int::detail::int_multiprecision_t;
@@ -214,6 +215,199 @@ TEST(BitShift, LeftThenRightRoundTripForPositive) {
     x <<= 130;
     x >>= 130;
     EXPECT_EQ(x == 123'456'789, true);
+}
+
+// ----- operator<< (non-mutating left shift) -----
+
+TEST(BitShift, OperatorLeftShiftBasic) {
+    const big_int x{1};
+    const big_int r = x << 1;
+    EXPECT_EQ(r, 2);
+    EXPECT_EQ(x, 1); // original unchanged
+}
+
+TEST(BitShift, OperatorLeftShiftZeroShift) {
+    const big_int x{42};
+    const big_int r = x << 0;
+    EXPECT_EQ(r, 42);
+}
+
+TEST(BitShift, OperatorLeftShiftZeroValue) {
+    const big_int x{0};
+    const big_int r = x << 100;
+    EXPECT_EQ(r, 0);
+}
+
+TEST(BitShift, OperatorLeftShiftNegative) {
+    const big_int x{-1};
+    const big_int r = x << 1;
+    EXPECT_EQ(r, -2);
+
+    const big_int y{-3};
+    const big_int s = y << 2;
+    EXPECT_EQ(s, -12);
+}
+
+TEST(BitShift, OperatorLeftShiftMatchesCompound) {
+    // operator<< on an lvalue should produce the same result as <<=
+    const big_int x{123'456'789};
+    big_int       y{123'456'789};
+
+    const big_int r = x << 17;
+    y <<= 17;
+    EXPECT_EQ(r, y);
+
+    const big_int a{std::numeric_limits<uint_multiprecision_t>::max()};
+    big_int       b{std::numeric_limits<uint_multiprecision_t>::max()};
+
+    const big_int r2 = a << 65;
+    b <<= 65;
+    EXPECT_EQ(r2, b);
+}
+
+TEST(BitShift, OperatorLeftShiftRvalue) {
+    // rvalue path: should move the storage, no copy
+    big_int r = big_int{1} << 10;
+    EXPECT_EQ(r, 1024);
+
+    big_int s = big_int{std::numeric_limits<uint_multiprecision_t>::max()} << 1;
+    EXPECT_EQ(s.representation().size(), 2U);
+    EXPECT_EQ(s.representation()[0], std::numeric_limits<uint_multiprecision_t>::max() - 1ULL);
+    EXPECT_EQ(s.representation()[1], 1ULL);
+}
+
+TEST(BitShift, OperatorLeftShiftInplaceToHeap) {
+    // default big_int has inplace_capacity=1 (one 64-bit limb).
+    // Shifting 1 left by 63 bits: top limb = 0x8000...0, CLZ = 0.
+    // A further shift by 1 bit must overflow into a second limb (heap).
+    const big_int x{1ULL << 63};
+    EXPECT_EQ(x.capacity(), 0U); // inline
+
+    const big_int r = x << 1;
+    EXPECT_EQ(r.representation().size(), 2U);
+    EXPECT_EQ(r.representation()[0], 0ULL);
+    EXPECT_EQ(r.representation()[1], 1ULL);
+}
+
+TEST(BitShift, OperatorLeftShiftInplaceStaysInlineCLZ) {
+    // Value 1 has CLZ = 63 in a 64-bit limb. Shifting left by up to 63 bits
+    // should NOT overflow into a new limb, staying in inline storage.
+    const big_int x{1};
+    EXPECT_EQ(x.capacity(), 0U); // inline
+
+    const big_int r = x << 63;
+    EXPECT_EQ(r.capacity(), 0U); // still inline
+    EXPECT_EQ(r.representation().size(), 1U);
+    EXPECT_EQ(r.representation()[0], 1ULL << 63);
+}
+
+TEST(BitShift, OperatorLeftShiftWiderInplaceStaysInline) {
+    // basic_big_int<256> has 4 inline limbs (256 bits). A small value shifted
+    // within those 256 bits should never touch the heap.
+    using big_int_256 = basic_big_int<256>;
+    const big_int_256 x{1};
+    EXPECT_EQ(x.capacity(), 0U);
+
+    const big_int_256 r = x << 255;
+    EXPECT_EQ(r.capacity(), 0U); // still inline
+
+    // Top limb should be 1 << (255 % 64) = 1 << 63
+    EXPECT_EQ(r.representation().size(), 4U);
+    EXPECT_EQ(r.representation()[3], 1ULL << 63);
+    EXPECT_EQ(r.representation()[2], 0ULL);
+    EXPECT_EQ(r.representation()[1], 0ULL);
+    EXPECT_EQ(r.representation()[0], 0ULL);
+}
+
+TEST(BitShift, OperatorLeftShiftWiderInplaceToHeap) {
+    // basic_big_int<256>: 4 inline limbs. Shifting 1 by 256 bits requires
+    // 5 limbs, which must spill to the heap.
+    using big_int_256 = basic_big_int<256>;
+    const big_int_256 x{1};
+
+    const big_int_256 r = x << 256;
+    EXPECT_EQ(r.representation().size(), 5U);
+    EXPECT_NE(r.capacity(), 0U); // heap
+    EXPECT_EQ(r.representation()[4], 1ULL);
+    for (int i = 0; i < 4; ++i) {
+        EXPECT_EQ(r.representation()[static_cast<std::size_t>(i)], 0ULL);
+    }
+}
+
+TEST(BitShift, OperatorLeftShiftAcrossLimbs) {
+    const big_int x{1};
+
+    const big_int r64  = x << 64;
+    const big_int r65  = x << 65;
+    const big_int r128 = x << 128;
+
+    EXPECT_EQ(r64.representation().size(), 2U);
+    EXPECT_EQ(r64.representation()[0], 0ULL);
+    EXPECT_EQ(r64.representation()[1], 1ULL);
+
+    EXPECT_EQ(r65.representation().size(), 2U);
+    EXPECT_EQ(r65.representation()[0], 0ULL);
+    EXPECT_EQ(r65.representation()[1], 2ULL);
+
+    EXPECT_EQ(r128.representation().size(), 3U);
+    EXPECT_EQ(r128.representation()[0], 0ULL);
+    EXPECT_EQ(r128.representation()[1], 0ULL);
+    EXPECT_EQ(r128.representation()[2], 1ULL);
+}
+
+TEST(BitShift, OperatorLeftShiftHuge) {
+    // Shift a small value by a large amount (10000 bits).
+    const big_int x{1};
+    const big_int r = x << 10000;
+
+    // 10000 / 64 = 156 whole limbs, 10000 % 64 = 16-bit shift
+    EXPECT_EQ(r.representation().size(), 157U);
+    EXPECT_EQ(r.representation()[156], 1ULL << 16);
+    EXPECT_EQ(r.representation()[155], 0ULL);
+    EXPECT_EQ(r.representation()[0], 0ULL);
+
+    // Verify via round-trip with >>=
+    big_int rt = r;
+    rt >>= 10000;
+    EXPECT_EQ(rt, 1);
+}
+
+TEST(BitShift, OperatorLeftShiftHeapSource) {
+    // Source already on the heap; operator<< should pre-allocate headroom
+    // so shift_left doesn't reallocate.
+    big_int x{std::numeric_limits<uint_multiprecision_t>::max()};
+    x <<= 1; // now 2 limbs, on heap
+    EXPECT_NE(x.capacity(), 0U);
+
+    const big_int r = x << 64;
+    EXPECT_EQ(r.representation().size(), 3U);
+    EXPECT_EQ(r.representation()[0], 0ULL);
+    EXPECT_EQ(r.representation()[1], std::numeric_limits<uint_multiprecision_t>::max() - 1ULL);
+    EXPECT_EQ(r.representation()[2], 1ULL);
+}
+
+TEST(BitShift, OperatorLeftShiftSignedShiftAmount) {
+    const big_int x{1};
+    const big_int r = x << static_cast<int>(10);
+    EXPECT_EQ(r, 1024);
+}
+
+TEST(BitShift, OperatorLeftShiftPreservesOriginal) {
+    // Verify operator<< doesn't modify the source even when the source
+    // is large and heap-allocated.
+    const big_int x = big_int{1} << 200;
+    const auto    x_rep = x.representation();
+
+    const big_int r = x << 50;
+    EXPECT_EQ(x.representation().size(), x_rep.size());
+    for (std::size_t i = 0; i < x_rep.size(); ++i) {
+        EXPECT_EQ(x.representation()[i], x_rep[i]);
+    }
+
+    // And the result should match doing it in two steps
+    big_int expected{1};
+    expected <<= 250;
+    EXPECT_EQ(r, expected);
 }
 
 } // namespace

--- a/tests/beman/big_int/bit_shift.test.cpp
+++ b/tests/beman/big_int/bit_shift.test.cpp
@@ -388,7 +388,7 @@ TEST(BitShift, OperatorLeftShiftHeapSource) {
 
 TEST(BitShift, OperatorLeftShiftSignedShiftAmount) {
     const big_int x{1};
-    const big_int r = x << static_cast<int>(10);
+    const big_int r = x << 10;
     EXPECT_EQ(r, 1024);
 }
 
@@ -526,7 +526,7 @@ TEST(BitShift, OperatorRightShiftPreservesOriginal) {
 
 TEST(BitShift, OperatorRightShiftSignedShiftAmount) {
     const big_int x{1024};
-    const big_int r = x >> static_cast<int>(5);
+    const big_int r = x >> 5;
     EXPECT_EQ(r, 32);
 }
 

--- a/tests/beman/big_int/bit_shift.test.cpp
+++ b/tests/beman/big_int/bit_shift.test.cpp
@@ -395,7 +395,7 @@ TEST(BitShift, OperatorLeftShiftSignedShiftAmount) {
 TEST(BitShift, OperatorLeftShiftPreservesOriginal) {
     // Verify operator<< doesn't modify the source even when the source
     // is large and heap-allocated.
-    const big_int x = big_int{1} << 200;
+    const big_int x     = big_int{1} << 200;
     const auto    x_rep = x.representation();
 
     const big_int r = x << 50;
@@ -509,7 +509,7 @@ TEST(BitShift, OperatorRightShiftKeepsHeapStorage) {
 }
 
 TEST(BitShift, OperatorRightShiftPreservesOriginal) {
-    const big_int x = big_int{1} << 200;
+    const big_int x     = big_int{1} << 200;
     const auto    x_rep = x.representation();
 
     const big_int r = x >> 50;

--- a/tests/beman/big_int/bit_shift.test.cpp
+++ b/tests/beman/big_int/bit_shift.test.cpp
@@ -410,4 +410,133 @@ TEST(BitShift, OperatorLeftShiftPreservesOriginal) {
     EXPECT_EQ(r, expected);
 }
 
+// ----- operator>> (non-mutating right shift) -----
+
+TEST(BitShift, OperatorRightShiftBasic) {
+    const big_int x{4};
+    const big_int r = x >> 1;
+    EXPECT_EQ(r, 2);
+    EXPECT_EQ(x, 4); // original unchanged
+}
+
+TEST(BitShift, OperatorRightShiftZeroShift) {
+    const big_int x{42};
+    const big_int r = x >> 0;
+    EXPECT_EQ(r, 42);
+}
+
+TEST(BitShift, OperatorRightShiftZeroValue) {
+    const big_int x{0};
+    const big_int r = x >> 100;
+    EXPECT_EQ(r, 0);
+}
+
+TEST(BitShift, OperatorRightShiftToZero) {
+    const big_int x{1};
+    const big_int r = x >> 1;
+    EXPECT_EQ(r, 0);
+
+    const big_int s = x >> 64;
+    EXPECT_EQ(s, 0);
+
+    const big_int t = x >> 1000;
+    EXPECT_EQ(t, 0);
+}
+
+TEST(BitShift, OperatorRightShiftNegativeRounding) {
+    // Right shift of negative values rounds toward negative infinity.
+    const big_int x{-3};
+    const big_int r = x >> 1;
+    EXPECT_EQ(r, -2);
+
+    const big_int y{-4};
+    const big_int s = y >> 1;
+    EXPECT_EQ(s, -2);
+
+    const big_int w{-1};
+    const big_int t = w >> 64;
+    EXPECT_EQ(t, -1);
+}
+
+TEST(BitShift, OperatorRightShiftMatchesCompound) {
+    const big_int x = big_int{1} << 200;
+    big_int       y = big_int{1} << 200;
+
+    const big_int r = x >> 130;
+    y >>= 130;
+    EXPECT_EQ(r, y);
+
+    big_int expected{1};
+    expected <<= 70;
+    EXPECT_EQ(r, expected);
+}
+
+TEST(BitShift, OperatorRightShiftRvalue) {
+    big_int r = big_int{1024} >> 5;
+    EXPECT_EQ(r, 32);
+
+    // Rvalue from a heap source
+    big_int r2 = (big_int{1} << 128) >> 64;
+    big_int expected{1};
+    expected <<= 64;
+    EXPECT_EQ(r2, expected);
+}
+
+TEST(BitShift, OperatorRightShiftAcrossLimbs) {
+    const big_int x = big_int{1} << 128; // 3 limbs
+    EXPECT_EQ(x.representation().size(), 3U);
+
+    const big_int r = x >> 64;
+    EXPECT_EQ(r.representation().size(), 2U);
+    EXPECT_EQ(r.representation()[0], 0ULL);
+    EXPECT_EQ(r.representation()[1], 1ULL);
+
+    const big_int s = x >> 128;
+    EXPECT_EQ(s, 1);
+}
+
+TEST(BitShift, OperatorRightShiftKeepsHeapStorage) {
+    // When the source is on the heap and the result could fit inline,
+    // operator>> should keep the heap buffer (no shrink_to_fit).
+    big_int x{1};
+    x <<= 128; // 3 limbs, on heap
+    EXPECT_NE(x.capacity(), 0U);
+
+    const big_int r = x >> 200; // result is 0, but copied from heap source
+    EXPECT_EQ(r, 0);
+    // The copy via assign_value inherits the heap buffer
+    EXPECT_NE(r.capacity(), 0U);
+}
+
+TEST(BitShift, OperatorRightShiftPreservesOriginal) {
+    const big_int x = big_int{1} << 200;
+    const auto    x_rep = x.representation();
+
+    const big_int r = x >> 50;
+    // Original unchanged
+    EXPECT_EQ(x.representation().size(), x_rep.size());
+    for (std::size_t i = 0; i < x_rep.size(); ++i) {
+        EXPECT_EQ(x.representation()[i], x_rep[i]);
+    }
+
+    big_int expected{1};
+    expected <<= 150;
+    EXPECT_EQ(r, expected);
+}
+
+TEST(BitShift, OperatorRightShiftSignedShiftAmount) {
+    const big_int x{1024};
+    const big_int r = x >> static_cast<int>(5);
+    EXPECT_EQ(r, 32);
+}
+
+TEST(BitShift, OperatorLeftRightRoundTrip) {
+    // Non-mutating round trip: (x << n) >> n == x for positive values
+    const big_int x{123'456'789};
+
+    EXPECT_EQ((x << 17) >> 17, x);
+    EXPECT_EQ((x << 64) >> 64, x);
+    EXPECT_EQ((x << 130) >> 130, x);
+}
+
 } // namespace


### PR DESCRIPTION
- Implements `operator>>` and `operator<<` by using the existing `shift_left` and `shift_right` functions
- Changes `shift_left` to use CLZ to figure out exactly where the high bit is rather than always allocating an extra limb
- Changes the definition of `max_size()` and `shift_max()` based on conversation on WhatsApp. These now fit inside a `size_t` instead of always being 64-bits.

Closes: #55 