### PR TITLE
Make `uint_wide_t` more optional

### DIFF
--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -172,10 +172,13 @@ struct access_bypass;
 template <std::size_t min_inplace_bits, class Allocator>
 class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
 
-    using limb_type               = uint_multiprecision_t;
+    using limb_type        = uint_multiprecision_t;
+    using signed_limb_type = detail::int_multiprecision_t;
+
+#ifdef BEMAN_BIG_INT_HAS_WIDE_INT
     using double_limb_type        = detail::uint_wide_t;
-    using signed_limb_type        = detail::int_multiprecision_t;
     using signed_double_limb_type = detail::int_wide_t;
+#endif
 
   public:
     using allocator_type = Allocator;

--- a/include/beman/big_int/detail/div_impl.hpp
+++ b/include/beman/big_int/detail/div_impl.hpp
@@ -139,6 +139,9 @@ constexpr void divide_unsigned(const std::span<uint_multiprecision_t>       quot
         std::ranges::fill(remainder.subspan(dividend.size()), uint_multiprecision_t{0});
     }
 
+#ifndef BEMAN_BIG_INT_HAS_WIDE_INT
+    #error Sorry, division currently requires uint_wide_t.
+#endif
     // Fast path: 2 limb / 2 limb. Do the whole thing in uint_wide_t.
     if (r_order == 1) {
         // r_order == 1 && divisor.size() >= 2 && divisor.size() <= dividend.size()


### PR DESCRIPTION
I haven't looked close enough at division to figure out how to make `uint_wide_t` optional there.

For `double_limb_type`, it's easy.