### PR TITLE
Deep Mersenne test and order of complexity

### DIFF
--- a/tests/beman/big_int/karatsuba_mersenne.test.cpp
+++ b/tests/beman/big_int/karatsuba_mersenne.test.cpp
@@ -60,9 +60,10 @@ auto run_one_mersenne(const unsigned p2) -> void {
     const big_int_type big_int_two{2};
     const big_int_type big_int_mersenne{big_int_type{local::pow(big_int_two, p2)} - 1};
 
-    const std::span<const ::boost::multiprecision::limb_type> cpp_int_rep{cpp_int_mersenne.backend().limbs(), cpp_int_mersenne.backend().size()};
-    const auto                                                big_int_bytes = std::as_bytes(big_int_mersenne.representation());
-    const auto                                                cpp_int_bytes = std::as_bytes(cpp_int_rep);
+    const std::span<const ::boost::multiprecision::limb_type> cpp_int_rep{cpp_int_mersenne.backend().limbs(),
+                                                                          cpp_int_mersenne.backend().size()};
+    const auto big_int_bytes = std::as_bytes(big_int_mersenne.representation());
+    const auto cpp_int_bytes = std::as_bytes(cpp_int_rep);
 
     const auto big_int_sig = local::significant_byte_len(big_int_bytes);
     const auto cpp_int_sig = local::significant_byte_len(cpp_int_bytes);

--- a/tests/beman/big_int/karatsuba_mersenne.test.cpp
+++ b/tests/beman/big_int/karatsuba_mersenne.test.cpp
@@ -92,12 +92,10 @@ auto run_one_mersenne(const unsigned p2) -> void {
     EXPECT_EQ(result_is_ok, true);
 }
 
-// Note: We test millonns of decimal digits, since
-// 2^15317227 - 1 approx 5.989550289491989*10^4610944
-
+// Note: We test millons of decimal digits, since
 // Mathematica:
-// 2^1398269 - 1
-// IntegerString[%, 16]
+//   N[2^20996011 - 1]
+//   1.259768954503301*10^6320429
 
 constexpr std::array<unsigned, std::size_t{7}> my_mersenne_powers_of_two{
     1257787U, 1398269U, 2976221U, 3021377U, 6972593U, 13466917U, 20996011U};

--- a/tests/beman/big_int/karatsuba_mersenne.test.cpp
+++ b/tests/beman/big_int/karatsuba_mersenne.test.cpp
@@ -1,0 +1,136 @@
+
+#include <beman/big_int/big_int.hpp>
+
+#include <gtest/gtest.h>
+
+#include <boost/multiprecision/cpp_int.hpp>
+
+#include <array>
+#include <span>
+
+namespace local {
+
+template<typename IntegralType>
+constexpr auto pow(const IntegralType& b, unsigned p) -> IntegralType {
+    using local_integer_type = IntegralType;
+
+    // Calculate (b ^ p).
+
+    local_integer_type result{1};
+
+    local_integer_type y{b};
+
+    while (p != 0U) {
+        if (static_cast<unsigned>(p & 1U) != 0U) {
+            result *= y;
+        }
+
+        y = y *= y;
+
+        p >>= 1U;
+    }
+
+    return result;
+}
+
+// Returns the number of bytes before the trailing run of zero bytes.
+[[nodiscard]] inline auto significant_byte_len(const std::span<const std::byte> bytes) noexcept -> std::size_t {
+    std::size_t n = bytes.size();
+    while (n > 0 && bytes[n - 1] == std::byte{0}) {
+        --n;
+    }
+    return n;
+}
+
+auto run_one_mersenne(const unsigned p2) -> void {
+    using cpp_int_type = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<>, boost::multiprecision::et_off>;
+    using big_int_type = beman::big_int::big_int;
+
+    // Mersenne prime (2^1398269 - 1) approx. 8.147175644125731*10^420920
+
+    // Mathematica:
+    //
+    // 2^1398269 - 1
+    // N[%]
+
+    const cpp_int_type cpp_int_two{2};
+    const cpp_int_type cpp_int_mersenne{cpp_int_type{local::pow(cpp_int_two, p2)} - 1};
+
+    const big_int_type big_int_two{2};
+    const big_int_type big_int_mersenne{big_int_type{local::pow(big_int_two, p2)} - 1};
+
+    const std::span<const ::boost::multiprecision::limb_type> cpp_int_rep{cpp_int_mersenne.backend().limbs(), cpp_int_mersenne.backend().size()};
+    const auto                                                big_int_bytes = std::as_bytes(big_int_mersenne.representation());
+    const auto                                                cpp_int_bytes = std::as_bytes(cpp_int_rep);
+
+    const auto big_int_sig = local::significant_byte_len(big_int_bytes);
+    const auto cpp_int_sig = local::significant_byte_len(cpp_int_bytes);
+
+    const bool result_length_is_ok{big_int_sig == cpp_int_sig};
+
+    EXPECT_EQ(result_length_is_ok, true);
+
+    bool result_is_ok{result_length_is_ok};
+
+    bool result_bytes_same_is_ok{false};
+
+    if (result_is_ok) {
+        for (std::size_t i = 0; i < big_int_sig; ++i)
+        {
+            if (big_int_bytes[i] != cpp_int_bytes[i]) {
+                result_bytes_same_is_ok = false;
+                break;
+            }
+            else {
+                result_bytes_same_is_ok = true;
+            }
+        }
+    }
+
+    EXPECT_EQ(result_bytes_same_is_ok, true);
+
+    result_is_ok = (result_bytes_same_is_ok && result_is_ok);
+
+    EXPECT_EQ(result_is_ok, true);
+}
+
+// Note: We test millonns of decimal digits, since
+// 2^15317227 - 1 approx 5.989550289491989*10^4610944
+
+// Mathematica:
+// 2^1398269 - 1
+// IntegerString[%, 16]
+
+constexpr std::array<unsigned, std::size_t{7}>
+    my_mersenne_powers_of_two{1257787U, 1398269U, 2976221U, 3021377U, 6972593U, 13466917U, 20996011U};
+} // namespace local
+
+// See also https://oeis.org/A057429 sequencs of Mersenne primes.
+
+TEST(Multiplication, KaratsubaMersenne00) {
+  local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{0}]);
+}
+
+TEST(Multiplication, KaratsubaMersenne01) {
+  local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{1}]);
+}
+
+TEST(Multiplication, KaratsubaMersenne02) {
+  local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{2}]);
+}
+
+TEST(Multiplication, KaratsubaMersenne03) {
+  local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{3}]);
+}
+
+TEST(Multiplication, KaratsubaMersenne04) {
+  local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{4}]);
+}
+
+TEST(Multiplication, KaratsubaMersenne05) {
+  local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{5}]);
+}
+
+TEST(Multiplication, KaratsubaMersenne06) {
+  local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{6}]);
+}

