### PR TITLE
Disable MaxSan options for GCC

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -43,7 +43,7 @@ jobs:
                     { "stdlibs": ["libstdc++"],
                       "tests": [
                         "Debug.Default", "Release.Default", "Release.TSan",
-                        "Release.MaxSan", "Debug.Werror",
+                        "Debug.Werror",
                         "Debug.Coverage"
                       ]
                     }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -16,8 +16,7 @@
       "name": "_debug-base",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "BEMAN_BUILDSYS_SANITIZER": "MaxSan"
+        "CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {
@@ -57,7 +56,8 @@
         "_debug-base"
       ],
       "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "infra/cmake/llvm-toolchain.cmake"
+        "CMAKE_TOOLCHAIN_FILE": "infra/cmake/llvm-toolchain.cmake",
+        "BEMAN_BUILDSYS_SANITIZER": "MaxSan"
       }
     },
     {
@@ -79,7 +79,8 @@
         "_debug-base"
       ],
       "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "infra/cmake/appleclang-toolchain.cmake"
+        "CMAKE_TOOLCHAIN_FILE": "infra/cmake/appleclang-toolchain.cmake",
+        "BEMAN_BUILDSYS_SANITIZER": "MaxSan"
       }
     },
     {
@@ -101,7 +102,8 @@
         "_debug-base"
       ],
       "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "infra/cmake/msvc-toolchain.cmake"
+        "CMAKE_TOOLCHAIN_FILE": "infra/cmake/msvc-toolchain.cmake",
+        "BEMAN_BUILDSYS_SANITIZER": "MaxSan"
       }
     },
     {


### PR DESCRIPTION
GCC sanitizers are too fragile to be used; see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71962

Even something as benign as
```cpp
int main()
{
  static constexpr int x = 0;
  static_assert(bool(&x), "");
}
```
... doesn't work with `-fsanitize=undefined` enabled.