### PR TITLE
Add testing utilities for big_int vs cpp_int

### DIFF
--- a/tests/beman/big_int/CMakeLists.txt
+++ b/tests/beman/big_int/CMakeLists.txt
@@ -2,8 +2,24 @@
 # SPDX-License-Identifier: BSL-1.0
 
 include(GoogleTest)
+include(FetchContent)
 
 file(GLOB TEST_SOURCES "*.test.cpp")
+
+# Pull in Boost.Multiprecision for parity tests that cross-check beman::big_int
+# against boost::cpp_int.
+# The standalone release of this library is self-contained
+
+FetchContent_Declare(
+    boost_multiprecision
+    URL
+        https://github.com/boostorg/multiprecision/archive/refs/tags/Boost_1_89_0.tar.gz
+    URL_HASH
+        SHA256=d6000cc58594fead142eee4bf3a1aec39bf144dcb6accd8f4b8e6d780d258482
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    SYSTEM
+)
+FetchContent_MakeAvailable(boost_multiprecision)
 
 foreach(test_source ${TEST_SOURCES})
     get_filename_component(test_name ${test_source} NAME_WE)
@@ -13,7 +29,7 @@ foreach(test_source ${TEST_SOURCES})
     target_sources(${test_target} PRIVATE ${test_source})
     target_link_libraries(
         ${test_target}
-        PRIVATE beman::big_int GTest::gtest_main
+        PRIVATE beman::big_int GTest::gtest_main Boost::multiprecision
     )
     if(
         CMAKE_CXX_COMPILER_ID STREQUAL "GNU"

--- a/tests/beman/big_int/boost_mp_testing.hpp
+++ b/tests/beman/big_int/boost_mp_testing.hpp
@@ -8,11 +8,18 @@
 
 #include <gtest/gtest.h>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 #include <beman/big_int/big_int.hpp>
 
+BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
+BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Warray-bounds") // This causes way too many problems.
+BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Wstringop-overflow")
+BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Wstringop-overread")
+
+#include <boost/multiprecision/cpp_int.hpp>
+
 #include <cstddef>
+#include <format>
+#include <ios>
 #include <random>
 #include <stdexcept>
 #include <string>
@@ -24,13 +31,6 @@ namespace beman::big_int::boost_mp_testing {
 namespace detail {
 
 using cpp_int = ::boost::multiprecision::cpp_int;
-
-// The limb-level comparison assumes both libraries store magnitude in
-// same-width limbs. Both default to 64-bit on platforms with __int128; on a
-// 32-bit-limb build of beman, boost cpp_int would still be 64-bit, and the
-// limb arrays wouldn't line up.
-static_assert(sizeof(uint_multiprecision_t) == sizeof(::boost::multiprecision::limb_type),
-              "Matching limb widths required between beman::big_int and boost::cpp_int for this test helper.");
 
 // Generates a random hex string for a size of exactly `bits` bits,
 // meaning the MSB is 1 (so the value is in [2^(bits-1), 2^bits)).
@@ -83,53 +83,49 @@ inline cpp_int parse_cpp_int(std::string_view signed_hex) {
     return cpp_int{s};
 }
 
-// Trims trailing zero limbs for robust comparison.
-inline std::size_t trimmed_len(const ::beman::big_int::uint_multiprecision_t* limbs, std::size_t n) noexcept {
-    while (n > 1 && limbs[n - 1] == 0) {
+// Canonical lowercase-hex rendering of a beman::big_int. Prints limbs from
+// MSB to LSB, with a leading '-' for negative values. Zero renders as "0".
+// Used both as a hashable canonical form for comparison and for diagnostics.
+inline std::string to_hex(const ::beman::big_int::big_int& bn) {
+    const auto  rep = bn.representation();
+    std::size_t n   = rep.size();
+    while (n > 1 && rep[n - 1] == 0) {
         --n;
     }
-    return n;
+    std::string s;
+    if (bn < 0) {
+        s.push_back('-');
+    }
+    s += std::format("{:x}", rep[n - 1]);
+    constexpr std::size_t limb_hex = sizeof(::beman::big_int::uint_multiprecision_t) * 2;
+    for (std::size_t i = n - 1; i > 0; --i) {
+        s += std::format("{:0{}x}", rep[i - 1], limb_hex);
+    }
+    return s;
 }
 
 // Asserts that a beman::big_int and a boost::cpp_int represent the exact same
-// integer, by comparing:
-//   1) zeroness,
-//   2) sign,
-//   3) trimmed limb arrays.
+// integer. Uses a canonical hex-string roundtrip so the check is independent
+// of the internal limb width used by each library — boost.multiprecision uses
+// 32-bit limbs on platforms without __int128 (e.g. MSVC) while beman uses
+// 64-bit, so a direct limb-by-limb comparison isn't portable.
 [[nodiscard]] inline ::testing::AssertionResult same_value(const ::beman::big_int::big_int& bn, const cpp_int& cp) {
-    const bool bn_zero = (bn == 0);
-    const bool cp_zero = cp.is_zero();
-    if (bn_zero != cp_zero) {
-        return ::testing::AssertionFailure()
-               << "zeroness mismatch: big_int::is_zero=" << bn_zero << " cpp_int::is_zero=" << cp_zero;
+    // cpp_int::str() refuses to render a negative magnitude as hex or octal
+    // ("Base 8 or 16 printing of negative numbers is not supported."), so
+    // print the magnitude of abs(cp) and prepend '-' ourselves when needed.
+    const bool        cp_neg = !cp.is_zero() && cp.backend().sign();
+    const std::string cp_mag = (cp_neg ? cpp_int{-cp} : cp).str(0, std::ios_base::hex);
+    std::string       cp_hex;
+    cp_hex.reserve(cp_mag.size() + 1);
+    if (cp_neg) {
+        cp_hex.push_back('-');
     }
-    if (!bn_zero) {
-        const bool bn_neg = (bn < 0);
-        const bool cp_neg = cp.backend().sign();
-        if (bn_neg != cp_neg) {
-            return ::testing::AssertionFailure()
-                   << "sign mismatch: big_int<0=" << bn_neg << " cpp_int.sign()=" << cp_neg;
-        }
+    cp_hex += cp_mag;
+    const auto expected_bn = parse_big_int(cp_hex);
+    if (bn == expected_bn) {
+        return ::testing::AssertionSuccess();
     }
-
-    const auto        bn_rep  = bn.representation();
-    const auto* const cp_ptr  = cp.backend().limbs();
-    const auto        bn_size = trimmed_len(bn_rep.data(), bn_rep.size());
-    const auto        cp_size = trimmed_len(cp_ptr, cp.backend().size());
-
-    if (bn_size != cp_size) {
-        return ::testing::AssertionFailure()
-               << "trimmed limb count mismatch: big_int=" << bn_size << " cpp_int=" << cp_size;
-    }
-    for (std::size_t i = 0; i < bn_size; ++i) {
-        const auto bn_limb = bn_rep[i];
-        const auto cp_limb = static_cast<::beman::big_int::uint_multiprecision_t>(cp_ptr[i]);
-        if (bn_limb != cp_limb) {
-            return ::testing::AssertionFailure()
-                   << "limb[" << i << "] differs: big_int=" << std::hex << bn_limb << " cpp_int=" << cp_limb;
-        }
-    }
-    return ::testing::AssertionSuccess();
+    return ::testing::AssertionFailure() << "value mismatch: big_int=" << to_hex(bn) << " cpp_int=" << cp_hex;
 }
 
 } // namespace detail
@@ -178,5 +174,7 @@ inline std::string random_big_int(std::size_t bits, bool negative = false) {
 }
 
 } // namespace beman::big_int::boost_mp_testing
+
+BEMAN_BIG_INT_DIAGNOSTIC_POP()
 
 #endif // BEMAN_BIG_INT_TESTS_BOOST_MP_TESTING_HPP

--- a/tests/beman/big_int/boost_mp_testing.hpp
+++ b/tests/beman/big_int/boost_mp_testing.hpp
@@ -97,7 +97,10 @@ inline std::string to_hex(const ::beman::big_int::big_int& bn) {
         s.push_back('-');
     }
     s += std::format("{:x}", rep[n - 1]);
-    constexpr std::size_t limb_hex = sizeof(::beman::big_int::uint_multiprecision_t) * 2;
+    // libstdc++ restricts the dynamic-width argument of std::format to
+    // {int, unsigned, long long, unsigned long long} — std::size_t is
+    // rejected at constant-evaluation time. Pass an int explicitly.
+    constexpr int limb_hex = static_cast<int>(sizeof(::beman::big_int::uint_multiprecision_t) * 2);
     for (std::size_t i = n - 1; i > 0; --i) {
         s += std::format("{:0{}x}", rep[i - 1], limb_hex);
     }

--- a/tests/beman/big_int/boost_mp_testing.hpp
+++ b/tests/beman/big_int/boost_mp_testing.hpp
@@ -63,7 +63,7 @@ inline ::beman::big_int::big_int parse_big_int(std::string_view signed_hex) {
     ::beman::big_int::big_int out;
     const char* const         first = signed_hex.data();
     const char* const         last  = first + signed_hex.size();
-    const auto [p, ec]               = ::beman::big_int::from_chars(first, last, out, 16);
+    const auto [p, ec]              = ::beman::big_int::from_chars(first, last, out, 16);
     if (ec != std::errc{} || p != last) {
         throw std::runtime_error("parse_big_int: from_chars failed to parse hex string");
     }
@@ -107,7 +107,8 @@ inline std::size_t trimmed_len(const ::beman::big_int::uint_multiprecision_t* li
         const bool bn_neg = (bn < 0);
         const bool cp_neg = cp.backend().sign();
         if (bn_neg != cp_neg) {
-            return ::testing::AssertionFailure() << "sign mismatch: big_int<0=" << bn_neg << " cpp_int.sign()=" << cp_neg;
+            return ::testing::AssertionFailure()
+                   << "sign mismatch: big_int<0=" << bn_neg << " cpp_int.sign()=" << cp_neg;
         }
     }
 

--- a/tests/beman/big_int/boost_mp_testing.hpp
+++ b/tests/beman/big_int/boost_mp_testing.hpp
@@ -106,7 +106,7 @@ inline std::string to_hex(const ::beman::big_int::big_int& bn) {
 
 // Asserts that a beman::big_int and a boost::cpp_int represent the exact same
 // integer. Uses a canonical hex-string roundtrip so the check is independent
-// of the internal limb width used by each library — boost.multiprecision uses
+// of the internal limb width used by each library - boost.multiprecision uses
 // 32-bit limbs on platforms without __int128 (e.g. MSVC) while beman uses
 // 64-bit, so a direct limb-by-limb comparison isn't portable.
 [[nodiscard]] inline ::testing::AssertionResult same_value(const ::beman::big_int::big_int& bn, const cpp_int& cp) {
@@ -159,7 +159,7 @@ check_cpp_int_equal(BinOp&& op, std::string_view lhs, std::string_view rhs) {
 // that the sequence is deterministic across runs.
 // The RNG state advances on every call and is shared across all callers of this function.
 inline std::string random_big_int(std::size_t bits, bool negative = false) {
-    // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) — deterministic seed is intentional for test reproducibility.
+    // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) - deterministic seed is intentional for test reproducibility.
     static std::mt19937_64 rng{42};
     if (bits == 0) {
         return std::string{"0"};

--- a/tests/beman/big_int/boost_mp_testing.hpp
+++ b/tests/beman/big_int/boost_mp_testing.hpp
@@ -112,8 +112,8 @@ using cpp_int = ::boost::multiprecision::cpp_int;
     }
 
     const std::span<const ::boost::multiprecision::limb_type> cp_rep{cp.backend().limbs(), cp.backend().size()};
-    const auto bn_bytes = std::as_bytes(bn.representation());
-    const auto cp_bytes = std::as_bytes(cp_rep);
+    const auto                                                bn_bytes = std::as_bytes(bn.representation());
+    const auto                                                cp_bytes = std::as_bytes(cp_rep);
 
     const auto bn_sig = significant_byte_len(bn_bytes);
     const auto cp_sig = significant_byte_len(cp_bytes);

--- a/tests/beman/big_int/boost_mp_testing.hpp
+++ b/tests/beman/big_int/boost_mp_testing.hpp
@@ -18,9 +18,9 @@ BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Wstringop-overread")
 #include <boost/multiprecision/cpp_int.hpp>
 
 #include <cstddef>
-#include <format>
 #include <ios>
 #include <random>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -35,7 +35,7 @@ using cpp_int = ::boost::multiprecision::cpp_int;
 // Generates a random hex string for a size of exactly `bits` bits,
 // meaning the MSB is 1 (so the value is in [2^(bits-1), 2^bits)).
 // `bits == 0` returns "0".
-inline std::string random_hex_of_bits(std::mt19937_64& rng, std::size_t bits) {
+[[nodiscard]] inline std::string random_hex_of_bits(std::mt19937_64& rng, std::size_t bits) {
     static constexpr char table[] = "0123456789abcdef";
     if (bits == 0) {
         return std::string{"0"};
@@ -59,7 +59,7 @@ inline std::string random_hex_of_bits(std::mt19937_64& rng, std::size_t bits) {
 }
 
 // Parses a signed hex string (e.g. "deadbeef" or "-deadbeef"; no "0x" prefix) into a beman::big_int.
-inline ::beman::big_int::big_int parse_big_int(std::string_view signed_hex) {
+[[nodiscard]] inline ::beman::big_int::big_int parse_big_int(std::string_view signed_hex) {
     ::beman::big_int::big_int out;
     const char* const         first = signed_hex.data();
     const char* const         last  = first + signed_hex.size();
@@ -71,7 +71,7 @@ inline ::beman::big_int::big_int parse_big_int(std::string_view signed_hex) {
 }
 
 // Parses a signed hex string (e.g. "deadbeef" or "-deadbeef"; no "0x" prefix) into a boost cpp_int.
-inline cpp_int parse_cpp_int(std::string_view signed_hex) {
+[[nodiscard]] inline cpp_int parse_cpp_int(std::string_view signed_hex) {
     std::string s;
     s.reserve(signed_hex.size() + 3);
     if (!signed_hex.empty() && signed_hex.front() == '-') {
@@ -83,52 +83,53 @@ inline cpp_int parse_cpp_int(std::string_view signed_hex) {
     return cpp_int{s};
 }
 
-// Canonical lowercase-hex rendering of a beman::big_int. Prints limbs from
-// MSB to LSB, with a leading '-' for negative values. Zero renders as "0".
-// Used both as a hashable canonical form for comparison and for diagnostics.
-inline std::string to_hex(const ::beman::big_int::big_int& bn) {
-    const auto  rep = bn.representation();
-    std::size_t n   = rep.size();
-    while (n > 1 && rep[n - 1] == 0) {
+// Returns the number of bytes before the trailing run of zero bytes.
+[[nodiscard]] inline std::size_t significant_byte_len(std::span<const std::byte> bytes) noexcept {
+    std::size_t n = bytes.size();
+    while (n > 0 && bytes[n - 1] == std::byte{0}) {
         --n;
     }
-    std::string s;
-    if (bn < 0) {
-        s.push_back('-');
-    }
-    s += std::format("{:x}", rep[n - 1]);
-    // libstdc++ restricts the dynamic-width argument of std::format to
-    // {int, unsigned, long long, unsigned long long} — std::size_t is
-    // rejected at constant-evaluation time. Pass an int explicitly.
-    constexpr int limb_hex = static_cast<int>(sizeof(::beman::big_int::uint_multiprecision_t) * 2);
-    for (std::size_t i = n - 1; i > 0; --i) {
-        s += std::format("{:0{}x}", rep[i - 1], limb_hex);
-    }
-    return s;
+    return n;
 }
 
-// Asserts that a beman::big_int and a boost::cpp_int represent the exact same
-// integer. Uses a canonical hex-string roundtrip so the check is independent
-// of the internal limb width used by each library - boost.multiprecision uses
-// 32-bit limbs on platforms without __int128 (e.g. MSVC) while beman uses
-// 64-bit, so a direct limb-by-limb comparison isn't portable.
+// Asserts that a beman::big_int and a boost::cpp_int represent the same integer.
+// Compares sign + zeroness directly, then compares magnitudes via std::as_bytes.
+// Both libraries store limbs in little endian order,
+// so the byte sequences are identical regardless of limb width
 [[nodiscard]] inline ::testing::AssertionResult same_value(const ::beman::big_int::big_int& bn, const cpp_int& cp) {
-    // cpp_int::str() refuses to render a negative magnitude as hex or octal
-    // ("Base 8 or 16 printing of negative numbers is not supported."), so
-    // print the magnitude of abs(cp) and prepend '-' ourselves when needed.
-    const bool        cp_neg = !cp.is_zero() && cp.backend().sign();
-    const std::string cp_mag = (cp_neg ? cpp_int{-cp} : cp).str(0, std::ios_base::hex);
-    std::string       cp_hex;
-    cp_hex.reserve(cp_mag.size() + 1);
-    if (cp_neg) {
-        cp_hex.push_back('-');
+    const bool bn_zero = (bn == 0);
+    const bool cp_zero = cp.is_zero();
+    if (bn_zero != cp_zero) {
+        return ::testing::AssertionFailure()
+               << "zeroness mismatch: big_int::is_zero=" << bn_zero << " cpp_int::is_zero=" << cp_zero;
     }
-    cp_hex += cp_mag;
-    const auto expected_bn = parse_big_int(cp_hex);
-    if (bn == expected_bn) {
-        return ::testing::AssertionSuccess();
+    if (!bn_zero) {
+        const bool bn_neg = (bn < 0);
+        const bool cp_neg = cp.backend().sign();
+        if (bn_neg != cp_neg) {
+            return ::testing::AssertionFailure() << "sign mismatch: big_int<0=" << bn_neg << " cpp_int.sign()=" << cp_neg;
+        }
     }
-    return ::testing::AssertionFailure() << "value mismatch: big_int=" << to_hex(bn) << " cpp_int=" << cp_hex;
+
+    const std::span<const ::boost::multiprecision::limb_type> cp_rep{cp.backend().limbs(), cp.backend().size()};
+    const auto bn_bytes = std::as_bytes(bn.representation());
+    const auto cp_bytes = std::as_bytes(cp_rep);
+
+    const auto bn_sig = significant_byte_len(bn_bytes);
+    const auto cp_sig = significant_byte_len(cp_bytes);
+
+    if (bn_sig != cp_sig) {
+        return ::testing::AssertionFailure()
+               << "significant byte count differs: big_int=" << bn_sig << " cpp_int=" << cp_sig;
+    }
+    for (std::size_t i = 0; i < bn_sig; ++i) {
+        if (bn_bytes[i] != cp_bytes[i]) {
+            return ::testing::AssertionFailure()
+                   << "byte " << i << " differs: big_int=0x" << std::hex << std::to_integer<int>(bn_bytes[i])
+                   << " cpp_int=0x" << std::to_integer<int>(cp_bytes[i]);
+        }
+    }
+    return ::testing::AssertionSuccess();
 }
 
 } // namespace detail
@@ -161,7 +162,7 @@ check_cpp_int_equal(BinOp&& op, std::string_view lhs, std::string_view rhs) {
 // Uses a function-local std::mt19937_64 seeded with the fixed value 42 so
 // that the sequence is deterministic across runs.
 // The RNG state advances on every call and is shared across all callers of this function.
-inline std::string random_big_int(std::size_t bits, bool negative = false) {
+[[nodiscard]] inline std::string random_big_int(std::size_t bits, bool negative = false) {
     // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) - deterministic seed is intentional for test reproducibility.
     static std::mt19937_64 rng{42};
     if (bits == 0) {

--- a/tests/beman/big_int/boost_mp_testing.hpp
+++ b/tests/beman/big_int/boost_mp_testing.hpp
@@ -107,7 +107,8 @@ using cpp_int = ::boost::multiprecision::cpp_int;
         const bool bn_neg = (bn < 0);
         const bool cp_neg = cp.backend().sign();
         if (bn_neg != cp_neg) {
-            return ::testing::AssertionFailure() << "sign mismatch: big_int<0=" << bn_neg << " cpp_int.sign()=" << cp_neg;
+            return ::testing::AssertionFailure()
+                   << "sign mismatch: big_int<0=" << bn_neg << " cpp_int.sign()=" << cp_neg;
         }
     }
 

--- a/tests/beman/big_int/boost_mp_testing.hpp
+++ b/tests/beman/big_int/boost_mp_testing.hpp
@@ -35,7 +35,7 @@ using cpp_int = ::boost::multiprecision::cpp_int;
 // Generates a random hex string for a size of exactly `bits` bits,
 // meaning the MSB is 1 (so the value is in [2^(bits-1), 2^bits)).
 // `bits == 0` returns "0".
-[[nodiscard]] inline std::string random_hex_of_bits(std::mt19937_64& rng, std::size_t bits) {
+[[nodiscard]] inline std::string random_hex_of_bits(std::mt19937_64& rng, const std::size_t bits) {
     static constexpr char table[] = "0123456789abcdef";
     if (bits == 0) {
         return std::string{"0"};
@@ -59,7 +59,7 @@ using cpp_int = ::boost::multiprecision::cpp_int;
 }
 
 // Parses a signed hex string (e.g. "deadbeef" or "-deadbeef"; no "0x" prefix) into a beman::big_int.
-[[nodiscard]] inline ::beman::big_int::big_int parse_big_int(std::string_view signed_hex) {
+[[nodiscard]] inline ::beman::big_int::big_int parse_big_int(const std::string_view signed_hex) {
     ::beman::big_int::big_int out;
     const char* const         first = signed_hex.data();
     const char* const         last  = first + signed_hex.size();
@@ -84,7 +84,7 @@ using cpp_int = ::boost::multiprecision::cpp_int;
 }
 
 // Returns the number of bytes before the trailing run of zero bytes.
-[[nodiscard]] inline std::size_t significant_byte_len(std::span<const std::byte> bytes) noexcept {
+[[nodiscard]] inline std::size_t significant_byte_len(const std::span<const std::byte> bytes) noexcept {
     std::size_t n = bytes.size();
     while (n > 0 && bytes[n - 1] == std::byte{0}) {
         --n;
@@ -144,7 +144,7 @@ using cpp_int = ::boost::multiprecision::cpp_int;
 //     EXPECT_TRUE(check_cpp_int_equal(std::plus<>{}, "deadbeefcafebabe", "1234567890abcdef"));
 template <class BinOp>
 [[nodiscard]] inline ::testing::AssertionResult
-check_cpp_int_equal(BinOp&& op, std::string_view lhs, std::string_view rhs) {
+check_cpp_int_equal(BinOp&& op, const std::string_view lhs, const std::string_view rhs) {
     const auto a_bn = detail::parse_big_int(lhs);
     const auto b_bn = detail::parse_big_int(rhs);
     const auto a_cp = detail::parse_cpp_int(lhs);
@@ -162,7 +162,7 @@ check_cpp_int_equal(BinOp&& op, std::string_view lhs, std::string_view rhs) {
 // Uses a function-local std::mt19937_64 seeded with the fixed value 42 so
 // that the sequence is deterministic across runs.
 // The RNG state advances on every call and is shared across all callers of this function.
-[[nodiscard]] inline std::string random_big_int(std::size_t bits, bool negative = false) {
+[[nodiscard]] inline std::string random_big_int(const std::size_t bits, const bool negative = false) {
     // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) - deterministic seed is intentional for test reproducibility.
     static std::mt19937_64 rng{42};
     if (bits == 0) {

--- a/tests/beman/big_int/boost_mp_testing.hpp
+++ b/tests/beman/big_int/boost_mp_testing.hpp
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: BSL-1.0
+
+#ifndef BEMAN_BIG_INT_TESTS_BOOST_MP_TESTING_HPP
+#define BEMAN_BIG_INT_TESTS_BOOST_MP_TESTING_HPP
+
+#define BOOST_MP_STANDALONE 1
+
+#include <gtest/gtest.h>
+
+#include <boost/multiprecision/cpp_int.hpp>
+
+#include <beman/big_int/big_int.hpp>
+
+#include <cstddef>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+namespace beman::big_int::boost_mp_testing {
+
+namespace detail {
+
+using cpp_int = ::boost::multiprecision::cpp_int;
+
+// The limb-level comparison assumes both libraries store magnitude in
+// same-width limbs. Both default to 64-bit on platforms with __int128; on a
+// 32-bit-limb build of beman, boost cpp_int would still be 64-bit, and the
+// limb arrays wouldn't line up.
+static_assert(sizeof(uint_multiprecision_t) == sizeof(::boost::multiprecision::limb_type),
+              "Matching limb widths required between beman::big_int and boost::cpp_int for this test helper.");
+
+// Generates a random hex string for a size of exactly `bits` bits,
+// meaning the MSB is 1 (so the value is in [2^(bits-1), 2^bits)).
+// `bits == 0` returns "0".
+inline std::string random_hex_of_bits(std::mt19937_64& rng, std::size_t bits) {
+    static constexpr char table[] = "0123456789abcdef";
+    if (bits == 0) {
+        return std::string{"0"};
+    }
+
+    const std::size_t num_hex  = (bits + 3) / 4;
+    const std::size_t top_bits = bits - (num_hex - 1) * 4; // 1..4
+
+    std::string s;
+    s.reserve(num_hex);
+
+    const unsigned                          top_high = 1u << (top_bits - 1);
+    std::uniform_int_distribution<unsigned> top_rand(0, top_high - 1);
+    s.push_back(table[top_high | top_rand(rng)]);
+
+    std::uniform_int_distribution<unsigned> any(0, 15);
+    for (std::size_t i = 1; i < num_hex; ++i) {
+        s.push_back(table[any(rng)]);
+    }
+    return s;
+}
+
+// Parses a signed hex string (e.g. "deadbeef" or "-deadbeef"; no "0x" prefix) into a beman::big_int.
+inline ::beman::big_int::big_int parse_big_int(std::string_view signed_hex) {
+    ::beman::big_int::big_int out;
+    const char* const         first = signed_hex.data();
+    const char* const         last  = first + signed_hex.size();
+    const auto [p, ec]               = ::beman::big_int::from_chars(first, last, out, 16);
+    if (ec != std::errc{} || p != last) {
+        throw std::runtime_error("parse_big_int: from_chars failed to parse hex string");
+    }
+    return out;
+}
+
+// Parses a signed hex string (e.g. "deadbeef" or "-deadbeef"; no "0x" prefix) into a boost cpp_int.
+inline cpp_int parse_cpp_int(std::string_view signed_hex) {
+    std::string s;
+    s.reserve(signed_hex.size() + 3);
+    if (!signed_hex.empty() && signed_hex.front() == '-') {
+        s.push_back('-');
+        signed_hex.remove_prefix(1);
+    }
+    s += "0x";
+    s += signed_hex;
+    return cpp_int{s};
+}
+
+// Trims trailing zero limbs for robust comparison.
+inline std::size_t trimmed_len(const ::beman::big_int::uint_multiprecision_t* limbs, std::size_t n) noexcept {
+    while (n > 1 && limbs[n - 1] == 0) {
+        --n;
+    }
+    return n;
+}
+
+// Asserts that a beman::big_int and a boost::cpp_int represent the exact same
+// integer, by comparing:
+//   1) zeroness,
+//   2) sign,
+//   3) trimmed limb arrays.
+[[nodiscard]] inline ::testing::AssertionResult same_value(const ::beman::big_int::big_int& bn, const cpp_int& cp) {
+    const bool bn_zero = (bn == 0);
+    const bool cp_zero = cp.is_zero();
+    if (bn_zero != cp_zero) {
+        return ::testing::AssertionFailure()
+               << "zeroness mismatch: big_int::is_zero=" << bn_zero << " cpp_int::is_zero=" << cp_zero;
+    }
+    if (!bn_zero) {
+        const bool bn_neg = (bn < 0);
+        const bool cp_neg = cp.backend().sign();
+        if (bn_neg != cp_neg) {
+            return ::testing::AssertionFailure() << "sign mismatch: big_int<0=" << bn_neg << " cpp_int.sign()=" << cp_neg;
+        }
+    }
+
+    const auto        bn_rep  = bn.representation();
+    const auto* const cp_ptr  = cp.backend().limbs();
+    const auto        bn_size = trimmed_len(bn_rep.data(), bn_rep.size());
+    const auto        cp_size = trimmed_len(cp_ptr, cp.backend().size());
+
+    if (bn_size != cp_size) {
+        return ::testing::AssertionFailure()
+               << "trimmed limb count mismatch: big_int=" << bn_size << " cpp_int=" << cp_size;
+    }
+    for (std::size_t i = 0; i < bn_size; ++i) {
+        const auto bn_limb = bn_rep[i];
+        const auto cp_limb = static_cast<::beman::big_int::uint_multiprecision_t>(cp_ptr[i]);
+        if (bn_limb != cp_limb) {
+            return ::testing::AssertionFailure()
+                   << "limb[" << i << "] differs: big_int=" << std::hex << bn_limb << " cpp_int=" << cp_limb;
+        }
+    }
+    return ::testing::AssertionSuccess();
+}
+
+} // namespace detail
+
+// Applies `op` to each backend after parsing `lhs` and `rhs` as signed hex
+// strings (leading '-' allowed; no "0x" prefix), then asserts the two results
+// match bit-for-bit. `op` must be a generic callable that accepts two
+// integers of either library type, e.g. `std::plus<>{}`, `std::minus<>{}`,
+// `std::multiplies<>{}`, or a user lambda.
+//
+// Example:
+//     EXPECT_TRUE(check_cpp_int_equal(std::plus<>{}, "deadbeefcafebabe", "1234567890abcdef"));
+template <class BinOp>
+[[nodiscard]] inline ::testing::AssertionResult
+check_cpp_int_equal(BinOp&& op, std::string_view lhs, std::string_view rhs) {
+    const auto a_bn = detail::parse_big_int(lhs);
+    const auto b_bn = detail::parse_big_int(rhs);
+    const auto a_cp = detail::parse_cpp_int(lhs);
+    const auto b_cp = detail::parse_cpp_int(rhs);
+    return detail::same_value(op(a_bn, b_bn), op(a_cp, b_cp));
+}
+
+// Returns a signed hex string representing a random integer whose magnitude
+// has exactly `bits` bits (the MSB is set).
+// If `negative` is true, the returned string is prefixed with '-'. `bits == 0` returns "0".
+//
+// The intended use is to feed the result directly into `check_cpp_int_equal`:
+//     EXPECT_TRUE(check_cpp_int_equal(std::plus<>{}, random_big_int(1024), random_big_int(1024)));
+//
+// Uses a function-local std::mt19937_64 seeded with the fixed value 42 so
+// that the sequence is deterministic across runs.
+// The RNG state advances on every call and is shared across all callers of this function.
+inline std::string random_big_int(std::size_t bits, bool negative = false) {
+    // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) — deterministic seed is intentional for test reproducibility.
+    static std::mt19937_64 rng{42};
+    if (bits == 0) {
+        return std::string{"0"};
+    }
+    std::string signed_hex;
+    signed_hex.reserve(((bits + 3) / 4) + 1);
+    if (negative) {
+        signed_hex.push_back('-');
+    }
+    signed_hex += detail::random_hex_of_bits(rng, bits);
+    return signed_hex;
+}
+
+} // namespace beman::big_int::boost_mp_testing
+
+#endif // BEMAN_BIG_INT_TESTS_BOOST_MP_TESTING_HPP

--- a/tests/beman/big_int/vs_cpp_int.test.cpp
+++ b/tests/beman/big_int/vs_cpp_int.test.cpp
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: BSL-1.0
+
+#include "boost_mp_testing.hpp"
+
+#include <cstddef>
+#include <functional>
+
+namespace {
+
+namespace bmp = ::beman::big_int::boost_mp_testing;
+using bmp::check_cpp_int_equal;
+using bmp::random_big_int;
+
+// ----- specific-value tests -----
+//
+// Good for pinning down regressions at known-interesting inputs
+// (all-ones magnitudes, single bits high up, values that straddle a limb
+// boundary, etc.) without relying on the random sweep to happen to hit them.
+
+TEST(VsCppInt, AddSpecific) {
+    EXPECT_TRUE(check_cpp_int_equal(std::plus<>{}, "1", "1"));
+    EXPECT_TRUE(check_cpp_int_equal(std::plus<>{}, "ffffffffffffffff", "1"));                  // limb carry out
+    EXPECT_TRUE(check_cpp_int_equal(std::plus<>{}, "ffffffffffffffffffffffffffffffff", "1"));  // two-limb carry out
+    EXPECT_TRUE(check_cpp_int_equal(std::plus<>{}, "-deadbeef", "deadbeef"));                  // cancel to zero
+    EXPECT_TRUE(check_cpp_int_equal(std::plus<>{},
+                                    "deadbeefcafebabef00dfacec0ffee1234567890abcdef",
+                                    "1234567890abcdeffedcba9876543210"));
+}
+
+TEST(VsCppInt, SubSpecific) {
+    EXPECT_TRUE(check_cpp_int_equal(std::minus<>{}, "1", "1"));
+    EXPECT_TRUE(check_cpp_int_equal(std::minus<>{}, "10000000000000000", "1"));  // borrow through limb
+    EXPECT_TRUE(check_cpp_int_equal(std::minus<>{}, "1", "10000000000000000"));  // negative result
+    EXPECT_TRUE(check_cpp_int_equal(std::minus<>{}, "-ffffffff", "-ffffffff")); // negative cancel
+    EXPECT_TRUE(check_cpp_int_equal(std::minus<>{},
+                                    "deadbeefcafebabef00dfacec0ffee1234567890abcdef",
+                                    "1234567890abcdeffedcba9876543210"));
+}
+
+TEST(VsCppInt, MulSpecific) {
+    EXPECT_TRUE(check_cpp_int_equal(std::multiplies<>{}, "0", "deadbeef"));
+    EXPECT_TRUE(check_cpp_int_equal(std::multiplies<>{}, "ffffffff", "ffffffff"));
+    EXPECT_TRUE(check_cpp_int_equal(std::multiplies<>{}, "ffffffffffffffff", "ffffffffffffffff"));
+    EXPECT_TRUE(check_cpp_int_equal(std::multiplies<>{}, "-abcdef", "123456"));
+    EXPECT_TRUE(check_cpp_int_equal(std::multiplies<>{},
+                                    "deadbeefcafebabef00dfacec0ffee1234567890abcdef",
+                                    "1234567890abcdeffedcba9876543210"));
+}
+
+// ----- random parity sweep -----
+//
+// Bit widths chosen to exercise a spread of limb counts:
+//   32 bits -> single small limb
+//  160 bits -> a few limbs
+//  800 bits -> ~13 limbs, result of mul spans ~26 limbs
+// 2000 bits -> large multi-limb, clearly heap-allocated
+
+constexpr std::size_t kBitWidths[]   = {32, 160, 800, 2000};
+constexpr std::size_t kTrialsPerSize = 25;
+
+template <class BinOp>
+void run_parity_sweep(BinOp op) {
+    for (const std::size_t lhs_bits : kBitWidths) {
+        for (const std::size_t rhs_bits : kBitWidths) {
+            for (std::size_t trial = 0; trial < kTrialsPerSize; ++trial) {
+                const bool lhs_neg = (trial & 0b01) != 0;
+                const bool rhs_neg = (trial & 0b10) != 0;
+                ASSERT_TRUE(
+                    check_cpp_int_equal(op, random_big_int(lhs_bits, lhs_neg), random_big_int(rhs_bits, rhs_neg)))
+                    << "lhs_bits=" << lhs_bits << " rhs_bits=" << rhs_bits << " trial=" << trial;
+            }
+        }
+    }
+}
+
+TEST(VsCppInt, AddRandom) { run_parity_sweep(std::plus<>{}); }
+TEST(VsCppInt, SubRandom) { run_parity_sweep(std::minus<>{}); }
+TEST(VsCppInt, MulRandom) { run_parity_sweep(std::multiplies<>{}); }
+
+// Exercises zero-operand corner cases, which the random sweep is unlikely to
+// hit on its own.
+TEST(VsCppInt, ZeroCornerCases) {
+    EXPECT_TRUE(check_cpp_int_equal(std::plus<>{}, "0", "0"));
+    EXPECT_TRUE(check_cpp_int_equal(std::plus<>{},
+                                    "deadbeefcafebabef00dfacec0ffee1234567890abcdef",
+                                    "0"));
+    EXPECT_TRUE(check_cpp_int_equal(std::plus<>{},
+                                    "0",
+                                    "deadbeefcafebabef00dfacec0ffee1234567890abcdef"));
+    EXPECT_TRUE(check_cpp_int_equal(std::minus<>{},
+                                    "deadbeefcafebabef00dfacec0ffee1234567890abcdef",
+                                    "deadbeefcafebabef00dfacec0ffee1234567890abcdef"));
+    EXPECT_TRUE(check_cpp_int_equal(std::multiplies<>{},
+                                    "deadbeefcafebabef00dfacec0ffee1234567890abcdef",
+                                    "0"));
+}
+
+} // namespace

--- a/tests/beman/big_int/vs_cpp_int.test.cpp
+++ b/tests/beman/big_int/vs_cpp_int.test.cpp
@@ -20,22 +20,20 @@ using bmp::random_big_int;
 
 TEST(VsCppInt, AddSpecific) {
     EXPECT_TRUE(check_cpp_int_equal(std::plus<>{}, "1", "1"));
-    EXPECT_TRUE(check_cpp_int_equal(std::plus<>{}, "ffffffffffffffff", "1"));                  // limb carry out
-    EXPECT_TRUE(check_cpp_int_equal(std::plus<>{}, "ffffffffffffffffffffffffffffffff", "1"));  // two-limb carry out
-    EXPECT_TRUE(check_cpp_int_equal(std::plus<>{}, "-deadbeef", "deadbeef"));                  // cancel to zero
-    EXPECT_TRUE(check_cpp_int_equal(std::plus<>{},
-                                    "deadbeefcafebabef00dfacec0ffee1234567890abcdef",
-                                    "1234567890abcdeffedcba9876543210"));
+    EXPECT_TRUE(check_cpp_int_equal(std::plus<>{}, "ffffffffffffffff", "1"));                 // limb carry out
+    EXPECT_TRUE(check_cpp_int_equal(std::plus<>{}, "ffffffffffffffffffffffffffffffff", "1")); // two-limb carry out
+    EXPECT_TRUE(check_cpp_int_equal(std::plus<>{}, "-deadbeef", "deadbeef"));                 // cancel to zero
+    EXPECT_TRUE(check_cpp_int_equal(
+        std::plus<>{}, "deadbeefcafebabef00dfacec0ffee1234567890abcdef", "1234567890abcdeffedcba9876543210"));
 }
 
 TEST(VsCppInt, SubSpecific) {
     EXPECT_TRUE(check_cpp_int_equal(std::minus<>{}, "1", "1"));
-    EXPECT_TRUE(check_cpp_int_equal(std::minus<>{}, "10000000000000000", "1"));  // borrow through limb
-    EXPECT_TRUE(check_cpp_int_equal(std::minus<>{}, "1", "10000000000000000"));  // negative result
+    EXPECT_TRUE(check_cpp_int_equal(std::minus<>{}, "10000000000000000", "1")); // borrow through limb
+    EXPECT_TRUE(check_cpp_int_equal(std::minus<>{}, "1", "10000000000000000")); // negative result
     EXPECT_TRUE(check_cpp_int_equal(std::minus<>{}, "-ffffffff", "-ffffffff")); // negative cancel
-    EXPECT_TRUE(check_cpp_int_equal(std::minus<>{},
-                                    "deadbeefcafebabef00dfacec0ffee1234567890abcdef",
-                                    "1234567890abcdeffedcba9876543210"));
+    EXPECT_TRUE(check_cpp_int_equal(
+        std::minus<>{}, "deadbeefcafebabef00dfacec0ffee1234567890abcdef", "1234567890abcdeffedcba9876543210"));
 }
 
 TEST(VsCppInt, MulSpecific) {
@@ -43,9 +41,8 @@ TEST(VsCppInt, MulSpecific) {
     EXPECT_TRUE(check_cpp_int_equal(std::multiplies<>{}, "ffffffff", "ffffffff"));
     EXPECT_TRUE(check_cpp_int_equal(std::multiplies<>{}, "ffffffffffffffff", "ffffffffffffffff"));
     EXPECT_TRUE(check_cpp_int_equal(std::multiplies<>{}, "-abcdef", "123456"));
-    EXPECT_TRUE(check_cpp_int_equal(std::multiplies<>{},
-                                    "deadbeefcafebabef00dfacec0ffee1234567890abcdef",
-                                    "1234567890abcdeffedcba9876543210"));
+    EXPECT_TRUE(check_cpp_int_equal(
+        std::multiplies<>{}, "deadbeefcafebabef00dfacec0ffee1234567890abcdef", "1234567890abcdeffedcba9876543210"));
 }
 
 // ----- random parity sweep -----
@@ -82,18 +79,12 @@ TEST(VsCppInt, MulRandom) { run_parity_sweep(std::multiplies<>{}); }
 // hit on its own.
 TEST(VsCppInt, ZeroCornerCases) {
     EXPECT_TRUE(check_cpp_int_equal(std::plus<>{}, "0", "0"));
-    EXPECT_TRUE(check_cpp_int_equal(std::plus<>{},
-                                    "deadbeefcafebabef00dfacec0ffee1234567890abcdef",
-                                    "0"));
-    EXPECT_TRUE(check_cpp_int_equal(std::plus<>{},
-                                    "0",
-                                    "deadbeefcafebabef00dfacec0ffee1234567890abcdef"));
+    EXPECT_TRUE(check_cpp_int_equal(std::plus<>{}, "deadbeefcafebabef00dfacec0ffee1234567890abcdef", "0"));
+    EXPECT_TRUE(check_cpp_int_equal(std::plus<>{}, "0", "deadbeefcafebabef00dfacec0ffee1234567890abcdef"));
     EXPECT_TRUE(check_cpp_int_equal(std::minus<>{},
                                     "deadbeefcafebabef00dfacec0ffee1234567890abcdef",
                                     "deadbeefcafebabef00dfacec0ffee1234567890abcdef"));
-    EXPECT_TRUE(check_cpp_int_equal(std::multiplies<>{},
-                                    "deadbeefcafebabef00dfacec0ffee1234567890abcdef",
-                                    "0"));
+    EXPECT_TRUE(check_cpp_int_equal(std::multiplies<>{}, "deadbeefcafebabef00dfacec0ffee1234567890abcdef", "0"));
 }
 
 } // namespace


### PR DESCRIPTION
Intention is that you can do:

```c++
EXPECT_TRUE(check_cpp_int_equal(std::plus<>{}, random_big_int(1024), random_big_int(1024)));
```

Or whichever op you want, and it will automatically compare the values in the background. `random_big_int` takes two arguments, number of bits, and sign following signbit convention.

CC: @ckormanyos 