### PR TITLE
Improve `to_chars` coverage

### DIFF
--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -2908,13 +2908,15 @@ to_chars(char* const begin, char* const end, const basic_big_int<b, A>& x, const
         if (width <= detail::width_v<uint_multiprecision_t>) {
             // The super happy case is that we can use the std::to_chars implementation for a single limb.
             return std::to_chars(current_begin, end, x.template to<uint_multiprecision_t, ignore_sign>(), base);
-        } else if (width <= detail::width_v<std::uintmax_t>) {
+        } else if constexpr (detail::width_v<uint_multiprecision_t> < detail::width_v<std::uintmax_t>) {
             // The slightly less happy case is that we need to use
             // the multiprecision implementation of `std::to_chars`.
             // While we could skip the previous "super happy" check, it may be cheaper to dispatch here
             // because `std::to_chars` would otherwise need to re-check
             // whether it can delegate to a single-limb implementation itself.
-            return std::to_chars(current_begin, end, x.template to<std::uintmax_t, ignore_sign>(), base);
+            if (width <= detail::width_v<std::uintmax_t>) {
+                return std::to_chars(current_begin, end, x.template to<std::uintmax_t, ignore_sign>(), base);
+            }
         }
     }
 

--- a/tests/beman/big_int/charconv.test.cpp
+++ b/tests/beman/big_int/charconv.test.cpp
@@ -748,4 +748,37 @@ TEST(ToChars, EveryBase_12345678901234567890123456789012345678901122334455667788
 }
 // clang-format on
 
+TEST(ToChars, EmptyRangeValueTooLarge) {
+    const big_int values[]{
+        0,
+        1,
+        -1,
+        255,
+        -255,
+        1_n << 128,
+        -(1_n << 128),
+    };
+    char range;
+    for (const auto& value : values) {
+        for (int base = 2; base < 36; ++base) {
+            const auto [p, ec] = to_chars(&range, &range, value, base);
+            EXPECT_EQ(ec, std::errc::value_too_large);
+        }
+    }
+}
+
+TEST(ToChars, OnlyMinusValueTooLarge) {
+    const big_int values[]{
+        -1,
+        -(1_n << 128),
+    };
+    char range;
+    for (const auto& value : values) {
+        for (int base = 2; base < 36; ++base) {
+            const auto [p, ec] = to_chars(&range, &range + 1, value, base);
+            EXPECT_EQ(ec, std::errc::value_too_large);
+        }
+    }
+}
+
 } // namespace

--- a/tests/beman/big_int/charconv.test.cpp
+++ b/tests/beman/big_int/charconv.test.cpp
@@ -781,4 +781,13 @@ TEST(ToChars, OnlyMinusValueTooLarge) {
     }
 }
 
+TEST(ToChars, HugeValueTooLarge) {
+    const big_int value = 1_n << 128;
+    char          range[8];
+    for (int base = 2; base < 36; ++base) {
+        const auto [p, ec] = to_chars(range, std::end(range), value, base);
+        EXPECT_EQ(ec, std::errc::value_too_large);
+    }
+}
+
 } // namespace


### PR DESCRIPTION
This adds some test for the error handling in `to_chars`.

The `uintmax_t` case is also only instantiated when `uint_multiprecision_t` isn't already as wide, which should also improve coverage data on 64-bit, where `uint_multiprecision_t` and `uintmax_t` are probably the same width anyway.