--- a/tests/beman/big_int/karatsuba_mersenne.test.cpp
+++ b/tests/beman/big_int/karatsuba_mersenne.test.cpp
@@ -10,7 +10,7 @@
 
 namespace local {
 
-template<typename IntegralType>
+template <class IntegralType>
 constexpr auto pow(const IntegralType& b, unsigned p) -> IntegralType {
     using local_integer_type = IntegralType;
 
@@ -21,7 +21,7 @@ constexpr auto pow(const IntegralType& b, unsigned p) -> IntegralType {
     local_integer_type y{b};
 
     while (p != 0U) {
-        if (static_cast<unsigned>(p & 1U) != 0U) {
+        if ((p & 1U) != 0U) {
             result *= y;
         }
 
@@ -75,13 +75,11 @@ auto run_one_mersenne(const unsigned p2) -> void {
     bool result_bytes_same_is_ok{false};
 
     if (result_is_ok) {
-        for (std::size_t i = 0; i < big_int_sig; ++i)
-        {
+        for (std::size_t i = 0; i < big_int_sig; ++i) {
             if (big_int_bytes[i] != cpp_int_bytes[i]) {
                 result_bytes_same_is_ok = false;
                 break;
-            }
-            else {
+            } else {
                 result_bytes_same_is_ok = true;
             }
         }
@@ -101,36 +99,36 @@ auto run_one_mersenne(const unsigned p2) -> void {
 // 2^1398269 - 1
 // IntegerString[%, 16]
 
-constexpr std::array<unsigned, std::size_t{7}>
-    my_mersenne_powers_of_two{1257787U, 1398269U, 2976221U, 3021377U, 6972593U, 13466917U, 20996011U};
+constexpr std::array<unsigned, std::size_t{7}> my_mersenne_powers_of_two{
+    1257787U, 1398269U, 2976221U, 3021377U, 6972593U, 13466917U, 20996011U};
 } // namespace local
 
 // See also https://oeis.org/A057429 sequencs of Mersenne primes.
 
 TEST(Multiplication, KaratsubaMersenne00) {
-  local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{0}]);
+    local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{0}]);
 }
 
 TEST(Multiplication, KaratsubaMersenne01) {
-  local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{1}]);
+    local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{1}]);
 }
 
 TEST(Multiplication, KaratsubaMersenne02) {
-  local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{2}]);
+    local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{2}]);
 }
 
 TEST(Multiplication, KaratsubaMersenne03) {
-  local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{3}]);
+    local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{3}]);
 }
 
 TEST(Multiplication, KaratsubaMersenne04) {
-  local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{4}]);
+    local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{4}]);
 }
 
 TEST(Multiplication, KaratsubaMersenne05) {
-  local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{5}]);
+    local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{5}]);
 }
 
 TEST(Multiplication, KaratsubaMersenne06) {
-  local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{6}]);
+    local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{6}]);
 }

