### PR TITLE
Add `eval_bitwise` utility and `cv_unqualified_integral` concept

### DIFF
--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -148,6 +148,19 @@ static_assert(invert(std::strong_ordering::less) == std::strong_ordering::greate
 
 enum struct bitwise_op : unsigned char { and_, or_, xor_ };
 
+template <bitwise_op op, cv_unqualified_integral T>
+[[nodiscard]] constexpr T eval_bitwise(const T x, const T y) noexcept {
+    if constexpr (op == bitwise_op::and_) {
+        return static_cast<T>(x & y);
+    } else if constexpr (op == bitwise_op::or_) {
+        return static_cast<T>(x | y);
+    } else if constexpr (op == bitwise_op::xor_) {
+        return static_cast<T>(x ^ y);
+    } else {
+        static_assert(false, "Unsupported operation.");
+    }
+}
+
 struct access_bypass;
 
 } // namespace detail
@@ -1968,9 +1981,7 @@ template <detail::bitwise_op op, bool neg_left, bool neg_right, std::size_t exte
 constexpr basic_big_int<b, A>
 basic_big_int<b, A>::make_bitwise_of_limbs(const std::span<const uint_multiprecision_t, extent_a> lhs,
                                            const std::span<const uint_multiprecision_t, extent_b> rhs) {
-    constexpr bool res_neg = op == detail::bitwise_op::and_  ? (neg_left && neg_right)
-                             : op == detail::bitwise_op::or_ ? (neg_left || neg_right)
-                                                             : (neg_left != neg_right);
+    constexpr bool res_neg = detail::eval_bitwise<op>(neg_left, neg_right);
     const auto     n       = [&]() -> std::size_t {
         if constexpr (op == detail::bitwise_op::and_) {
             if constexpr (!neg_left && !neg_right) {
@@ -2009,14 +2020,7 @@ basic_big_int<b, A>::make_bitwise_of_limbs(const std::span<const uint_multipreci
             r                 = sum;
             carry_r           = carry;
         }
-        limb_type res;
-        if constexpr (op == detail::bitwise_op::and_) {
-            res = l & r;
-        } else if constexpr (op == detail::bitwise_op::or_) {
-            res = l | r;
-        } else {
-            res = l ^ r;
-        }
+        limb_type res = detail::eval_bitwise<op>(l, r);
         if constexpr (res_neg) {
             res               = ~res;
             auto [sum, carry] = detail::carrying_add(res, limb_type{0}, carry_o);

--- a/include/beman/big_int/detail/config.hpp
+++ b/include/beman/big_int/detail/config.hpp
@@ -211,10 +211,13 @@ concept integral = std::integral<T> || is_bit_int_v<T>;
 using std::integral;
 #endif
 
+template <class T>
+concept cv_unqualified_integral = integral<T> && cv_unqualified<T>;
+
 // Modeled if `T` is a signed or unsigned integer type.
 // That is, a standard integer type, extended integer type, or bit-precise integer type.
 template <class T>
-concept signed_or_unsigned = integral<T> && cv_unqualified<T> //
+concept signed_or_unsigned = cv_unqualified_integral<T> //
                              && !std::is_same_v<T, bool> && !character_type<T>;
 template <class T>
 concept negative_representing = static_cast<T>(-1) < static_cast<T>(0);
@@ -236,8 +239,7 @@ static_assert(signed_integer<_BitInt(32)>);
 // signed or unsigned integer type.
 // For example, this converts `char8_t` to `unsigned char`, `int` to `int`, etc.
 // The goal is to reduce redundant template instantiations.
-template <class T>
-    requires std::integral<T> && cv_unqualified<T>
+template <cv_unqualified_integral T>
 using make_signed_or_unsigned_t =
     std::conditional_t<std::is_signed_v<T>, std::make_signed_t<T>, std::make_unsigned_t<T>>;
 


### PR DESCRIPTION
This may assist in #85 if the implementations of the copying and in-place operators is separate.