### PR TITLE
Implement `from_chars`

### DIFF
--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -2559,11 +2559,11 @@ struct parse_non_allocating {
                 .ec         = std::errc::result_out_of_range,
             };
         }
-        return parse_non_allocating_result{
-            .value      = std::move(parsed),
-            .limb_count = parsed.size(),
-            .ec         = std::errc{},
-        };
+        parse_non_allocating_result r;
+        r.value      = std::move(parsed);
+        r.limb_count = parsed.size();
+        r.ec         = std::errc{};
+        return r;
     }
 
     static constexpr auto result = parse();

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -2400,10 +2400,12 @@ from_chars(const char* const begin, const char* const end, basic_big_int<b, A>& 
     }
 
     // The number of bits per base digit, or zero if the base is not a power of two.
+    // clang-format off
     const auto bits_per_digit = std::has_single_bit(static_cast<unsigned char>(base))
-                                    ? static_cast<unsigned char>(std::countr_zero(static_cast<unsigned char>(base)))
-                                    : static_cast<unsigned char>(0);
-    bool       at_least_one_digit = false;
+                              ? static_cast<unsigned char>(std::countr_zero(static_cast<unsigned char>(base)))
+                              : static_cast<unsigned char>(0);
+    // clang-format on
+    bool at_least_one_digit = false;
     for (; p != end; ++p) {
         const int digit = detail::digit_value(*p);
         if (digit < 0 || digit >= base) {
@@ -2541,7 +2543,7 @@ struct parse_non_allocating {
     // Returns the result of parsing a `big_int` using `from_chars_auto_base`.
     // However, if the result is too large to fit into inplace storage,
     // `{limb_count(), std::errc::result_out_of_range}` is returned.
-    [[nodiscard]] static consteval parse_non_allocating_result operator()() {
+    [[nodiscard]] static consteval parse_non_allocating_result parse() {
         big_int parsed;
         const auto [p, ec] = from_chars_auto_base(begin, end, parsed);
         if (ec != std::errc{}) {
@@ -2564,7 +2566,7 @@ struct parse_non_allocating {
         };
     }
 
-    static constexpr auto result = operator()();
+    static constexpr auto result = parse();
 
   public:
     static constexpr big_int   value      = result.value;

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -2547,19 +2547,19 @@ struct parse_non_allocating {
         big_int parsed;
         const auto [p, ec] = from_chars_auto_base(begin, end, parsed);
         if (ec != std::errc{}) {
-            return {0, 0, ec};
+            return parse_non_allocating_result{0, 0, ec};
         }
         if (p != end) {
-            return {0, 0, std::errc::invalid_argument};
+            return parse_non_allocating_result{0, 0, std::errc::invalid_argument};
         }
         if (parsed.capacity() != 0) {
-            return {
+            return parse_non_allocating_result{
                 .value      = 0,
                 .limb_count = parsed.size(),
                 .ec         = std::errc::result_out_of_range,
             };
         }
-        return {
+        return parse_non_allocating_result{
             .value      = std::move(parsed),
             .limb_count = parsed.size(),
             .ec         = std::errc{},

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -2400,9 +2400,9 @@ from_chars(const char* const begin, const char* const end, basic_big_int<b, A>& 
     }
 
     // The number of bits per base digit, or zero if the base is not a power of two.
-    const auto bits_per_digit = std::has_single_bit(static_cast<unsigned char>(base))
-                                    ? static_cast<unsigned char>(std::countr_zero(static_cast<unsigned char>(base)))
-                                    : static_cast<unsigned char>(0);
+    const auto bits_per_digit     = std::has_single_bit(static_cast<unsigned char>(base))
+                                        ? static_cast<unsigned char>(std::countr_zero(static_cast<unsigned char>(base)))
+                                        : static_cast<unsigned char>(0);
     bool       at_least_one_digit = false;
     for (; p != end; ++p) {
         const int digit = detail::digit_value(*p);
@@ -2542,25 +2542,25 @@ struct parse_non_allocating {
     // However, if the result is too large to fit into inplace storage,
     // `{limb_count(), std::errc::result_out_of_range}` is returned.
     [[nodiscard]] static consteval parse_non_allocating_result operator()() {
-        big_int result;
-        const auto [p, ec] = from_chars_auto_base(begin, end, result);
+        big_int parsed;
+        const auto [p, ec] = from_chars_auto_base(begin, end, parsed);
         if (ec != std::errc{}) {
             return {0, 0, ec};
         }
         if (p != end) {
             return {0, 0, std::errc::invalid_argument};
         }
-        if (result.capacity() != 0) {
+        if (parsed.capacity() != 0) {
             return {
                 .value      = 0,
-                .limb_count = result.size(),
+                .limb_count = parsed.size(),
                 .ec         = std::errc::result_out_of_range,
             };
         }
         return {
-            .value      = result,
-            .limb_count = result.size(),
-            .ec         = {},
+            .value      = std::move(parsed),
+            .limb_count = parsed.size(),
+            .ec         = std::errc{},
         };
     }
 

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -2535,7 +2535,7 @@ BEMAN_BIG_INT_DIAGNOSTIC_POP()
 // Returns the result of parsing a `big_int` using `from_chars_auto_base`.
 // However, if the result is too large to fit into inplace storage,
 // `{limb_count(), std::errc::result_out_of_range}` is returned.
-[[nodiscard]] static constexpr parse_non_allocating_result parse_non_allocating_impl(const char*       begin,
+[[nodiscard]] static constexpr parse_non_allocating_result parse_non_allocating_impl(const char* const begin,
                                                                                      const char* const end) {
     // This function is not consteval because of compiler bugs,
     // but should only be called during constant evaluation.

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -2571,7 +2571,7 @@ struct parse_non_allocating {
 
 template <std::size_t limb_count>
 [[nodiscard]] consteval std::array<uint_multiprecision_t, limb_count>
-literal_operator_n_compute_limbs(const char* begin, const char* const end) {
+literal_operator_n_compute_limbs(const char* const begin, const char* const end) {
     std::array<uint_multiprecision_t, limb_count> result;
     big_int                                       parsed;
     const auto [p, ec] = detail::from_chars_auto_base(begin, end, parsed);
@@ -2622,12 +2622,7 @@ template <char... digits>
         // we can precompute a constexpr limb array which is used for fast runtime initialization.
         // We already know the limb count from the previous parsing attempt:
         constexpr const auto& limbs = detail::literal_operator_n_limbs_v<buffer>;
-
-        big_int result(limbs.data(), limbs.data() + limbs.size());
-        if (buffer[0] == '-') {
-            detail::access_bypass::negate(result);
-        }
-        return result;
+        return big_int(limbs.data(), limbs.data() + limbs.size());
     } else {
         static_assert(detail::parse_non_allocating<buffer>::ec == std::errc::invalid_argument);
         static_assert(false, "The given literal is not a valid integer-literal.");

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -253,7 +253,7 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     template <std::ranges::input_range R>
         requires detail::signed_or_unsigned<std::ranges::range_value_t<R>>
     constexpr explicit basic_big_int(std::from_range_t, R&& r, const allocator_type& a = allocator_type())
-        : basic_big_int(std::ranges::begin(r), std::ranges; : end(r), a) {}
+        : basic_big_int(std::ranges::begin(r), std::ranges::end(r), a) {}
 #endif
 
     constexpr ~basic_big_int();

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -2400,9 +2400,9 @@ from_chars(const char* const begin, const char* const end, basic_big_int<b, A>& 
     }
 
     // The number of bits per base digit, or zero if the base is not a power of two.
-    const auto bits_per_digit     = std::has_single_bit(static_cast<unsigned char>(base))
-                                        ? static_cast<unsigned char>(std::countr_zero(static_cast<unsigned char>(base)))
-                                        : static_cast<unsigned char>(0);
+    const auto bits_per_digit = std::has_single_bit(static_cast<unsigned char>(base))
+                                    ? static_cast<unsigned char>(std::countr_zero(static_cast<unsigned char>(base)))
+                                    : static_cast<unsigned char>(0);
     bool       at_least_one_digit = false;
     for (; p != end; ++p) {
         const int digit = detail::digit_value(*p);

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -2535,8 +2535,12 @@ BEMAN_BIG_INT_DIAGNOSTIC_POP()
 // Returns the result of parsing a `big_int` using `from_chars_auto_base`.
 // However, if the result is too large to fit into inplace storage,
 // `{limb_count(), std::errc::result_out_of_range}` is returned.
-[[nodiscard]] static consteval parse_non_allocating_result parse_non_allocating_impl(const char*       begin,
+[[nodiscard]] static constexpr parse_non_allocating_result parse_non_allocating_impl(const char*       begin,
                                                                                      const char* const end) {
+    // This function is not consteval because of compiler bugs,
+    // but should only be called during constant evaluation.
+    // https://developercommunity.microsoft.com/t/Nonsensical-error-C2440-when-initializin/11077170
+
     big_int parsed;
     const auto [p, ec] = from_chars_auto_base(begin, end, parsed);
     if (ec != std::errc{}) {
@@ -2545,18 +2549,11 @@ BEMAN_BIG_INT_DIAGNOSTIC_POP()
     if (p != end) {
         return parse_non_allocating_result{0, 0, std::errc::invalid_argument};
     }
+    const auto parsed_size = parsed.size();
     if (parsed.capacity() != 0) {
-        parse_non_allocating_result r;
-        r.value      = 0;
-        r.limb_count = parsed.size();
-        r.ec         = std::errc::result_out_of_range;
-        return r;
+        return {big_int{}, parsed_size, std::errc::result_out_of_range};
     }
-    parse_non_allocating_result r;
-    r.value      = parsed;
-    r.limb_count = parsed.size();
-    r.ec         = std::errc{};
-    return r;
+    return {std::move(parsed), parsed_size, std::errc{}};
 }
 
 template <std::array buffer>

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -2381,6 +2381,8 @@ namespace detail {
                                   : -1;
 }
 
+} // namespace detail
+
 template <size_t b, class A>
 constexpr std::from_chars_result
 from_chars(const char* const begin, const char* const end, basic_big_int<b, A>& out, const int base) {
@@ -2402,7 +2404,7 @@ from_chars(const char* const begin, const char* const end, basic_big_int<b, A>& 
                                         : static_cast<unsigned char>(0);
     bool       at_least_one_digit = false;
     for (; p != end; ++p) {
-        const int digit = digit_value(*p);
+        const int digit = detail::digit_value(*p);
         if (digit < 0 || digit >= base) {
             break;
         }
@@ -2438,16 +2440,19 @@ from_chars(const char* const begin, const char* const end, basic_big_int<b, A>& 
     return {p, std::errc{}};
 }
 
+namespace detail {
+
 using std::from_chars;
 
-// Like `std::from_chars`, but detects the base automatically
-// based on the `0x`, `0b`, or `0` prefix.
+// Detects the base automatically based on the `0x`, `0b`, or `0` prefix
+// and dispatches to `from_chars` with the identified base.
+// Leading minus signs are not supported.
 template <class T>
 [[nodiscard]] constexpr std::from_chars_result
 from_chars_auto_base(const char* const begin, const char* const end, T& out)
     requires requires { from_chars(begin, end, out, 10); }
 {
-    if (begin == end) {
+    if (begin == end || *begin < '0' || *begin > '9') {
         return {end, std::errc::invalid_argument};
     }
     if (*begin != '0' || end - begin <= 1) {
@@ -2470,40 +2475,121 @@ from_chars_auto_base(const char* const begin, const char* const end, T& out)
     return from_chars(begin, end, out, 8);
 }
 
+// Helper class which assists in removing digit separators from literals.
+template <char... digits>
+struct literal_buffer {
+  private:
+    // The sizeof... is necessary here because of:
+    // https://github.com/llvm/llvm-project/issues/79750
+    static constexpr char        raw_buffer[sizeof...(digits)]{digits...};
+    static constexpr const char* raw_end = raw_buffer + sizeof(raw_buffer);
+
+    static consteval std::size_t make_buffer_impl(const char* begin, const char* const end, char* out = nullptr) {
+        bool        digit_separator_allowed = false;
+        std::size_t length                  = 0;
+        for (; begin != end; ++begin) {
+            if (*begin == '\'') {
+                if (!digit_separator_allowed) {
+                    return 0;
+                }
+                digit_separator_allowed = false;
+            } else {
+                digit_separator_allowed = true;
+                ++length;
+                if (out != nullptr) {
+                    *out++ = *begin;
+                }
+            }
+        }
+        return length;
+    }
+
+    static constexpr std::size_t result_length = make_buffer_impl(raw_buffer, raw_end);
+
+    [[nodiscard]] static consteval auto make_buffer() {
+        if constexpr (result_length == 0) {
+            return std::array<char, 0>{};
+        } else {
+            std::array<char, result_length> result;
+            make_buffer_impl(raw_buffer, raw_end, result.data());
+            return result;
+        }
+    }
+
+  public:
+    static constexpr std::array<char, result_length> value = make_buffer();
+};
+
 BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
 BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Wpadded")
-struct big_int_and_errc {
-    big_int   value_or_limb_count;
-    std::errc ec;
+struct parse_non_allocating_result {
+    big_int            value;
+    big_int::size_type limb_count;
+    std::errc          ec;
 };
 BEMAN_BIG_INT_DIAGNOSTIC_POP()
 
-// Returns the result of parsing a `big_int` using `from_chars_auto_base`.
-// However, if the result is too large to fit into inplace storage,
-// `{limb_count(), std::errc::result_out_of_range}` is returned.
-[[nodiscard]] constexpr big_int_and_errc parse_non_allocating(const char* const begin, const char* const end) {
-    big_int result;
-    const auto [p, ec] = from_chars_auto_base(begin, end, result);
-    if (ec != std::errc{}) {
-        return {0, ec};
+template <std::array buffer>
+struct parse_non_allocating {
+  private:
+    static_assert(std::is_same_v<typename decltype(buffer)::value_type, char>);
+
+    static constexpr const char* begin = buffer.data();
+    static constexpr const char* end   = begin + buffer.size();
+
+    // Returns the result of parsing a `big_int` using `from_chars_auto_base`.
+    // However, if the result is too large to fit into inplace storage,
+    // `{limb_count(), std::errc::result_out_of_range}` is returned.
+    [[nodiscard]] static consteval parse_non_allocating_result operator()() {
+        big_int result;
+        const auto [p, ec] = from_chars_auto_base(begin, end, result);
+        if (ec != std::errc{}) {
+            return {0, 0, ec};
+        }
+        if (p != end) {
+            return {0, 0, std::errc::invalid_argument};
+        }
+        if (result.capacity() != 0) {
+            return {
+                .value      = 0,
+                .limb_count = result.size(),
+                .ec         = std::errc::result_out_of_range,
+            };
+        }
+        return {
+            .value      = result,
+            .limb_count = result.size(),
+            .ec         = {},
+        };
     }
-    if (p != end) {
-        return {0, std::errc::invalid_argument};
-    }
-    if (result.capacity() != 0) {
-        return {result.size(), std::errc::result_out_of_range};
-    }
-    return {.value_or_limb_count = result, .ec = {}};
+
+    static constexpr auto result = operator()();
+
+  public:
+    static constexpr big_int   value      = result.value;
+    static constexpr auto      limb_count = result.limb_count;
+    static constexpr std::errc ec         = result.ec;
+};
+
+template <std::size_t limb_count>
+[[nodiscard]] consteval std::array<uint_multiprecision_t, limb_count>
+literal_operator_n_compute_limbs(const char* begin, const char* const end) {
+    std::array<uint_multiprecision_t, limb_count> result;
+    big_int                                       parsed;
+    const auto [p, ec] = detail::from_chars_auto_base(begin, end, parsed);
+    // We've already parsed this successfully once in parse_non_allocating,
+    // so there's no reason it would fail now.
+    BEMAN_BIG_INT_ASSERT(p == end);
+    BEMAN_BIG_INT_ASSERT(ec == std::errc{});
+    BEMAN_BIG_INT_ASSERT(parsed.size() == limb_count);
+    std::copy_n(parsed.representation().data(), limb_count, result.data());
+    return result;
 }
 
-// Helper variable template which prevents multiple constant evaluations of parse_non_allocating,
-// in case compilers don't memoize.
-// It also provides some convenience.
-template <char... digits>
-inline constexpr big_int_and_errc parse_non_allocating_v = []() constexpr {
-    static constexpr char buffer[]{digits...};
-    return parse_non_allocating(buffer, buffer + sizeof(buffer));
-}();
+template <std::array buffer>
+inline constexpr std::array<uint_multiprecision_t, detail::parse_non_allocating<buffer>::limb_count>
+    literal_operator_n_limbs_v = literal_operator_n_compute_limbs<detail::parse_non_allocating<buffer>::limb_count>(
+        buffer.data(), buffer.data() + buffer.size());
 
 } // namespace detail
 
@@ -2520,57 +2606,33 @@ BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_MSVC(4455)
 // clang-format off
 template <char... digits>
 [[nodiscard]] constexpr big_int operator""n()
-  //noexcept(detail::parse_non_allocating_v<digits...>.ec == std::errc{}) 
+  noexcept(detail::parse_non_allocating<detail::literal_buffer<digits...>::value>::ec == std::errc{}) 
   {
     // clang-format on
 
-    // For this user-defined literal, there are two radically distinct situations.
-    // We are either able to fit the parsed value into the inplace storage,
-    // in which case `operator""n()` simply copies the resulting `big_int`
-    // out of a `constexpr` variable;
-    // or the parsed value doesn't fit and needs to be dynamically allocated on the fly.
-    //
-    // This weirdness is caused only by the fact that we don't have non-transient allocations,
-    // meaning that we cannot create a `constexpr` variable that holds an allocation.
-    // This also prevents us from making `operator""n()` `consteval` rather than `constexpr`.
-    // Because it is only `constexpr`, it is important to handle the "small case" specially,
-    // so that no runtime parsing takes place.
-    if constexpr (detail::parse_non_allocating_v<digits...>.ec == std::errc{}) {
-        return detail::parse_non_allocating_v<digits...>.value_or_limb_count;
-    } else if constexpr (detail::parse_non_allocating_v<digits...>.ec == std::errc::invalid_argument) {
-        static_assert(false,
-                      "The given literal is not a valid integer-literal. "
-                      "This should not even be possible "
-                      "without explicitly providing template arguments to the user-defined literal.");
-    } else {
-        static_assert(detail::parse_non_allocating_v<digits...>.ec == std::errc::result_out_of_range);
-        static_assert(false);
+    // The first step is to do basic validation and to eliminate any digit separators.
+    constexpr const auto& buffer = detail::literal_buffer<digits...>::value;
+    static_assert(!buffer.empty(), "The given literal is not a valid integer-literal.");
 
+    if constexpr (detail::parse_non_allocating<buffer>::ec == std::errc{}) {
+        // The happy case is where the literal's integer value is small enough to fit into big_int without allocations.
+        // In that case, we've already parsed the literal, and simply return the pre-computed big_int.
+        return detail::parse_non_allocating<buffer>::value;
+    } else if constexpr (detail::parse_non_allocating<buffer>::ec == std::errc::result_out_of_range) {
+        // The unhappy case is where allocations are required.
         // While we don't have non-transient allocations and cannot store a constexpr big_int,
         // we can precompute a constexpr limb array which is used for fast runtime initialization.
-        static constexpr char buffer[]{digits...};
         // We already know the limb count from the previous parsing attempt:
-        static constexpr auto dynamic_limb_count =
-            static_cast<std::size_t>(detail::parse_non_allocating_v<digits...>.value_or_limb_count);
-        // Unfortunately, we need to parse a second time to also obtain the limb data.
-        static constexpr auto limbs = [] {
-            big_int parsed;
-            const auto [p, ec] = detail::from_chars_auto_base(std::begin(buffer), std::end(buffer), parsed);
-            // We've already parsed this successfully once in parse_non_allocating,
-            // so there's no reason it would fail now.
-            BEMAN_BIG_INT_ASSERT(p == std::end(buffer));
-            BEMAN_BIG_INT_ASSERT(ec == std::errc{});
-            BEMAN_BIG_INT_ASSERT(parsed.size() == dynamic_limb_count);
-            std::array<uint_multiprecision_t, dynamic_limb_count> result;
-            std::copy_n(parsed.representation().data(), dynamic_limb_count, result.data());
-            return result;
-        }();
+        constexpr const auto& limbs = detail::literal_operator_n_limbs_v<buffer>;
 
-        big_int result(std::begin(limbs), std::end(limbs));
+        big_int result(limbs.data(), limbs.data() + limbs.size());
         if (buffer[0] == '-') {
             detail::access_bypass::negate(result);
         }
         return result;
+    } else {
+        static_assert(detail::parse_non_allocating<buffer>::ec == std::errc::invalid_argument);
+        static_assert(false, "The given literal is not a valid integer-literal.");
     }
 }
 
@@ -2578,8 +2640,7 @@ template <char... digits>
 // https://github.com/llvm/llvm-project/issues/76394
 // clang-format off
 template <char... digits>
-[[nodiscard]] constexpr big_int operator""_n()
-// noexcept(noexcept(operator""n<digits...>())) 
+[[nodiscard]] constexpr big_int operator""_n() noexcept(noexcept(operator""n<digits...>())) 
 {
     return operator""n<digits...>();
 }

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -2532,41 +2532,39 @@ struct parse_non_allocating_result {
 };
 BEMAN_BIG_INT_DIAGNOSTIC_POP()
 
+// Returns the result of parsing a `big_int` using `from_chars_auto_base`.
+// However, if the result is too large to fit into inplace storage,
+// `{limb_count(), std::errc::result_out_of_range}` is returned.
+[[nodiscard]] static consteval parse_non_allocating_result parse_non_allocating_impl(const char*       begin,
+                                                                                     const char* const end) {
+    big_int parsed;
+    const auto [p, ec] = from_chars_auto_base(begin, end, parsed);
+    if (ec != std::errc{}) {
+        return parse_non_allocating_result{0, 0, ec};
+    }
+    if (p != end) {
+        return parse_non_allocating_result{0, 0, std::errc::invalid_argument};
+    }
+    if (parsed.capacity() != 0) {
+        parse_non_allocating_result r;
+        r.value      = 0;
+        r.limb_count = parsed.size();
+        r.ec         = std::errc::result_out_of_range;
+        return r;
+    }
+    parse_non_allocating_result r;
+    r.value      = parsed;
+    r.limb_count = parsed.size();
+    r.ec         = std::errc{};
+    return r;
+}
+
 template <std::array buffer>
 struct parse_non_allocating {
   private:
     static_assert(std::is_same_v<typename decltype(buffer)::value_type, char>);
-
-    static constexpr const char* begin = buffer.data();
-    static constexpr const char* end   = begin + buffer.size();
-
-    // Returns the result of parsing a `big_int` using `from_chars_auto_base`.
-    // However, if the result is too large to fit into inplace storage,
-    // `{limb_count(), std::errc::result_out_of_range}` is returned.
-    [[nodiscard]] static consteval parse_non_allocating_result parse() {
-        big_int parsed;
-        const auto [p, ec] = from_chars_auto_base(begin, end, parsed);
-        if (ec != std::errc{}) {
-            return parse_non_allocating_result{0, 0, ec};
-        }
-        if (p != end) {
-            return parse_non_allocating_result{0, 0, std::errc::invalid_argument};
-        }
-        if (parsed.capacity() != 0) {
-            parse_non_allocating_result r;
-            r.value      = 0;
-            r.limb_count = parsed.size();
-            r.ec         = std::errc::result_out_of_range;
-            return r;
-        }
-        parse_non_allocating_result r;
-        r.value      = parsed;
-        r.limb_count = parsed.size();
-        r.ec         = std::errc{};
-        return r;
-    }
-
-    static constexpr parse_non_allocating_result result = parse();
+    static constexpr parse_non_allocating_result result =
+        parse_non_allocating_impl(buffer.data(), buffer.data() + buffer.size());
 
   public:
     static constexpr big_int   value      = result.value;

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -146,6 +146,9 @@ static_assert(invert(std::strong_ordering::less) == std::strong_ordering::greate
               "where negation exchanges less and greater.");
 
 enum struct bitwise_op : unsigned char { and_, or_, xor_ };
+
+struct access_bypass;
+
 } // namespace detail
 
 // [big.int.class], class template basic_big_int
@@ -242,10 +245,15 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     constexpr basic_big_int(const T&              value,
                             const allocator_type& a) noexcept(detail::no_alloc_constructible_from<inplace_bits, T>);
 
+    template <std::input_iterator I, std::sentinel_for<I> S>
+        requires detail::signed_or_unsigned<std::iter_value_t<I>>
+    constexpr basic_big_int(I begin, S end, const allocator_type& a = allocator_type());
+
 #if defined(__cpp_lib_containers_ranges) && __cpp_lib_containers_ranges >= 202202L
     template <std::ranges::input_range R>
         requires detail::signed_or_unsigned<std::ranges::range_value_t<R>>
-    constexpr explicit basic_big_int(std::from_range_t, R&& r, const allocator_type& a = allocator_type());
+    constexpr explicit basic_big_int(std::from_range_t, R&& r, const allocator_type& a = allocator_type())
+        : basic_big_int(std::ranges::begin(r), std::ranges; : end(r), a) {}
 #endif
 
     constexpr ~basic_big_int();
@@ -553,7 +561,20 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
 
     template <detail::bitwise_op op, class L, class R>
     [[nodiscard]] static constexpr detail::common_big_int_type<L, R> bitwise_impl(L&& x, R&& y);
+
+    friend detail::access_bypass;
 };
+
+namespace detail {
+
+struct access_bypass {
+    template <size_t b, class A>
+    static constexpr void negate(basic_big_int<b, A>& x) {
+        x.negate();
+    }
+};
+
+} // namespace detail
 
 // =============================================================================
 // Out-of-class definitions
@@ -712,36 +733,34 @@ constexpr basic_big_int<b, A>::basic_big_int(const T& value, const allocator_typ
     }
 }
 
-#if defined(__cpp_lib_containers_ranges) && __cpp_lib_containers_ranges >= 202202L
 template <std::size_t b, class A>
-template <std::ranges::input_range R>
-    requires detail::signed_or_unsigned<std::ranges::range_value_t<R>>
-constexpr basic_big_int<b, A>::basic_big_int(std::from_range_t, R&& r, const allocator_type& a)
+template <std::input_iterator I, std::sentinel_for<I> S>
+    requires detail::signed_or_unsigned<std::iter_value_t<I>>
+constexpr basic_big_int<b, A>::basic_big_int(I begin, S end, const allocator_type& a)
     : m_capacity{0}, m_size_and_sign{1}, m_storage{}, m_alloc{a} {
 
-    if constexpr (std::ranges::sized_range<R>) {
-        reserve(std::ranges::size(r));
+    if constexpr (std::ranges::sized_range<std::ranges::subrange<I, S>>) {
+        reserve(std::ranges::size(std::ranges::subrange(begin, end)));
         std::size_t i   = 0;
         auto* const dst = limb_ptr();
-        for (auto&& elem : r) {
-            using U = std::make_unsigned_t<std::ranges::range_value_t<R>>;
-            std::construct_at(dst + i++, static_cast<limb_type>(static_cast<U>(elem)));
+        for (; begin != end; ++begin) {
+            using U = std::make_unsigned_t<std::iter_value_t<I>>;
+            std::construct_at(dst + i++, static_cast<limb_type>(static_cast<U>(*begin)));
         }
         set_limb_count(static_cast<std::uint32_t>(i == 0 ? 1 : i));
         while (limb_count() > 1 && dst[limb_count() - 1] == 0) {
             set_limb_count(limb_count() - 1);
         }
     } else {
-        for (auto&& elem : r) {
-            using U = std::make_unsigned_t<std::ranges::range_value_t<R>>;
-            push_back_limb(static_cast<limb_type>(static_cast<U>(elem)));
+        for (; begin != end; ++begin) {
+            using U = std::make_unsigned_t<std::iter_value_t<I>>;
+            push_back_limb(static_cast<limb_type>(static_cast<U>(*begin)));
         }
         while (limb_count() > 1 && limb_ptr()[limb_count() - 1] == 0) {
             set_limb_count(limb_count() - 1);
         }
     }
 }
-#endif
 
 template <std::size_t b, class A>
 constexpr basic_big_int<b, A>::~basic_big_int() {
@@ -2354,60 +2373,134 @@ using big_int = basic_big_int<64, std::allocator<uint_multiprecision_t>>;
 // [big.int.literal]
 namespace detail {
 
+[[nodiscard]] constexpr int digit_value(char c) noexcept {
+    static_assert('A' == 0x41 && 'Z' == 0x5a, "This function requires the ordinary literal encoding to be ASCII.");
+    return '0' <= c && c <= '9'   ? c - '0'
+           : 'A' <= c && c <= 'Z' ? c - 'A' + 10
+           : 'a' <= c && c <= 'z' ? c - 'a' + 10
+                                  : -1;
+}
+
+template <size_t b, class A>
+constexpr std::from_chars_result
+from_chars(const char* const begin, const char* const end, basic_big_int<b, A>& out, const int base) {
+    if (begin == nullptr || begin == end || base < 2 || base > 36) {
+        return {end, std::errc::invalid_argument};
+    }
+
+    const char* p = begin;
+    if (*p == '-') {
+        ++p;
+    }
+    if (p == end) {
+        return {end, std::errc::invalid_argument};
+    }
+
+    // The number of bits per base digit, or zero if the base is not a power of two.
+    const auto bits_per_digit     = std::has_single_bit(static_cast<unsigned char>(base))
+                                        ? static_cast<unsigned char>(std::countr_zero(static_cast<unsigned char>(base)))
+                                        : static_cast<unsigned char>(0);
+    bool       at_least_one_digit = false;
+    for (; p != end; ++p) {
+        const int digit = digit_value(*p);
+        if (digit < 0 || digit >= base) {
+            break;
+        }
+        if (!at_least_one_digit) {
+            // Reset to zero, but keep the allocation (if any).
+            // We have to delay this assignment because if invalid_argument is returned,
+            // the output parameter must remain unmodified.
+            out                = {};
+            at_least_one_digit = true;
+        }
+        // In general, each time we concatenate a digit, we multiply with the base and add the digit.
+        // For powers of two, this is equivalent to a left shift, followed by a bitwise OR.
+        // Casting to unsigned char selects a potentially simpler specialization
+        // of the binary operators than using int.
+        if (bits_per_digit) {
+            out <<= bits_per_digit;
+            // TODO: Once `|=` exists, this `+=` should be replaced.
+            out += static_cast<unsigned char>(digit);
+        } else {
+            out *= base;
+            out += static_cast<unsigned char>(digit);
+        }
+    }
+    if (!at_least_one_digit) {
+        return {end, std::errc::invalid_argument};
+    }
+    if (begin[0] == '-') {
+        detail::access_bypass::negate(out);
+    }
+    if BEMAN_BIG_INT_IS_CONSTEVAL {
+        out.shrink_to_fit();
+    }
+    return {p, std::errc{}};
+}
+
+using std::from_chars;
+
 // Like `std::from_chars`, but detects the base automatically
 // based on the `0x`, `0b`, or `0` prefix.
-template <unsigned_integer T>
+template <class T>
 [[nodiscard]] constexpr std::from_chars_result
-from_chars_auto_base(const char* const begin, const char* const end, T& out) {
+from_chars_auto_base(const char* const begin, const char* const end, T& out)
+    requires requires { from_chars(begin, end, out, 10); }
+{
     if (begin == end) {
         return {end, std::errc::invalid_argument};
     }
     if (*begin != '0' || end - begin <= 1) {
-        return std::from_chars(begin, end, out);
+        return from_chars(begin, end, out, 10);
     }
     switch (begin[1]) {
     case 'b':
     case 'B':
-        return std::from_chars(begin + 2, end, out, 2);
+        return from_chars(begin + 2, end, out, 2);
     // In the future, this will also have a case for 'o'
     // https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p0085r3.html
     case 'x':
     case 'X':
-        return std::from_chars(begin + 2, end, out, 16);
+        return from_chars(begin + 2, end, out, 16);
     default:
         break;
     }
     // This case (leading zero for octal) is deprecated,
     // but we have no real way to communicate that and raise a warning here.
-    return std::from_chars(begin, end, out, 8);
+    return from_chars(begin, end, out, 8);
 }
 
 BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
 BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Wpadded")
 struct big_int_and_errc {
-    big_int   value;
+    big_int   value_or_limb_count;
     std::errc ec;
 };
 BEMAN_BIG_INT_DIAGNOSTIC_POP()
 
+// Returns the result of parsing a `big_int` using `from_chars_auto_base`.
+// However, if the result is too large to fit into inplace storage,
+// `{limb_count(), std::errc::result_out_of_range}` is returned.
 [[nodiscard]] constexpr big_int_and_errc parse_non_allocating(const char* const begin, const char* const end) {
-    // TODO(eisenwave): This should support more than a single limb.
-    uint_multiprecision_t parsed_limb = 0;
-    const auto [p, ec]                = detail::from_chars_auto_base(begin, end, parsed_limb);
+    big_int result;
+    const auto [p, ec] = from_chars_auto_base(begin, end, result);
     if (ec != std::errc{}) {
         return {0, ec};
     }
     if (p != end) {
         return {0, std::errc::invalid_argument};
     }
-    return {.value = parsed_limb, .ec = {}};
+    if (result.capacity() != 0) {
+        return {result.size(), std::errc::result_out_of_range};
+    }
+    return {.value_or_limb_count = result, .ec = {}};
 }
 
 // Helper variable template which prevents multiple constant evaluations of parse_non_allocating,
 // in case compilers don't memoize.
 // It also provides some convenience.
 template <char... digits>
-inline constexpr big_int_and_errc parse_non_allocating_v = [] {
+inline constexpr big_int_and_errc parse_non_allocating_v = []() constexpr {
     static constexpr char buffer[]{digits...};
     return parse_non_allocating(buffer, buffer + sizeof(buffer));
 }();
@@ -2427,7 +2520,8 @@ BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_MSVC(4455)
 // clang-format off
 template <char... digits>
 [[nodiscard]] constexpr big_int operator""n()
-  noexcept(detail::parse_non_allocating_v<digits...>.ec == std::errc{}) {
+  //noexcept(detail::parse_non_allocating_v<digits...>.ec == std::errc{}) 
+  {
     // clang-format on
 
     // For this user-defined literal, there are two radically distinct situations.
@@ -2442,7 +2536,7 @@ template <char... digits>
     // Because it is only `constexpr`, it is important to handle the "small case" specially,
     // so that no runtime parsing takes place.
     if constexpr (detail::parse_non_allocating_v<digits...>.ec == std::errc{}) {
-        return detail::parse_non_allocating_v<digits...>.value;
+        return detail::parse_non_allocating_v<digits...>.value_or_limb_count;
     } else if constexpr (detail::parse_non_allocating_v<digits...>.ec == std::errc::invalid_argument) {
         static_assert(false,
                       "The given literal is not a valid integer-literal. "
@@ -2450,9 +2544,33 @@ template <char... digits>
                       "without explicitly providing template arguments to the user-defined literal.");
     } else {
         static_assert(detail::parse_non_allocating_v<digits...>.ec == std::errc::result_out_of_range);
-        static_assert(false, "Sorry, allocating literals are not supported yet.");
-        // TODO: 1. Create a pre-computed constexpr limb array and sign bit.
-        //       2. At runtime, create a `big_int` using the constructor taking a limb array.
+        static_assert(false);
+
+        // While we don't have non-transient allocations and cannot store a constexpr big_int,
+        // we can precompute a constexpr limb array which is used for fast runtime initialization.
+        static constexpr char buffer[]{digits...};
+        // We already know the limb count from the previous parsing attempt:
+        static constexpr auto dynamic_limb_count =
+            static_cast<std::size_t>(detail::parse_non_allocating_v<digits...>.value_or_limb_count);
+        // Unfortunately, we need to parse a second time to also obtain the limb data.
+        static constexpr auto limbs = [] {
+            big_int parsed;
+            const auto [p, ec] = detail::from_chars_auto_base(std::begin(buffer), std::end(buffer), parsed);
+            // We've already parsed this successfully once in parse_non_allocating,
+            // so there's no reason it would fail now.
+            BEMAN_BIG_INT_ASSERT(p == std::end(buffer));
+            BEMAN_BIG_INT_ASSERT(ec == std::errc{});
+            BEMAN_BIG_INT_ASSERT(parsed.size() == dynamic_limb_count);
+            std::array<uint_multiprecision_t, dynamic_limb_count> result;
+            std::copy_n(parsed.representation().data(), dynamic_limb_count, result.data());
+            return result;
+        }();
+
+        big_int result(std::begin(limbs), std::end(limbs));
+        if (buffer[0] == '-') {
+            detail::access_bypass::negate(result);
+        }
+        return result;
     }
 }
 
@@ -2460,7 +2578,9 @@ template <char... digits>
 // https://github.com/llvm/llvm-project/issues/76394
 // clang-format off
 template <char... digits>
-[[nodiscard]] constexpr big_int operator""_n() noexcept(noexcept(operator""n<digits...>())) {
+[[nodiscard]] constexpr big_int operator""_n()
+// noexcept(noexcept(operator""n<digits...>())) 
+{
     return operator""n<digits...>();
 }
 // clang-format on

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -2553,20 +2553,20 @@ struct parse_non_allocating {
             return parse_non_allocating_result{0, 0, std::errc::invalid_argument};
         }
         if (parsed.capacity() != 0) {
-            return parse_non_allocating_result{
-                .value      = 0,
-                .limb_count = parsed.size(),
-                .ec         = std::errc::result_out_of_range,
-            };
+            parse_non_allocating_result r;
+            r.value      = 0;
+            r.limb_count = parsed.size();
+            r.ec         = std::errc::result_out_of_range;
+            return r;
         }
         parse_non_allocating_result r;
-        r.value      = std::move(parsed);
+        r.value      = parsed;
         r.limb_count = parsed.size();
         r.ec         = std::errc{};
         return r;
     }
 
-    static constexpr auto result = parse();
+    static constexpr parse_non_allocating_result result = parse();
 
   public:
     static constexpr big_int   value      = result.value;

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -2399,9 +2399,9 @@ from_chars(const char* const begin, const char* const end, basic_big_int<b, A>& 
     }
 
     // The number of bits per base digit, or zero if the base is not a power of two.
-    const auto bits_per_digit = std::has_single_bit(static_cast<unsigned char>(base))
-                                    ? static_cast<unsigned char>(std::countr_zero(static_cast<unsigned char>(base)))
-                                    : static_cast<unsigned char>(0);
+    const auto bits_per_digit     = std::has_single_bit(static_cast<unsigned char>(base))
+                                        ? static_cast<unsigned char>(std::countr_zero(static_cast<unsigned char>(base)))
+                                        : static_cast<unsigned char>(0);
     bool       at_least_one_digit = false;
     for (; p != end; ++p) {
         const int digit = detail::digit_value(*p);
@@ -2640,8 +2640,7 @@ template <char... digits>
 // https://github.com/llvm/llvm-project/issues/76394
 // clang-format off
 template <char... digits>
-[[nodiscard]] constexpr big_int operator""_n() noexcept(noexcept(operator""n<digits...>()))
-{
+[[nodiscard]] constexpr big_int operator""_n() noexcept(noexcept(operator""n<digits...>())) {
     return operator""n<digits...>();
 }
 // clang-format on

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -2399,9 +2399,9 @@ from_chars(const char* const begin, const char* const end, basic_big_int<b, A>& 
     }
 
     // The number of bits per base digit, or zero if the base is not a power of two.
-    const auto bits_per_digit     = std::has_single_bit(static_cast<unsigned char>(base))
-                                        ? static_cast<unsigned char>(std::countr_zero(static_cast<unsigned char>(base)))
-                                        : static_cast<unsigned char>(0);
+    const auto bits_per_digit = std::has_single_bit(static_cast<unsigned char>(base))
+                                    ? static_cast<unsigned char>(std::countr_zero(static_cast<unsigned char>(base)))
+                                    : static_cast<unsigned char>(0);
     bool       at_least_one_digit = false;
     for (; p != end; ++p) {
         const int digit = detail::digit_value(*p);
@@ -2606,7 +2606,7 @@ BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_MSVC(4455)
 // clang-format off
 template <char... digits>
 [[nodiscard]] constexpr big_int operator""n()
-  noexcept(detail::parse_non_allocating<detail::literal_buffer<digits...>::value>::ec == std::errc{}) 
+  noexcept(detail::parse_non_allocating<detail::literal_buffer<digits...>::value>::ec == std::errc{})
   {
     // clang-format on
 
@@ -2640,7 +2640,7 @@ template <char... digits>
 // https://github.com/llvm/llvm-project/issues/76394
 // clang-format off
 template <char... digits>
-[[nodiscard]] constexpr big_int operator""_n() noexcept(noexcept(operator""n<digits...>())) 
+[[nodiscard]] constexpr big_int operator""_n() noexcept(noexcept(operator""n<digits...>()))
 {
     return operator""n<digits...>();
 }

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -2399,9 +2399,9 @@ from_chars(const char* const begin, const char* const end, basic_big_int<b, A>& 
     }
 
     // The number of bits per base digit, or zero if the base is not a power of two.
-    const auto bits_per_digit     = std::has_single_bit(static_cast<unsigned char>(base))
-                                        ? static_cast<unsigned char>(std::countr_zero(static_cast<unsigned char>(base)))
-                                        : static_cast<unsigned char>(0);
+    const auto bits_per_digit = std::has_single_bit(static_cast<unsigned char>(base))
+                                    ? static_cast<unsigned char>(std::countr_zero(static_cast<unsigned char>(base)))
+                                    : static_cast<unsigned char>(0);
     bool       at_least_one_digit = false;
     for (; p != end; ++p) {
         const int digit = detail::digit_value(*p);

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -4,6 +4,7 @@
 #ifndef BEMAN_BIG_INT_BIG_INT_HPP
 #define BEMAN_BIG_INT_BIG_INT_HPP
 
+#include <array>
 #include <algorithm>
 #include <bit>
 #include <climits>
@@ -2399,9 +2400,9 @@ from_chars(const char* const begin, const char* const end, basic_big_int<b, A>& 
     }
 
     // The number of bits per base digit, or zero if the base is not a power of two.
-    const auto bits_per_digit = std::has_single_bit(static_cast<unsigned char>(base))
-                                    ? static_cast<unsigned char>(std::countr_zero(static_cast<unsigned char>(base)))
-                                    : static_cast<unsigned char>(0);
+    const auto bits_per_digit     = std::has_single_bit(static_cast<unsigned char>(base))
+                                        ? static_cast<unsigned char>(std::countr_zero(static_cast<unsigned char>(base)))
+                                        : static_cast<unsigned char>(0);
     bool       at_least_one_digit = false;
     for (; p != end; ++p) {
         const int digit = detail::digit_value(*p);

--- a/include/beman/big_int/detail/wide_ops.hpp
+++ b/include/beman/big_int/detail/wide_ops.hpp
@@ -292,49 +292,56 @@ struct carry_result {
 
 template <unsigned_integer T>
 [[nodiscard]] constexpr carry_result<T> carrying_add(const T x, const T y, const bool carry = false) noexcept {
-#if BEMAN_BIG_INT_LIMB_WIDTH == 32 && BEMAN_BIG_INT_HAS_BUILTIN(__builtin_addc)
-    unsigned carry_out;
-    unsigned value = __builtin_addc(x, y, carry, &carry_out);
-    return {.value = value, .carry = carry_out != 0};
-#elif BEMAN_BIG_INT_LIMB_WIDTH == 64 && BEMAN_BIG_INT_HAS_BUILTIN(__builtin_addcll)
-    unsigned long long carry_out;
-    unsigned long long value = __builtin_addcll(x, y, carry, &carry_out);
-    return {.value = value, .carry = carry_out != 0};
-#elif defined(BEMAN_BIG_INT_MSVC) && (defined(_M_AMD64) || defined(_M_IX86))
-    // Theoretically we could use the ADX intrinsic, but then the user always has to compile for it
-    // This is more portable.
-    // Each branch returns directly, so we don't share uninitialized state
-    // across the `if constexpr` chain.
+    // None of the intrinsics below are portably constexpr,
+    // so we put everything into a giant if !consteval block.
     if BEMAN_BIG_INT_IS_NOT_CONSTEVAL {
-        if constexpr (std::is_same_v<T, std::uint8_t>) {
-            T                   value;
+
+#if BEMAN_BIG_INT_HAS_BUILTIN(__builtin_addc)
+        if constexpr (width_v<T> == 32) {
+            unsigned carry_out;
+            unsigned value = __builtin_addc(x, y, carry, &carry_out);
+            return {.value = value, .carry = carry_out != 0};
+        }
+#endif
+
+#if BEMAN_BIG_INT_HAS_BUILTIN(__builtin_addcll)
+        if constexpr (width_v<T> == 64) {
+            unsigned long long carry_out;
+            unsigned long long value = __builtin_addcll(x, y, carry, &carry_out);
+            return {.value = value, .carry = carry_out != 0};
+        }
+#endif
+
+#if defined(BEMAN_BIG_INT_MSVC) && (defined(_M_AMD64) || defined(_M_IX86))
+        // Theoretically we could use the ADX intrinsic, but then the user always has to compile for it
+        // This is more portable.
+        // Each branch returns directly, so we don't share uninitialized state
+        // across the `if constexpr` chain.
+        if constexpr (width_v<T> == 8) {
+            std::uint8_t        value;
             const unsigned char carry_out = _addcarry_u8(static_cast<unsigned char>(carry), x, y, &value);
             return {.value = value, .carry = carry_out != 0};
-        } else if constexpr (std::is_same_v<T, std::uint16_t>) {
-            T                   value;
+        } else if constexpr (width_v<T> == 16) {
+            std::uint16_t       value;
             const unsigned char carry_out = _addcarry_u16(static_cast<unsigned char>(carry), x, y, &value);
             return {.value = value, .carry = carry_out != 0};
-        } else if constexpr (std::is_same_v<T, std::uint32_t>) {
-            T                   value;
+        } else if constexpr (width_v<T> == 32) {
+            std::uint32_t       value;
             const unsigned char carry_out = _addcarry_u32(static_cast<unsigned char>(carry), x, y, &value);
             return {.value = value, .carry = carry_out != 0};
         }
     #ifdef _M_AMD64
-        else if constexpr (std::is_same_v<T, std::uint64_t>) {
-            T                   value;
+        else if constexpr (width_v<T> == 64) {
+            std::uint64_t       value;
             const unsigned char carry_out = _addcarry_u64(static_cast<unsigned char>(carry), x, y, &value);
             return {.value = value, .carry = carry_out != 0};
         }
     #endif
+#endif // BEMAN_BIG_INT_GNUC
     }
-    // Fallback: reached at consteval time, or at runtime when `T` has no matching intrinsic.
+
     const auto result = static_cast<wider_t<T>>(x) + static_cast<wider_t<T>>(y) + carry;
     return {.value = static_cast<T>(result), .carry = (result >> width_v<T>) != 0};
-#else
-    auto result    = static_cast<wider_t<T>>(x) + static_cast<wider_t<T>>(y) + carry;
-    bool carry_out = (result >> width_v<T>) != 0;
-    return {.value = static_cast<T>(result), .carry = carry_out};
-#endif // BEMAN_BIG_INT_GNUC
 }
 
 template <class T>
@@ -347,48 +354,55 @@ BEMAN_BIG_INT_DIAGNOSTIC_POP()
 
 template <unsigned_integer T>
 [[nodiscard]] constexpr borrow_result<T> borrowing_sub(const T x, const T y, const bool borrow = false) noexcept {
-#if BEMAN_BIG_INT_LIMB_WIDTH == 32 && BEMAN_BIG_INT_HAS_BUILTIN(__builtin_subc)
-    unsigned borrow_out;
-    unsigned value = __builtin_subc(x, y, borrow, &borrow_out);
-    return {.value = value, .borrow = borrow_out != 0};
-#elif BEMAN_BIG_INT_LIMB_WIDTH == 64 && BEMAN_BIG_INT_HAS_BUILTIN(__builtin_subcll)
-    unsigned long long borrow_out;
-    unsigned long long value = __builtin_subcll(x, y, borrow, &borrow_out);
-    return {.value = value, .borrow = borrow_out != 0};
-#elif defined(BEMAN_BIG_INT_MSVC) && (defined(_M_AMD64) || defined(_M_IX86))
-    // Mirror the `carrying_add` MSVC path using the matching `_subborrow_*` intrinsics.
-    // Each branch returns directly, so we don't share uninitialized state across the
-    // `if constexpr` chain.
+    // None of the intrinsics below are portably constexpr,
+    // so we put everything into a giant if !consteval block.
     if BEMAN_BIG_INT_IS_NOT_CONSTEVAL {
-        if constexpr (std::is_same_v<T, std::uint8_t>) {
-            T                   value;
+
+#if BEMAN_BIG_INT_HAS_BUILTIN(__builtin_subc)
+        if constexpr (width_v<T> == 32) {
+            unsigned borrow_out;
+            unsigned value = __builtin_subc(x, y, borrow, &borrow_out);
+            return {.value = value, .borrow = borrow_out != 0};
+        }
+#endif
+
+#if BEMAN_BIG_INT_HAS_BUILTIN(__builtin_subcll)
+        if constexpr (width_v<T> == 64) {
+            unsigned long long borrow_out;
+            unsigned long long value = __builtin_subcll(x, y, borrow, &borrow_out);
+            return {.value = value, .borrow = borrow_out != 0};
+        }
+#endif
+
+#if defined(BEMAN_BIG_INT_MSVC) && (defined(_M_AMD64) || defined(_M_IX86))
+        // Mirror the `carrying_add` MSVC path using the matching `_subborrow_*` intrinsics.
+        // Each branch returns directly, so we don't share uninitialized state across the
+        // `if constexpr` chain.
+        if constexpr (width_v<T> == 8) {
+            std::uint8_t        value;
             const unsigned char borrow_out = _subborrow_u8(static_cast<unsigned char>(borrow), x, y, &value);
             return {.value = value, .borrow = borrow_out != 0};
-        } else if constexpr (std::is_same_v<T, std::uint16_t>) {
-            T                   value;
+        } else if constexpr (width_v<T> == 16) {
+            std::uint16_t       value;
             const unsigned char borrow_out = _subborrow_u16(static_cast<unsigned char>(borrow), x, y, &value);
             return {.value = value, .borrow = borrow_out != 0};
-        } else if constexpr (std::is_same_v<T, std::uint32_t>) {
-            T                   value;
+        } else if constexpr (width_v<T> == 32) {
+            std::uint32_t       value;
             const unsigned char borrow_out = _subborrow_u32(static_cast<unsigned char>(borrow), x, y, &value);
             return {.value = value, .borrow = borrow_out != 0};
         }
     #ifdef _M_AMD64
-        else if constexpr (std::is_same_v<T, std::uint64_t>) {
-            T                   value;
+        else if constexpr (width_v<T> == 64) {
+            std::uint64_t       value;
             const unsigned char borrow_out = _subborrow_u64(static_cast<unsigned char>(borrow), x, y, &value);
             return {.value = value, .borrow = borrow_out != 0};
         }
     #endif
+#endif
     }
-    // Fallback: reached at consteval time, or at runtime when `T` has no matching intrinsic.
-    const auto result = static_cast<wider_t<T>>(x) - static_cast<wider_t<T>>(y) - borrow;
+
+    auto result = static_cast<wider_t<T>>(x) - static_cast<wider_t<T>>(y) - borrow;
     return {.value = static_cast<T>(result), .borrow = (result >> width_v<T>) != 0};
-#else
-    auto result     = static_cast<wider_t<T>>(x) - static_cast<wider_t<T>>(y) - borrow;
-    bool borrow_out = (result >> width_v<T>) != 0;
-    return {.value = static_cast<T>(result), .borrow = borrow_out};
-#endif // BEMAN_BIG_INT_GNUC
 }
 
 template <signed_or_unsigned T>

--- a/tests/beman/big_int/big_int.test.cpp
+++ b/tests/beman/big_int/big_int.test.cpp
@@ -41,4 +41,7 @@ static_assert(0XFF_n == 255_n);
 static_assert(0b1111_n == 15_n);
 static_assert(0B1111_n == 15_n);
 
+static_assert(1000_n == 1'0'00_n);
+static_assert(1'000'000'000'000'000'000'000'000'000_n == 0x33b'2e3c'9fd0'803c'e800'0000_n);
+
 } // namespace beman::big_int

--- a/tests/beman/big_int/multiplication.test.cpp
+++ b/tests/beman/big_int/multiplication.test.cpp
@@ -47,20 +47,6 @@ consteval bool ce_255() {
 }
 static_assert(ce_255());
 
-consteval bool move_heap_mul() {
-    big_int result{2};
-
-    big_int lhs{2};
-    lhs <<= 155;
-
-    result *= lhs;
-    big_int result2 = std::move(result);
-    result2 *= lhs;
-    result2 += 10;
-    return result2 > big_int{255};
-}
-static_assert(move_heap_mul());
-
 // ----- runtime tests -----
 
 TEST(Multiplication, SmallPositivePositive) {

--- a/tests/beman/big_int/multiplication.test.cpp
+++ b/tests/beman/big_int/multiplication.test.cpp
@@ -47,6 +47,20 @@ consteval bool ce_255() {
 }
 static_assert(ce_255());
 
+consteval bool move_heap_mul() {
+    big_int result{2};
+
+    big_int lhs{2};
+    lhs <<= 155;
+
+    result *= lhs;
+    big_int result2 = std::move(result);
+    result2 *= lhs;
+    result2 += 10;
+    return result2 > big_int{255};
+}
+static_assert(move_heap_mul());
+
 // ----- runtime tests -----
 
 TEST(Multiplication, SmallPositivePositive) {


### PR DESCRIPTION
Fixes #9

This also includes a couple of drive-by changes that were necessary to get the code to run, such as:
- Not using `__builtin_addc` during constant evaluation because it is not `constexpr` on older versions of Clang.
- Fixing some general issues with `carrying_add` and `borrowing_sub`.
- Adding a new constructor that takes iterators, in addition to the `std::from_range` constructor. This is necessary because the `std::from_range` constructor compiles conditionally.