--- a/tests/beman/big_int/karatsuba_mersenne.test.cpp
+++ b/tests/beman/big_int/karatsuba_mersenne.test.cpp
@@ -103,7 +103,7 @@ constexpr std::array<unsigned, std::size_t{7}> my_mersenne_powers_of_two{
     1257787U, 1398269U, 2976221U, 3021377U, 6972593U, 13466917U, 20996011U};
 } // namespace local
 
-// See also https://oeis.org/A057429 sequencs of Mersenne primes.
+// See also https://oeis.org/A057429 sequences of Mersenne primes.
 
 TEST(Multiplication, KaratsubaMersenne00) {
     local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{0}]);

--- a/tests/beman/big_int/karatsuba_mersenne.test.cpp
+++ b/tests/beman/big_int/karatsuba_mersenne.test.cpp
@@ -43,7 +43,8 @@ constexpr auto pow(const IntegralType& b, unsigned p) -> IntegralType {
 }
 
 auto run_one_mersenne(const unsigned p2) -> void {
-    using cpp_int_type = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<>, boost::multiprecision::et_off>;
+    using cpp_int_type =
+        boost::multiprecision::number<boost::multiprecision::cpp_int_backend<>, boost::multiprecision::et_off>;
     using big_int_type = beman::big_int::big_int;
 
     // Mersenne prime (2^1398269 - 1) approx. 8.147175644125731*10^420920


### PR DESCRIPTION
Building further on #104 this test adds Mersenne multiplication tests up to several million decimal digits.

It provides verification of our Karatsuba multiplication, also at high digit counts.

It also shows in the gtest time stamps a very nice order of numerical complexity as the digit count grows.

The powers of $2$ in the expression $2^n-1$ include:

```c++
constexpr std::array<unsigned, std::size_t{7}>
    my_mersenne_powers_of_two{1257787U, 1398269U, 2976221U, 3021377U, 6972593U, 13466917U, 20996011U};
```
