### PR TITLE
Optimize Right Shifting

### DIFF
--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -1479,36 +1479,58 @@ constexpr std::remove_cvref_t<T> operator>>(T&& x, const S s) {
         // For negative values we need to account for the rounding at the end
         //
         // If neither of these situations applies, make a full copy and shift.
+
+        using limb_type = uint_multiprecision_t;
+
         const shift_type shifted_limbs = shift / Result::bits_per_limb;
         const shift_type shifted_bits  = shift % Result::bits_per_limb;
+        const shift_type x_width_mag   = static_cast<shift_type>(x.width_mag());
 
         // Case 1: Everything is discarded except the sign
-        if (shift > static_cast<shift_type>(x.width_mag())) {
+        if (shift > x_width_mag) {
             if (x.is_negative()) {
                 return Result{-1};
             }
             return Result{};
         }
 
-        // Case 2: Some of the limbs are discarded
-        if (shifted_limbs != 0) {
-            using limb_type                 = uint_multiprecision_t;
-            const limb_type* const src_limbs = x.limb_ptr();
-            const std::size_t      src_count = x.limb_count();
-            const std::size_t      new_count = src_count - static_cast<std::size_t>(shifted_limbs);
+        const limb_type* const src_limbs = x.limb_ptr();
+        const shift_type       src_count = static_cast<shift_type>(x.limb_count());
+
+        // Number of limbs the shifted result actually occupies. Smaller than
+        // `src_count` exactly when at least one source limb (or the top
+        // limb's surviving bits) shrinks away.
+        const shift_type new_count = (x_width_mag - shift) / Result::bits_per_limb + 1;
+
+        // Case 2: Result is strictly smaller than the source
+        if (new_count < src_count) {
+            const shift_type src_offset = shifted_limbs;
 
             Result r;
             r.reserve(new_count);
-            std::copy_n(src_limbs + static_cast<std::size_t>(shifted_limbs), new_count, r.limb_ptr());
+            limb_type* const dst = r.limb_ptr();
+
+            if (shifted_bits == 0) {
+                std::copy_n(src_limbs + src_offset, new_count, dst);
+            } else {
+                // Funnel-shift directly from source limbs into `dst`.
+                // Handles the case where we can theoretically go from heap -> inline storage with our result
+                for (shift_type i = 0; i < new_count; ++i) {
+                    const shift_type src_idx = src_offset + i;
+                    const limb_type  low     = src_limbs[src_idx];
+                    const limb_type  high =
+                        (src_idx + 1 < src_count) ? src_limbs[src_idx + 1] : limb_type{0};
+                    const detail::wide<limb_type> all_bits{.low_bits = low, .high_bits = high};
+                    dst[i] = detail::funnel_shr(all_bits, static_cast<unsigned int>(shifted_bits));
+                }
+            }
             r.set_limb_count(static_cast<std::uint32_t>(new_count));
 
-            if (shifted_bits != 0) {
-                r.shift_right(shifted_bits);
-            }
-
             if (x.is_negative()) {
+                // Mirror `shift_right`'s rounding-toward-negative-infinity
+                // We have to account even for the bits that will never be copied
                 bool discarded_nonzero = false;
-                for (shift_type i = 0; i < shifted_limbs; ++i) {
+                for (shift_type i = 0; i < src_offset; ++i) {
                     if (src_limbs[i] != 0) {
                         discarded_nonzero = true;
                         break;
@@ -1517,7 +1539,7 @@ constexpr std::remove_cvref_t<T> operator>>(T&& x, const S s) {
 
                 if (!discarded_nonzero && shifted_bits != 0) {
                     const auto mask = static_cast<limb_type>((limb_type{1} << shifted_bits) - 1);
-                    if ((src_limbs[static_cast<std::size_t>(shifted_limbs)] & mask) != 0) {
+                    if ((src_limbs[src_offset] & mask) != 0) {
                         discarded_nonzero = true;
                     }
                 }

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -1471,6 +1471,16 @@ constexpr std::remove_cvref_t<T> operator>>(T&& x, const S s) {
         // lvalue: copy then shift. No extra headroom needed since right-shift
         // only shrinks. The result keeps the source's heap buffer (if any)
         // even if the shifted value would fit inline.
+        //
+        // Before making a copy and then shifting,
+        // we check to see if such an operation is even required.
+        // For example, if we are shifting further than the width of the value, this will be a NOOP
+        // A similar situation should occur for partial copies
+        const auto bit_count = static_cast<shift_type>(std::countl_zero(x.limb_ptr()[x.limb_count() - 1])) + ((x.limb_count() - 1) * detail::width_v<uint_multiprecision_t>);
+        if (static_cast<shift_type>(s) > bit_count) {
+            return Result{0u};
+        }
+
         Result r;
         r.assign_value(x);
         r.shift_right(shift);

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -1518,8 +1518,7 @@ constexpr std::remove_cvref_t<T> operator>>(T&& x, const S s) {
                 for (shift_type i = 0; i < new_count; ++i) {
                     const shift_type src_idx = src_offset + i;
                     const limb_type  low     = src_limbs[src_idx];
-                    const limb_type  high =
-                        (src_idx + 1 < src_count) ? src_limbs[src_idx + 1] : limb_type{0};
+                    const limb_type  high    = (src_idx + 1 < src_count) ? src_limbs[src_idx + 1] : limb_type{0};
                     const detail::wide<limb_type> all_bits{.low_bits = low, .high_bits = high};
                     dst[i] = detail::funnel_shr(all_bits, static_cast<unsigned int>(shifted_bits));
                 }

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -1468,19 +1468,69 @@ constexpr std::remove_cvref_t<T> operator>>(T&& x, const S s) {
         r.shift_right(shift);
         return r;
     } else if constexpr (form == detail::binary_op_form::copy_int) {
-        // lvalue: copy then shift. No extra headroom needed since right-shift
-        // only shrinks. The result keeps the source's heap buffer (if any)
-        // even if the shifted value would fit inline.
+        // lvalue: copy then shift. Two fast paths avoid copying bits that are
+        // about to be discarded anyway
         //
-        // Before making a copy and then shifting,
-        // we check to see if such an operation is even required.
-        // For example, if we are shifting further than the width of the value, this will be a NOOP
-        // A similar situation should occur for partial copies
-        const auto bit_count = static_cast<shift_type>(std::countl_zero(x.limb_ptr()[x.limb_count() - 1])) + ((x.limb_count() - 1) * detail::width_v<uint_multiprecision_t>);
-        if (static_cast<shift_type>(s) > bit_count) {
-            return Result{0u};
+        // First is the case where the value is discarded entirely
+        // All we need to do is copy the sign
+        //
+        // Second is the case where some of the value is discarded
+        // For positive values this is a simple copy what we need and make a final limb internal shift
+        // For negative values we need to account for the rounding at the end
+        //
+        // If neither of these situations applies, make a full copy and shift.
+        const shift_type shifted_limbs = shift / Result::bits_per_limb;
+        const shift_type shifted_bits  = shift % Result::bits_per_limb;
+
+        // Case 1: Everything is discarded except the sign
+        if (shift > static_cast<shift_type>(x.width_mag())) {
+            if (x.is_negative()) {
+                return Result{-1};
+            }
+            return Result{};
         }
 
+        // Case 2: Some of the limbs are discarded
+        if (shifted_limbs != 0) {
+            using limb_type                 = uint_multiprecision_t;
+            const limb_type* const src_limbs = x.limb_ptr();
+            const std::size_t      src_count = x.limb_count();
+            const std::size_t      new_count = src_count - static_cast<std::size_t>(shifted_limbs);
+
+            Result r;
+            r.reserve(new_count);
+            std::copy_n(src_limbs + static_cast<std::size_t>(shifted_limbs), new_count, r.limb_ptr());
+            r.set_limb_count(static_cast<std::uint32_t>(new_count));
+
+            if (shifted_bits != 0) {
+                r.shift_right(shifted_bits);
+            }
+
+            if (x.is_negative()) {
+                bool discarded_nonzero = false;
+                for (shift_type i = 0; i < shifted_limbs; ++i) {
+                    if (src_limbs[i] != 0) {
+                        discarded_nonzero = true;
+                        break;
+                    }
+                }
+
+                if (!discarded_nonzero && shifted_bits != 0) {
+                    const auto mask = static_cast<limb_type>((limb_type{1} << shifted_bits) - 1);
+                    if ((src_limbs[static_cast<std::size_t>(shifted_limbs)] & mask) != 0) {
+                        discarded_nonzero = true;
+                    }
+                }
+
+                r.set_sign(true);
+                if (discarded_nonzero) {
+                    r.unchecked_increment_magnitude();
+                }
+            }
+            return r;
+        }
+
+        // Case 3: Make a full copy and shift
         Result r;
         r.assign_value(x);
         r.shift_right(shift);

--- a/tests/beman/big_int/bit_shift.test.cpp
+++ b/tests/beman/big_int/bit_shift.test.cpp
@@ -614,4 +614,27 @@ TEST(BitShift, LValuePartialLimbSkipNegativeResidualRounding) {
     EXPECT_EQ(r, -2);
 }
 
+TEST(BitShift, LValueBitShiftDropsTopLimb) {
+    // (2^64) >> 1 == 2^63: the source is on the heap but the result can be inlined
+    // Should not allocate
+    const big_int x = big_int{1} << 64;
+    EXPECT_NE(x.capacity(), 0U);
+
+    const big_int r        = x >> 1;
+    const big_int expected = big_int{1} << 63;
+    EXPECT_EQ(r, expected);
+    EXPECT_EQ(r.capacity(), 0U);
+}
+
+TEST(BitShift, LValueBitShiftDropsTopLimbNegative) {
+    // Same situation as above but with a negative source whose discarded
+    // bit forces a rounding decrement: -(2^64 + 1) >> 1 == -(2^63 + 1).
+    const big_int x = -((big_int{1} << 64) + big_int{1});
+
+    const big_int r        = x >> 1;
+    const big_int expected = -((big_int{1} << 63) + big_int{1});
+    EXPECT_EQ(r, expected);
+    EXPECT_EQ(r.capacity(), 0U);
+}
+
 } // namespace

--- a/tests/beman/big_int/bit_shift.test.cpp
+++ b/tests/beman/big_int/bit_shift.test.cpp
@@ -539,4 +539,16 @@ TEST(BitShift, OperatorLeftRightRoundTrip) {
     EXPECT_EQ((x << 130) >> 130, x);
 }
 
+TEST(BitShift, LValueBiggerShiftThanRep) {
+    // If we are shifting more bits than the bidwidth of an lvalue,
+    // we can skip making a copy all together
+    const big_int x = big_int{1} << 200;
+    const big_int r = x >> 10000;
+
+    const big_int expected{0};
+    EXPECT_EQ(r, expected);
+    EXPECT_EQ(r.capacity(), 0);
+    EXPECT_EQ(r.size(), 0);
+}
+
 } // namespace

--- a/tests/beman/big_int/bit_shift.test.cpp
+++ b/tests/beman/big_int/bit_shift.test.cpp
@@ -495,17 +495,17 @@ TEST(BitShift, OperatorRightShiftAcrossLimbs) {
     EXPECT_EQ(s, 1);
 }
 
-TEST(BitShift, OperatorRightShiftKeepsHeapStorage) {
-    // When the source is on the heap and the result could fit inline,
-    // operator>> should keep the heap buffer (no shrink_to_fit).
+TEST(BitShift, OperatorRightShiftFullDiscardSkipsCopy) {
+    // When the shift discards every significant bit of the source, the
+    // result is constructed directly without copying, so it does not
+    // inherit the source's heap buffer.
     big_int x{1};
     x <<= 128; // 3 limbs, on heap
     EXPECT_NE(x.capacity(), 0U);
 
-    const big_int r = x >> 200; // result is 0, but copied from heap source
+    const big_int r = x >> 200;
     EXPECT_EQ(r, 0);
-    // The copy via assign_value inherits the heap buffer
-    EXPECT_NE(r.capacity(), 0U);
+    EXPECT_EQ(r.capacity(), 0U);
 }
 
 TEST(BitShift, OperatorRightShiftPreservesOriginal) {
@@ -540,15 +540,78 @@ TEST(BitShift, OperatorLeftRightRoundTrip) {
 }
 
 TEST(BitShift, LValueBiggerShiftThanRep) {
-    // If we are shifting more bits than the bidwidth of an lvalue,
-    // we can skip making a copy all together
+    // If we are shifting more bits than the bitwidth of an lvalue,
+    // we can skip making a copy altogether.
     const big_int x = big_int{1} << 200;
     const big_int r = x >> 10000;
 
-    const big_int expected{0};
+    EXPECT_EQ(r, big_int{0});
+    EXPECT_EQ(r.capacity(), 0U); // No allocation should have been made
+}
+
+TEST(BitShift, LValueBiggerShiftThanRepNegative) {
+    // For a negative value, we should retain the sign
+    const big_int x = -(big_int{1} << 200);
+    const big_int r = x >> 10000;
+
+    EXPECT_EQ(r, -1);
+    EXPECT_EQ(r.capacity(), 0U);
+}
+
+TEST(BitShift, LValuePartialLimbSkip) {
+    // Whole-limb shift of a positive, heap-allocated source: the low limbs
+    // are dropped without being copied.
+    const big_int x = (big_int{1} << 128) + (big_int{1} << 64) + big_int{1}; // limbs [1, 1, 1]
+    EXPECT_EQ(x.representation().size(), 3U);
+
+    const big_int r        = x >> 64;
+    const big_int expected = (big_int{1} << 64) + big_int{1}; // [1, 1]
     EXPECT_EQ(r, expected);
-    EXPECT_EQ(r.capacity(), 0);
-    EXPECT_EQ(r.size(), 0);
+    EXPECT_EQ(r.representation().size(), 2U);
+}
+
+TEST(BitShift, LValuePartialLimbSkipResidualBits) {
+    // Mixed whole-limb + residual-bit shift: combine a `shifted_limbs > 0`
+    // skip with a small bit-level shift on the surviving tail.
+    big_int x{1};
+    x <<= 130; // single bit at position 130; limbs [0, 0, 4]
+
+    const big_int r = x >> 65; // should equal 1 << 65
+    big_int       expected{1};
+    expected <<= 65;
+    EXPECT_EQ(r, expected);
+}
+
+TEST(BitShift, LValuePartialLimbSkipNegativeExact) {
+    // Negative, partial-limb shift where every discarded bit is zero
+    const big_int x = -(big_int{1} << 128);
+    const big_int r = x >> 64;
+    big_int       expected{1};
+    expected <<= 64;
+    expected = -expected;
+    EXPECT_EQ(r, expected); // exact: -(2^128) / 2^64 == -(2^64)
+}
+
+TEST(BitShift, LValuePartialLimbSkipNegativeWholeLimbRounding) {
+    // Negative value where a wholly discarded lower limb has a non-zero bit.
+    // We must account for these bits
+    const big_int x = -((big_int{1} << 128) + big_int{1}); // limbs [1, 0, 1], negative
+
+    const big_int r        = x >> 64; // -(2^128 + 1) / 2^64 rounds to -(2^64 + 1)
+    const big_int expected = -((big_int{1} << 64) + big_int{1});
+    EXPECT_EQ(r, expected);
+}
+
+TEST(BitShift, LValuePartialLimbSkipNegativeResidualRounding) {
+    // Negative source where the rounding-trigger bit is in the low portion
+    // of the first surviving limb. `shift_right`'s own mask check covers
+    // this case; make sure we don't double-decrement.
+    big_int x{3};
+    x <<= 64; // limbs [0, 3]
+    x = -x;   // -3 * 2^64
+
+    const big_int r = x >> 65; // -3 * 2^64 / 2^65 = -1.5 rounds to -2
+    EXPECT_EQ(r, -2);
 }
 
 } // namespace


### PR DESCRIPTION
Right shifting now has three cases:
1) Total loss of information. Return either -1 or 0 depending on the signbit
2) Partial loss of information. Make a copy of only the limbs we need and then make a partial shift. In the negative value case we then need to make sure that we are rounded correctly.
3) No loss of information. Make a full copy and shift accordingly

Closes: #65 