### PR TITLE
Clean up test assertions

### DIFF
--- a/tests/beman/big_int/.clangd
+++ b/tests/beman/big_int/.clangd
@@ -1,0 +1,2 @@
+Diagnostics:
+  UnusedIncludes: None

--- a/tests/beman/big_int/addition.test.cpp
+++ b/tests/beman/big_int/addition.test.cpp
@@ -8,6 +8,8 @@
 
 #include <beman/big_int/big_int.hpp>
 
+#include "testing.hpp"
+
 namespace {
 
 using beman::big_int::basic_big_int;
@@ -82,10 +84,7 @@ TEST(Addition, CarryOutOfTopLimbPromotesToHeap) {
     const big_int b{1};
     ASSERT_TRUE(a.representation().size() == 1);
     const big_int r = a + b;
-    // Value is 2^64.
-    EXPECT_EQ(r.representation().size(), 2u);
-    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
-    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+    EXPECT_EQ(r, big_int{1} << 64);
     EXPECT_FALSE(r < 0);
     // Storage should have promoted out of inline.
     EXPECT_GT(r.capacity(), 0u);
@@ -105,12 +104,10 @@ TEST(Addition, NoAllocationWhenInlineFits) {
     // the top inline limb), we should not allocate.
     const big_int_256 c{std::numeric_limits<std::uint64_t>::max()};
     const big_int_256 d{1};
-    const big_int_256 s = c + d;
-    // Value is 2^64, which fits in <= 4 inline limbs → no allocation.
+    const big_int_256 s        = c + d;
+    const big_int_256 expected = big_int_256{1} << 64;
     EXPECT_EQ(s.capacity(), 0u);
-    EXPECT_EQ(s.representation().size(), 2u);
-    EXPECT_EQ(s.representation()[0], uint_multiprecision_t{0});
-    EXPECT_EQ(s.representation()[1], uint_multiprecision_t{1});
+    EXPECT_EQ(s, expected);
 }
 
 TEST(Addition, MultiLimbValuesSameSign) {
@@ -118,10 +115,7 @@ TEST(Addition, MultiLimbValuesSameSign) {
     const big_int two_64     = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
     const big_int two_64_alt = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
     const big_int two_65     = two_64 + two_64_alt;
-    // 2^65 = [0, 2] in a 64-bit-limb representation.
-    ASSERT_EQ(two_65.representation().size(), 2u);
-    EXPECT_EQ(two_65.representation()[0], uint_multiprecision_t{0});
-    EXPECT_EQ(two_65.representation()[1], uint_multiprecision_t{2});
+    EXPECT_EQ(two_65, big_int{1} << 65);
 }
 
 TEST(Addition, MultiLimbOppositeSignTrimsLeadingZeros) {
@@ -130,9 +124,7 @@ TEST(Addition, MultiLimbOppositeSignTrimsLeadingZeros) {
     ASSERT_EQ(two_64.representation().size(), 2u);
 
     const big_int r = two_64 + big_int{-1};
-    // The subtraction path must trim the now-zero upper limb.
-    ASSERT_EQ(r.representation().size(), 1u);
-    EXPECT_EQ(r.representation()[0], std::numeric_limits<std::uint64_t>::max());
+    EXPECT_EQ(r, std::numeric_limits<std::uint64_t>::max());
     EXPECT_FALSE(r < 0);
 }
 
@@ -141,8 +133,6 @@ TEST(Addition, MultiLimbSubtractionToZero) {
     const big_int two_64     = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
     const big_int neg_two_64 = -two_64;
     const big_int r          = two_64 + neg_two_64;
-    ASSERT_EQ(r.representation().size(), 1u);
-    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
     EXPECT_EQ(r, 0);
     EXPECT_FALSE(r < 0);
 }
@@ -180,17 +170,14 @@ TEST(Addition, PrimitiveSignedPlusBigInt) {
 TEST(Addition, PrimitiveCarryIntoUpperLimb) {
     // big_int{UINT64_MAX} + 1U must promote to two limbs.
     const big_int r = big_int{std::numeric_limits<std::uint64_t>::max()} + 1U;
-    ASSERT_EQ(r.representation().size(), 2u);
-    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
-    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+    EXPECT_EQ(r, big_int{1} << 64);
 }
 
 TEST(Addition, NegativePrimitiveIntoMultiLimb) {
     // 2^64 + (-1) via primitive operand.
     const big_int two_64 = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
     const big_int r      = two_64 + -1;
-    ASSERT_EQ(r.representation().size(), 1u);
-    EXPECT_EQ(r.representation()[0], std::numeric_limits<std::uint64_t>::max());
+    EXPECT_EQ(r, std::numeric_limits<std::uint64_t>::max());
 }
 
 TEST(Addition, UnequalLengthMultiLimb) {
@@ -198,15 +185,11 @@ TEST(Addition, UnequalLengthMultiLimb) {
     const big_int two_64 = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
     const big_int a      = two_64 + big_int{7};
     const big_int r      = a + big_int{3};
-    ASSERT_EQ(r.representation().size(), 2u);
-    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{10});
-    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+    EXPECT_EQ(r, (big_int{1} << 64) + big_int{10});
 
     // Same but with a negative short operand: (2^64 + 7) + (-3) = 2^64 + 4.
     const big_int r2 = a + big_int{-3};
-    ASSERT_EQ(r2.representation().size(), 2u);
-    EXPECT_EQ(r2.representation()[0], uint_multiprecision_t{4});
-    EXPECT_EQ(r2.representation()[1], uint_multiprecision_t{1});
+    EXPECT_EQ(r2, (big_int{1} << 64) + big_int{4});
 }
 
 // ----- rvalue storage-reuse tests -----
@@ -222,9 +205,7 @@ TEST(Addition, RvalueLhsReusesStorage) {
     ASSERT_GT(a.capacity(), 0u); // heap-allocated
     const big_int r = std::move(a) + big_int{5};
     EXPECT_EQ(r.representation().data(), a_data);
-    ASSERT_EQ(r.representation().size(), 2u);
-    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{5});
-    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+    EXPECT_EQ(r, (big_int{1} << 64) + big_int{5});
 }
 
 TEST(Addition, RvalueRhsReusesStorage) {
@@ -235,9 +216,7 @@ TEST(Addition, RvalueRhsReusesStorage) {
     ASSERT_GT(b.capacity(), 0u);
     const big_int r = small + std::move(b);
     EXPECT_EQ(r.representation().data(), b_data);
-    ASSERT_EQ(r.representation().size(), 2u);
-    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{5});
-    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+    EXPECT_EQ(r, (big_int{1} << 64) + big_int{5});
 }
 
 TEST(Addition, BothRvaluesReusesLhsStorage) {
@@ -249,10 +228,7 @@ TEST(Addition, BothRvaluesReusesLhsStorage) {
     ASSERT_GT(b.capacity(), 0u);
     const big_int r = std::move(a) + std::move(b);
     EXPECT_EQ(r.representation().data(), a_data);
-    // 2 * 2^64 = 2^65 → [0, 2]
-    ASSERT_EQ(r.representation().size(), 2u);
-    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
-    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{2});
+    EXPECT_EQ(r, big_int{1} << 65);
 }
 
 TEST(Addition, RvalueCarryGrowsStorage) {
@@ -261,9 +237,7 @@ TEST(Addition, RvalueCarryGrowsStorage) {
     big_int a = big_int{std::numeric_limits<std::uint64_t>::max()}; // 1 limb, inline
     EXPECT_EQ(a.capacity(), 0u);
     const big_int r = std::move(a) + big_int{1}; // 2^64 requires 2 limbs
-    ASSERT_EQ(r.representation().size(), 2u);
-    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
-    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+    EXPECT_EQ(r, big_int{1} << 64);
 }
 
 TEST(Addition, RvalueCancelToZeroIsPositive) {
@@ -273,8 +247,6 @@ TEST(Addition, RvalueCancelToZeroIsPositive) {
     const big_int r = std::move(a) + b;
     EXPECT_EQ(r, 0);
     EXPECT_FALSE(r < 0);
-    ASSERT_EQ(r.representation().size(), 1u);
-    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
 }
 
 TEST(Addition, RvalueLhsSmallerMagnitudeThanRhs) {
@@ -294,18 +266,14 @@ TEST(Addition, RvaluePrimitiveMix) {
     const auto*   a_data = a.representation().data();
     const big_int r      = std::move(a) + 5U;
     EXPECT_EQ(r.representation().data(), a_data);
-    ASSERT_EQ(r.representation().size(), 2u);
-    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{5});
-    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+    EXPECT_EQ(r, (big_int{1} << 64) + big_int{5});
 
     // primitive + rvalue big_int: should reuse rhs.
     big_int       b      = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
     const auto*   b_data = b.representation().data();
     const big_int r2     = 7 + std::move(b);
     EXPECT_EQ(r2.representation().data(), b_data);
-    ASSERT_EQ(r2.representation().size(), 2u);
-    EXPECT_EQ(r2.representation()[0], uint_multiprecision_t{7});
-    EXPECT_EQ(r2.representation()[1], uint_multiprecision_t{1});
+    EXPECT_EQ(r2, (big_int{1} << 64) + big_int{7});
 }
 
 TEST(Addition, LvalueFallbackUnchanged) {
@@ -314,9 +282,7 @@ TEST(Addition, LvalueFallbackUnchanged) {
     const big_int a = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
     const big_int b = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
     const big_int r = a + b;
-    ASSERT_EQ(r.representation().size(), 2u);
-    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
-    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{2});
+    EXPECT_EQ(r, big_int{1} << 65);
     // Operands untouched.
     EXPECT_EQ(a.representation().size(), 2u);
     EXPECT_EQ(b.representation().size(), 2u);

--- a/tests/beman/big_int/allocation.test.cpp
+++ b/tests/beman/big_int/allocation.test.cpp
@@ -4,6 +4,8 @@
 #include <beman/big_int/big_int.hpp>
 #include <gtest/gtest.h>
 
+#include "testing.hpp"
+
 // ----- compile-time tests -----
 
 consteval bool test_size_default() {

--- a/tests/beman/big_int/basic_construction.test.cpp
+++ b/tests/beman/big_int/basic_construction.test.cpp
@@ -4,6 +4,8 @@
 #include <beman/big_int/big_int.hpp>
 #include <gtest/gtest.h>
 
+#include "testing.hpp"
+
 // ----- compile-time tests -----
 
 consteval bool test_default_construction() {

--- a/tests/beman/big_int/big_int.test.cpp
+++ b/tests/beman/big_int/big_int.test.cpp
@@ -3,6 +3,8 @@
 
 #include <beman/big_int/big_int.hpp>
 
+#include "testing.hpp"
+
 namespace beman::big_int {
 
 template class basic_big_int<big_int::inplace_bits, big_int::allocator_type>;

--- a/tests/beman/big_int/bit_shift.test.cpp
+++ b/tests/beman/big_int/bit_shift.test.cpp
@@ -7,6 +7,8 @@
 
 #include <beman/big_int/big_int.hpp>
 
+#include "testing.hpp"
+
 namespace {
 
 using beman::big_int::basic_big_int;
@@ -27,15 +29,11 @@ TEST(BitShift, LeftShiftBasic) {
     w <<= 1;
     q <<= 1;
 
-    EXPECT_EQ(x == 0, true);
-    EXPECT_EQ(y == 1, true);
-    EXPECT_EQ(z.representation().size(), 1U);
-    EXPECT_EQ(z.representation()[0], 2ULL);
-    EXPECT_EQ(z == 2, true);
-    EXPECT_EQ(w == -2, true);
-    EXPECT_EQ(q.representation().size(), 2U);
-    EXPECT_EQ(q.representation()[0], std::numeric_limits<uint_multiprecision_t>::max() - 1ULL);
-    EXPECT_EQ(q.representation()[1], 1ULL);
+    EXPECT_EQ(x, 0);
+    EXPECT_EQ(y, 1);
+    EXPECT_EQ(z, 2);
+    EXPECT_EQ(w, -2);
+    EXPECT_EQ(q, (big_int{1} << 65) + big_int{-2});
 }
 
 TEST(BitShift, LeftShiftAcrossLimbs) {
@@ -49,19 +47,11 @@ TEST(BitShift, LeftShiftAcrossLimbs) {
     z <<= 128;
     expected <<= 64;
 
-    EXPECT_EQ(x.representation().size(), 2U);
-    EXPECT_EQ(x.representation()[0], 0ULL);
-    EXPECT_EQ(x.representation()[1], 1ULL);
-    EXPECT_EQ(x == expected, true);
+    EXPECT_EQ(x, expected);
 
-    EXPECT_EQ(y.representation().size(), 2U);
-    EXPECT_EQ(y.representation()[0], 0ULL);
-    EXPECT_EQ(y.representation()[1], 2ULL);
+    EXPECT_EQ(y, big_int{1} << 65);
 
-    EXPECT_EQ(z.representation().size(), 3U);
-    EXPECT_EQ(z.representation()[0], 0ULL);
-    EXPECT_EQ(z.representation()[1], 0ULL);
-    EXPECT_EQ(z.representation()[2], 1ULL);
+    EXPECT_EQ(z, big_int{1} << 128);
 }
 
 TEST(BitShift, LeftShiftAllocatedValue) {
@@ -70,11 +60,8 @@ TEST(BitShift, LeftShiftAllocatedValue) {
     x <<= 1;
     x <<= 64;
 
-    EXPECT_EQ(x.representation().size(), 3U);
-    EXPECT_EQ(x.representation()[0], 0ULL);
-    EXPECT_EQ(x.representation()[1], std::numeric_limits<uint_multiprecision_t>::max() - 1ULL);
-    EXPECT_EQ(x.representation()[2], 1ULL);
-    EXPECT_EQ(x.capacity() > 0U, true);
+    EXPECT_EQ(x, (big_int{1} << 129) - (big_int{1} << 65));
+    EXPECT_GT(x.capacity(), 0U);
 }
 
 TEST(BitShift, RightShiftBasic) {
@@ -90,11 +77,11 @@ TEST(BitShift, RightShiftBasic) {
     w >>= 1;
     q >>= 1;
 
-    EXPECT_EQ(x == 0, true);
-    EXPECT_EQ(y == 1, true);
-    EXPECT_EQ(z == 1, true);
-    EXPECT_EQ(w == -1, true);
-    EXPECT_EQ(q == -1, true);
+    EXPECT_EQ(x, 0);
+    EXPECT_EQ(y, 1);
+    EXPECT_EQ(z, 1);
+    EXPECT_EQ(w, -1);
+    EXPECT_EQ(q, -1);
 }
 
 TEST(BitShift, RightShiftAcrossLimbs) {
@@ -110,9 +97,9 @@ TEST(BitShift, RightShiftAcrossLimbs) {
     y >>= 64;
     z >>= 128;
 
-    EXPECT_EQ(x == 1, true);
-    EXPECT_EQ(y == 2, true);
-    EXPECT_EQ(z == 1, true);
+    EXPECT_EQ(x, 1);
+    EXPECT_EQ(y, 2);
+    EXPECT_EQ(z, 1);
 }
 
 TEST(BitShift, RightShiftNegativeRounding) {
@@ -125,9 +112,9 @@ TEST(BitShift, RightShiftNegativeRounding) {
     y >>= 1;
     z >>= 64;
 
-    EXPECT_EQ(x == -2, true);
-    EXPECT_EQ(y == -2, true);
-    EXPECT_EQ(z == -1, true);
+    EXPECT_EQ(x, -2);
+    EXPECT_EQ(y, -2);
+    EXPECT_EQ(z, -1);
 }
 
 TEST(BitShift, LeftShiftZeroRemainsZero) {
@@ -137,10 +124,8 @@ TEST(BitShift, LeftShiftZeroRemainsZero) {
     x <<= 64;
     x <<= 129;
 
-    EXPECT_EQ(x == 0, true);
-    EXPECT_EQ(x.representation()[0], 0ULL);
-    EXPECT_EQ(x.representation().size() >= 1U, true);
-    EXPECT_EQ(x.representation()[x.representation().size() - 1], 0ULL);
+    EXPECT_EQ(x, 0);
+    EXPECT_GE(x.representation().size(), 1U);
 }
 
 TEST(BitShift, LeftShiftWholeLimbPreservesMagnitudeDigits) {
@@ -175,15 +160,11 @@ TEST(BitShift, RightShiftLargePositiveBecomesZero) {
     big_int x{1};
 
     x >>= 64;
-    EXPECT_EQ(x == 0, true);
-    EXPECT_EQ(x.representation().size(), 1U);
-    EXPECT_EQ(x.representation()[0], 0ULL);
+    EXPECT_EQ(x, 0);
 
     x = 1;
     x >>= 257;
-    EXPECT_EQ(x == 0, true);
-    EXPECT_EQ(x.representation().size(), 1U);
-    EXPECT_EQ(x.representation()[0], 0ULL);
+    EXPECT_EQ(x, 0);
 }
 
 TEST(BitShift, RightShiftLargeNegativeBecomesMinusOne) {
@@ -193,12 +174,12 @@ TEST(BitShift, RightShiftLargeNegativeBecomesMinusOne) {
     x >>= 64;
     y >>= 64;
 
-    EXPECT_EQ(x == -1, true);
-    EXPECT_EQ(y == -1, true);
+    EXPECT_EQ(x, -1);
+    EXPECT_EQ(y, -1);
 
     y = -2;
     y >>= 257;
-    EXPECT_EQ(y == -1, true);
+    EXPECT_EQ(y, -1);
 }
 
 TEST(BitShift, LeftThenRightRoundTripForPositive) {
@@ -206,15 +187,15 @@ TEST(BitShift, LeftThenRightRoundTripForPositive) {
 
     x <<= 17;
     x >>= 17;
-    EXPECT_EQ(x == 123'456'789, true);
+    EXPECT_EQ(x, 123'456'789);
 
     x <<= 64;
     x >>= 64;
-    EXPECT_EQ(x == 123'456'789, true);
+    EXPECT_EQ(x, 123'456'789);
 
     x <<= 130;
     x >>= 130;
-    EXPECT_EQ(x == 123'456'789, true);
+    EXPECT_EQ(x, 123'456'789);
 }
 
 // ----- operator<< (non-mutating left shift) -----
@@ -271,9 +252,7 @@ TEST(BitShift, OperatorLeftShiftRvalue) {
     EXPECT_EQ(r, 1024);
 
     big_int s = big_int{std::numeric_limits<uint_multiprecision_t>::max()} << 1;
-    EXPECT_EQ(s.representation().size(), 2U);
-    EXPECT_EQ(s.representation()[0], std::numeric_limits<uint_multiprecision_t>::max() - 1ULL);
-    EXPECT_EQ(s.representation()[1], 1ULL);
+    EXPECT_EQ(s, (big_int{1} << 65) + big_int{-2});
 }
 
 TEST(BitShift, OperatorLeftShiftInplaceToHeap) {
@@ -284,9 +263,7 @@ TEST(BitShift, OperatorLeftShiftInplaceToHeap) {
     EXPECT_EQ(x.capacity(), 0U); // inline
 
     const big_int r = x << 1;
-    EXPECT_EQ(r.representation().size(), 2U);
-    EXPECT_EQ(r.representation()[0], 0ULL);
-    EXPECT_EQ(r.representation()[1], 1ULL);
+    EXPECT_EQ(r, big_int{1} << 64);
 }
 
 TEST(BitShift, OperatorLeftShiftInplaceStaysInlineCLZ) {
@@ -297,8 +274,7 @@ TEST(BitShift, OperatorLeftShiftInplaceStaysInlineCLZ) {
 
     const big_int r = x << 63;
     EXPECT_EQ(r.capacity(), 0U); // still inline
-    EXPECT_EQ(r.representation().size(), 1U);
-    EXPECT_EQ(r.representation()[0], 1ULL << 63);
+    EXPECT_EQ(r, big_int{1} << 63);
 }
 
 TEST(BitShift, OperatorLeftShiftWiderInplaceStaysInline) {
@@ -310,13 +286,7 @@ TEST(BitShift, OperatorLeftShiftWiderInplaceStaysInline) {
 
     const big_int_256 r = x << 255;
     EXPECT_EQ(r.capacity(), 0U); // still inline
-
-    // Top limb should be 1 << (255 % 64) = 1 << 63
-    EXPECT_EQ(r.representation().size(), 4U);
-    EXPECT_EQ(r.representation()[3], 1ULL << 63);
-    EXPECT_EQ(r.representation()[2], 0ULL);
-    EXPECT_EQ(r.representation()[1], 0ULL);
-    EXPECT_EQ(r.representation()[0], 0ULL);
+    EXPECT_EQ(r, big_int_256{1} << 255);
 }
 
 TEST(BitShift, OperatorLeftShiftWiderInplaceToHeap) {
@@ -326,12 +296,8 @@ TEST(BitShift, OperatorLeftShiftWiderInplaceToHeap) {
     const big_int_256 x{1};
 
     const big_int_256 r = x << 256;
-    EXPECT_EQ(r.representation().size(), 5U);
     EXPECT_NE(r.capacity(), 0U); // heap
-    EXPECT_EQ(r.representation()[4], 1ULL);
-    for (int i = 0; i < 4; ++i) {
-        EXPECT_EQ(r.representation()[static_cast<std::size_t>(i)], 0ULL);
-    }
+    EXPECT_EQ(r, big_int_256{1} << 256);
 }
 
 TEST(BitShift, OperatorLeftShiftAcrossLimbs) {
@@ -341,18 +307,11 @@ TEST(BitShift, OperatorLeftShiftAcrossLimbs) {
     const big_int r65  = x << 65;
     const big_int r128 = x << 128;
 
-    EXPECT_EQ(r64.representation().size(), 2U);
-    EXPECT_EQ(r64.representation()[0], 0ULL);
-    EXPECT_EQ(r64.representation()[1], 1ULL);
+    EXPECT_EQ(r64, big_int{1} << 64);
 
-    EXPECT_EQ(r65.representation().size(), 2U);
-    EXPECT_EQ(r65.representation()[0], 0ULL);
-    EXPECT_EQ(r65.representation()[1], 2ULL);
+    EXPECT_EQ(r65, big_int{1} << 65);
 
-    EXPECT_EQ(r128.representation().size(), 3U);
-    EXPECT_EQ(r128.representation()[0], 0ULL);
-    EXPECT_EQ(r128.representation()[1], 0ULL);
-    EXPECT_EQ(r128.representation()[2], 1ULL);
+    EXPECT_EQ(r128, big_int{1} << 128);
 }
 
 TEST(BitShift, OperatorLeftShiftHuge) {
@@ -360,11 +319,7 @@ TEST(BitShift, OperatorLeftShiftHuge) {
     const big_int x{1};
     const big_int r = x << 10000;
 
-    // 10000 / 64 = 156 whole limbs, 10000 % 64 = 16-bit shift
-    EXPECT_EQ(r.representation().size(), 157U);
-    EXPECT_EQ(r.representation()[156], 1ULL << 16);
-    EXPECT_EQ(r.representation()[155], 0ULL);
-    EXPECT_EQ(r.representation()[0], 0ULL);
+    EXPECT_EQ(r, big_int{1} << 10000);
 
     // Verify via round-trip with >>=
     big_int rt = r;
@@ -380,10 +335,7 @@ TEST(BitShift, OperatorLeftShiftHeapSource) {
     EXPECT_NE(x.capacity(), 0U);
 
     const big_int r = x << 64;
-    EXPECT_EQ(r.representation().size(), 3U);
-    EXPECT_EQ(r.representation()[0], 0ULL);
-    EXPECT_EQ(r.representation()[1], std::numeric_limits<uint_multiprecision_t>::max() - 1ULL);
-    EXPECT_EQ(r.representation()[2], 1ULL);
+    EXPECT_EQ(r, (big_int{1} << 129) - (big_int{1} << 65));
 }
 
 TEST(BitShift, OperatorLeftShiftSignedShiftAmount) {

--- a/tests/beman/big_int/bit_shift.test.cpp
+++ b/tests/beman/big_int/bit_shift.test.cpp
@@ -33,7 +33,9 @@ TEST(BitShift, LeftShiftBasic) {
     EXPECT_EQ(y, 1);
     EXPECT_EQ(z, 2);
     EXPECT_EQ(w, -2);
-    EXPECT_EQ(q, (big_int{1} << 65) + big_int{-2});
+    EXPECT_EQ(q.representation().size(), 2U);
+    EXPECT_EQ(q.representation()[0], std::numeric_limits<uint_multiprecision_t>::max() - 1ULL);
+    EXPECT_EQ(q.representation()[1], 1ULL);
 }
 
 TEST(BitShift, LeftShiftAcrossLimbs) {
@@ -47,11 +49,19 @@ TEST(BitShift, LeftShiftAcrossLimbs) {
     z <<= 128;
     expected <<= 64;
 
+    EXPECT_EQ(x.representation().size(), 2U);
+    EXPECT_EQ(x.representation()[0], 0ULL);
+    EXPECT_EQ(x.representation()[1], 1ULL);
     EXPECT_EQ(x, expected);
 
-    EXPECT_EQ(y, big_int{1} << 65);
+    EXPECT_EQ(y.representation().size(), 2U);
+    EXPECT_EQ(y.representation()[0], 0ULL);
+    EXPECT_EQ(y.representation()[1], 2ULL);
 
-    EXPECT_EQ(z, big_int{1} << 128);
+    EXPECT_EQ(z.representation().size(), 3U);
+    EXPECT_EQ(z.representation()[0], 0ULL);
+    EXPECT_EQ(z.representation()[1], 0ULL);
+    EXPECT_EQ(z.representation()[2], 1ULL);
 }
 
 TEST(BitShift, LeftShiftAllocatedValue) {
@@ -60,7 +70,10 @@ TEST(BitShift, LeftShiftAllocatedValue) {
     x <<= 1;
     x <<= 64;
 
-    EXPECT_EQ(x, (big_int{1} << 129) - (big_int{1} << 65));
+    EXPECT_EQ(x.representation().size(), 3U);
+    EXPECT_EQ(x.representation()[0], 0ULL);
+    EXPECT_EQ(x.representation()[1], std::numeric_limits<uint_multiprecision_t>::max() - 1ULL);
+    EXPECT_EQ(x.representation()[2], 1ULL);
     EXPECT_GT(x.capacity(), 0U);
 }
 
@@ -252,7 +265,9 @@ TEST(BitShift, OperatorLeftShiftRvalue) {
     EXPECT_EQ(r, 1024);
 
     big_int s = big_int{std::numeric_limits<uint_multiprecision_t>::max()} << 1;
-    EXPECT_EQ(s, (big_int{1} << 65) + big_int{-2});
+    EXPECT_EQ(s.representation().size(), 2U);
+    EXPECT_EQ(s.representation()[0], std::numeric_limits<uint_multiprecision_t>::max() - 1ULL);
+    EXPECT_EQ(s.representation()[1], 1ULL);
 }
 
 TEST(BitShift, OperatorLeftShiftInplaceToHeap) {
@@ -263,7 +278,9 @@ TEST(BitShift, OperatorLeftShiftInplaceToHeap) {
     EXPECT_EQ(x.capacity(), 0U); // inline
 
     const big_int r = x << 1;
-    EXPECT_EQ(r, big_int{1} << 64);
+    EXPECT_EQ(r.representation().size(), 2U);
+    EXPECT_EQ(r.representation()[0], 0ULL);
+    EXPECT_EQ(r.representation()[1], 1ULL);
 }
 
 TEST(BitShift, OperatorLeftShiftInplaceStaysInlineCLZ) {
@@ -274,7 +291,8 @@ TEST(BitShift, OperatorLeftShiftInplaceStaysInlineCLZ) {
 
     const big_int r = x << 63;
     EXPECT_EQ(r.capacity(), 0U); // still inline
-    EXPECT_EQ(r, big_int{1} << 63);
+    EXPECT_EQ(r.representation().size(), 1U);
+    EXPECT_EQ(r.representation()[0], 1ULL << 63);
 }
 
 TEST(BitShift, OperatorLeftShiftWiderInplaceStaysInline) {
@@ -286,7 +304,13 @@ TEST(BitShift, OperatorLeftShiftWiderInplaceStaysInline) {
 
     const big_int_256 r = x << 255;
     EXPECT_EQ(r.capacity(), 0U); // still inline
-    EXPECT_EQ(r, big_int_256{1} << 255);
+
+    // Top limb should be 1 << (255 % 64) = 1 << 63
+    EXPECT_EQ(r.representation().size(), 4U);
+    EXPECT_EQ(r.representation()[3], 1ULL << 63);
+    EXPECT_EQ(r.representation()[2], 0ULL);
+    EXPECT_EQ(r.representation()[1], 0ULL);
+    EXPECT_EQ(r.representation()[0], 0ULL);
 }
 
 TEST(BitShift, OperatorLeftShiftWiderInplaceToHeap) {
@@ -296,8 +320,12 @@ TEST(BitShift, OperatorLeftShiftWiderInplaceToHeap) {
     const big_int_256 x{1};
 
     const big_int_256 r = x << 256;
+    EXPECT_EQ(r.representation().size(), 5U);
     EXPECT_NE(r.capacity(), 0U); // heap
-    EXPECT_EQ(r, big_int_256{1} << 256);
+    EXPECT_EQ(r.representation()[4], 1ULL);
+    for (int i = 0; i < 4; ++i) {
+        EXPECT_EQ(r.representation()[static_cast<std::size_t>(i)], 0ULL);
+    }
 }
 
 TEST(BitShift, OperatorLeftShiftAcrossLimbs) {
@@ -307,11 +335,18 @@ TEST(BitShift, OperatorLeftShiftAcrossLimbs) {
     const big_int r65  = x << 65;
     const big_int r128 = x << 128;
 
-    EXPECT_EQ(r64, big_int{1} << 64);
+    EXPECT_EQ(r64.representation().size(), 2U);
+    EXPECT_EQ(r64.representation()[0], 0ULL);
+    EXPECT_EQ(r64.representation()[1], 1ULL);
 
-    EXPECT_EQ(r65, big_int{1} << 65);
+    EXPECT_EQ(r65.representation().size(), 2U);
+    EXPECT_EQ(r65.representation()[0], 0ULL);
+    EXPECT_EQ(r65.representation()[1], 2ULL);
 
-    EXPECT_EQ(r128, big_int{1} << 128);
+    EXPECT_EQ(r128.representation().size(), 3U);
+    EXPECT_EQ(r128.representation()[0], 0ULL);
+    EXPECT_EQ(r128.representation()[1], 0ULL);
+    EXPECT_EQ(r128.representation()[2], 1ULL);
 }
 
 TEST(BitShift, OperatorLeftShiftHuge) {
@@ -319,7 +354,11 @@ TEST(BitShift, OperatorLeftShiftHuge) {
     const big_int x{1};
     const big_int r = x << 10000;
 
-    EXPECT_EQ(r, big_int{1} << 10000);
+    // 10000 / 64 = 156 whole limbs, 10000 % 64 = 16-bit shift
+    EXPECT_EQ(r.representation().size(), 157U);
+    EXPECT_EQ(r.representation()[156], 1ULL << 16);
+    EXPECT_EQ(r.representation()[155], 0ULL);
+    EXPECT_EQ(r.representation()[0], 0ULL);
 
     // Verify via round-trip with >>=
     big_int rt = r;
@@ -335,7 +374,10 @@ TEST(BitShift, OperatorLeftShiftHeapSource) {
     EXPECT_NE(x.capacity(), 0U);
 
     const big_int r = x << 64;
-    EXPECT_EQ(r, (big_int{1} << 129) - (big_int{1} << 65));
+    EXPECT_EQ(r.representation().size(), 3U);
+    EXPECT_EQ(r.representation()[0], 0ULL);
+    EXPECT_EQ(r.representation()[1], std::numeric_limits<uint_multiprecision_t>::max() - 1ULL);
+    EXPECT_EQ(r.representation()[2], 1ULL);
 }
 
 TEST(BitShift, OperatorLeftShiftSignedShiftAmount) {

--- a/tests/beman/big_int/bitwise.test.cpp
+++ b/tests/beman/big_int/bitwise.test.cpp
@@ -11,6 +11,8 @@
 
 #include <beman/big_int/big_int.hpp>
 
+#include "testing.hpp"
+
 using beman::big_int::big_int;
 using beman::big_int::uint_multiprecision_t;
 

--- a/tests/beman/big_int/charconv.test.cpp
+++ b/tests/beman/big_int/charconv.test.cpp
@@ -4,6 +4,8 @@
 
 #include <beman/big_int/big_int.hpp>
 
+#include "testing.hpp"
+
 namespace {
 
 using namespace beman::big_int;

--- a/tests/beman/big_int/comparison.test.cpp
+++ b/tests/beman/big_int/comparison.test.cpp
@@ -7,6 +7,8 @@
 
 #include <beman/big_int/big_int.hpp>
 
+#include "testing.hpp"
+
 namespace {
 
 using beman::big_int::big_int;
@@ -17,43 +19,43 @@ TEST(Comparison, EqualitySmallIntegers) {
     const big_int one{1};
     const big_int neg_one{-1};
 
-    EXPECT_EQ(zero == zero, true);
-    EXPECT_EQ(zero == 0U, true);
-    EXPECT_EQ(0U == zero, true);
-    EXPECT_EQ(zero == 0, true);
-    EXPECT_EQ(0 == zero, true);
+    EXPECT_EQ(zero, zero);
+    EXPECT_EQ(zero, 0U);
+    EXPECT_EQ(0U, zero);
+    EXPECT_EQ(zero, 0);
+    EXPECT_EQ(0, zero);
 
-    EXPECT_EQ(zero == one, false);
-    EXPECT_EQ(zero == 1U, false);
-    EXPECT_EQ(0U == one, false);
-    EXPECT_EQ(zero == 1, false);
-    EXPECT_EQ(0 == one, false);
+    EXPECT_NE(zero, one);
+    EXPECT_NE(zero, 1U);
+    EXPECT_NE(0U, one);
+    EXPECT_NE(zero, 1);
+    EXPECT_NE(0, one);
 
-    EXPECT_EQ(one == zero, false);
-    EXPECT_EQ(one == 0U, false);
-    EXPECT_EQ(1U == zero, false);
-    EXPECT_EQ(one == 0, false);
-    EXPECT_EQ(1 == zero, false);
+    EXPECT_NE(one, zero);
+    EXPECT_NE(one, 0U);
+    EXPECT_NE(1U, zero);
+    EXPECT_NE(one, 0);
+    EXPECT_NE(1, zero);
 
-    EXPECT_EQ(one == one, true);
-    EXPECT_EQ(one == 1U, true);
-    EXPECT_EQ(1U == one, true);
-    EXPECT_EQ(one == 1, true);
-    EXPECT_EQ(1 == one, true);
+    EXPECT_EQ(one, one);
+    EXPECT_EQ(one, 1U);
+    EXPECT_EQ(1U, one);
+    EXPECT_EQ(one, 1);
+    EXPECT_EQ(1, one);
 
-    EXPECT_EQ(one == neg_one, false);
-    EXPECT_EQ(one == -1, false);
-    EXPECT_EQ(1U == neg_one, false);
-    EXPECT_EQ(1 == neg_one, false);
+    EXPECT_NE(one, neg_one);
+    EXPECT_NE(one, -1);
+    EXPECT_NE(1U, neg_one);
+    EXPECT_NE(1, neg_one);
 
-    EXPECT_EQ(neg_one == one, false);
-    EXPECT_EQ(neg_one == 1U, false);
-    EXPECT_EQ(neg_one == 1, false);
-    EXPECT_EQ((-1) == one, false);
+    EXPECT_NE(neg_one, one);
+    EXPECT_NE(neg_one, 1U);
+    EXPECT_NE(neg_one, 1);
+    EXPECT_NE(-1, one);
 
-    EXPECT_EQ(neg_one == neg_one, true);
-    EXPECT_EQ(neg_one == -1, true);
-    EXPECT_EQ((-1) == neg_one, true);
+    EXPECT_EQ(neg_one, neg_one);
+    EXPECT_EQ(neg_one, -1);
+    EXPECT_EQ(-1, neg_one);
 }
 
 TEST(Comparison, EqualityWideIntegers) {
@@ -61,20 +63,20 @@ TEST(Comparison, EqualityWideIntegers) {
     const big_int wide_two{2.0e20};
     const big_int wide_neg = -wide_one;
 
-    EXPECT_EQ(wide_one == wide_one, true);
-    EXPECT_EQ(wide_two == wide_two, true);
-    EXPECT_EQ(wide_one == wide_two, false);
-    EXPECT_EQ(wide_two == wide_one, false);
-    EXPECT_EQ(wide_one == 1U, false);
-    EXPECT_EQ(wide_one == big_int{1U}, false);
-    EXPECT_EQ(1U == wide_one, false);
-    EXPECT_EQ(big_int{1U} == wide_one, false);
-    EXPECT_EQ(1 == wide_one, false);
-    EXPECT_EQ(big_int{1} == wide_one, false);
-    EXPECT_EQ(wide_one == wide_neg, false);
-    EXPECT_EQ(wide_neg == wide_one, false);
-    EXPECT_EQ(wide_neg == -wide_one, true);
-    EXPECT_EQ((-wide_one) == wide_neg, true);
+    EXPECT_EQ(wide_one, wide_one);
+    EXPECT_EQ(wide_two, wide_two);
+    EXPECT_NE(wide_one, wide_two);
+    EXPECT_NE(wide_two, wide_one);
+    EXPECT_NE(wide_one, 1U);
+    EXPECT_NE(wide_one, big_int{1U});
+    EXPECT_NE(1U, wide_one);
+    EXPECT_NE(big_int{1U}, wide_one);
+    EXPECT_NE(1, wide_one);
+    EXPECT_NE(big_int{1}, wide_one);
+    EXPECT_NE(wide_one, wide_neg);
+    EXPECT_NE(wide_neg, wide_one);
+    EXPECT_EQ(wide_neg, -wide_one);
+    EXPECT_EQ(-wide_one, wide_neg);
 }
 
 TEST(Comparison, OrderingSmallIntegers) {
@@ -172,13 +174,13 @@ TEST(Comparison, EqualityNegativeMagnitudes) {
     const big_int neg_five{-5};
     const big_int neg_three_copy{-3};
 
-    EXPECT_EQ(neg_three == neg_three_copy, true);
-    EXPECT_EQ(neg_three == neg_five, false);
-    EXPECT_EQ(neg_five == neg_three, false);
-    EXPECT_EQ(neg_three == -3, true);
-    EXPECT_EQ(neg_three == -5, false);
-    EXPECT_EQ(-3 == neg_three, true);
-    EXPECT_EQ(-5 == neg_three, false);
+    EXPECT_EQ(neg_three, neg_three_copy);
+    EXPECT_NE(neg_three, neg_five);
+    EXPECT_NE(neg_five, neg_three);
+    EXPECT_EQ(neg_three, -3);
+    EXPECT_NE(neg_three, -5);
+    EXPECT_EQ(-3, neg_three);
+    EXPECT_NE(-5, neg_three);
 }
 
 TEST(Comparison, OrderingNegativeMagnitudes) {

--- a/tests/beman/big_int/conversion.test.cpp
+++ b/tests/beman/big_int/conversion.test.cpp
@@ -6,6 +6,8 @@
 
 #include <beman/big_int/big_int.hpp>
 
+#include "testing.hpp"
+
 // [big.int.conv] compile-time tests
 
 static_assert(!static_cast<bool>(beman::big_int::big_int{}));

--- a/tests/beman/big_int/division.test.cpp
+++ b/tests/beman/big_int/division.test.cpp
@@ -3,23 +3,12 @@
 
 #include <cstdint>
 #include <limits>
-#include <ostream>
 
 #include <gtest/gtest.h>
 
 #include <beman/big_int/big_int.hpp>
 
-// TODO(eisenwave): This is for better debug printing in GTest.
-//                  It should be a separate testing utility included in all tests.
-namespace beman::big_int {
-
-std::ostream& operator<<(std::ostream& out, const big_int& x) { return out << to_string(x); }
-
-std::ostream& operator<<(std::ostream& out, const div_result<big_int>& x) {
-    return out << "{.quotient = " << x.quotient << ", .remainder = " << x.remainder << '}';
-}
-
-} // namespace beman::big_int
+#include "testing.hpp"
 
 namespace {
 
@@ -31,7 +20,7 @@ using beman::big_int::uint_multiprecision_t;
 
 // ----- compile-time sanity -----
 
-[[nodiscard]] consteval bool check_div_rem(const big_int x, const big_int y) {
+[[nodiscard]] consteval bool check_div_rem(const big_int& x, const big_int& y) {
     return div_rem_to_zero(x, y) == div_result{x / y, x % y};
 }
 

--- a/tests/beman/big_int/division_huge.test.cpp
+++ b/tests/beman/big_int/division_huge.test.cpp
@@ -7,6 +7,8 @@
 
 #include <beman/big_int/big_int.hpp>
 
+#include "testing.hpp"
+
 using beman::big_int::big_int;
 using namespace beman::big_int::literals;
 

--- a/tests/beman/big_int/float_construction.test.cpp
+++ b/tests/beman/big_int/float_construction.test.cpp
@@ -5,6 +5,8 @@
 #include <beman/big_int/big_int.hpp>
 #include <gtest/gtest.h>
 
+#include "testing.hpp"
+
 TEST(FloatConstruction, DoubleZero) {
     beman::big_int::big_int x(0.0);
     EXPECT_EQ(x.width_mag(), 0U);

--- a/tests/beman/big_int/increment_decrement.test.cpp
+++ b/tests/beman/big_int/increment_decrement.test.cpp
@@ -8,6 +8,8 @@
 
 #include <beman/big_int/big_int.hpp>
 
+#include "testing.hpp"
+
 namespace {
 
 using beman::big_int::big_int;
@@ -26,11 +28,9 @@ TEST(IncrementDecrement, PrefixIncrement) {
     EXPECT_EQ(&rx, &x);
     EXPECT_EQ(&ry, &y);
     EXPECT_EQ(&rz, &z);
-    EXPECT_EQ(x == 42, true);
-    EXPECT_EQ(y == -4, true);
-    EXPECT_EQ(z.representation().size(), 2U);
-    EXPECT_EQ(z.representation()[0], 0ULL);
-    EXPECT_EQ(z.representation()[1], 1ULL);
+    EXPECT_EQ(x, 42);
+    EXPECT_EQ(y, -4);
+    EXPECT_EQ(z, big_int{1} << 64);
 }
 
 TEST(IncrementDecrement, PostfixIncrement) {
@@ -40,10 +40,10 @@ TEST(IncrementDecrement, PostfixIncrement) {
     const big_int old_x = x++;
     const big_int old_y = y++;
 
-    EXPECT_EQ(old_x == 41, true);
-    EXPECT_EQ(x == 42, true);
-    EXPECT_EQ(old_y == -5, true);
-    EXPECT_EQ(y == -4, true);
+    EXPECT_EQ(old_x, 41);
+    EXPECT_EQ(x, 42);
+    EXPECT_EQ(old_y, -5);
+    EXPECT_EQ(y, -4);
 }
 
 TEST(IncrementDecrement, PrefixDecrement) {
@@ -62,12 +62,10 @@ TEST(IncrementDecrement, PrefixDecrement) {
     EXPECT_EQ(&rq, &q);
     EXPECT_EQ(&rr, &r);
     EXPECT_EQ(&rs, &s);
-    EXPECT_EQ(p == 4, true);
-    EXPECT_EQ(q == -1, true);
-    EXPECT_EQ(r == -6, true);
-    ASSERT_EQ(s.representation().size(), 2U);
-    EXPECT_EQ(s.representation()[0], 0ULL);
-    EXPECT_EQ(s.representation()[1], 1ULL);
+    EXPECT_EQ(p, 4);
+    EXPECT_EQ(q, -1);
+    EXPECT_EQ(r, -6);
+    EXPECT_EQ(s, -(big_int{1} << 64));
     EXPECT_EQ((s <=> 0), std::strong_ordering::less);
 }
 
@@ -80,12 +78,12 @@ TEST(IncrementDecrement, PostfixDecrement) {
     const big_int old_y = y--;
     const big_int old_z = z--;
 
-    EXPECT_EQ(old_x == 41, true);
-    EXPECT_EQ(x == 40, true);
-    EXPECT_EQ(old_y == 0, true);
-    EXPECT_EQ(y == -1, true);
-    EXPECT_EQ(old_z == -5, true);
-    EXPECT_EQ(z == -6, true);
+    EXPECT_EQ(old_x, 41);
+    EXPECT_EQ(x, 40);
+    EXPECT_EQ(old_y, 0);
+    EXPECT_EQ(y, -1);
+    EXPECT_EQ(old_z, -5);
+    EXPECT_EQ(z, -6);
 }
 
 TEST(IncrementDecrement, PrefixIncrementRequiresAllocationForLargeValue) {
@@ -96,10 +94,8 @@ TEST(IncrementDecrement, PrefixIncrementRequiresAllocationForLargeValue) {
 
     ++x;
 
-    EXPECT_EQ(x.representation().size(), 2U);
-    EXPECT_EQ(x.representation()[0], 0ULL);
-    EXPECT_EQ(x.representation()[1], 1ULL);
-    EXPECT_EQ(x.capacity() > 0U, true);
+    EXPECT_EQ(x, big_int{1} << 64);
+    EXPECT_GT(x.capacity(), 0U);
 }
 
 TEST(IncrementDecrement, ZeroAndOneTransitions) {
@@ -113,10 +109,10 @@ TEST(IncrementDecrement, ZeroAndOneTransitions) {
     ++c;
     --d;
 
-    EXPECT_EQ(a == 0, true);
-    EXPECT_EQ(b == 0, true);
-    EXPECT_EQ(c == 1, true);
-    EXPECT_EQ(d == -1, true);
+    EXPECT_EQ(a, 0);
+    EXPECT_EQ(b, 0);
+    EXPECT_EQ(c, 1);
+    EXPECT_EQ(d, -1);
 }
 
 TEST(IncrementDecrement, PrefixIncrementAllocatedCarryChain) {
@@ -124,36 +120,26 @@ TEST(IncrementDecrement, PrefixIncrementAllocatedCarryChain) {
     ++x;
     x = -x;
 
-    EXPECT_EQ(x.capacity() > 0U, true);
-    ASSERT_EQ(x.representation().size(), 2U);
-    EXPECT_EQ(x.representation()[0], 0ULL);
-    EXPECT_EQ(x.representation()[1], 1ULL);
+    EXPECT_GT(x.capacity(), 0U);
+    EXPECT_EQ(x, -(big_int{1} << 64));
 
     ++x;
 
-    EXPECT_EQ(x == -big_int{std::numeric_limits<uint_multiprecision_t>::max()}, true);
-    ASSERT_EQ(x.representation().size(), 2U);
-    EXPECT_EQ(x.representation()[0], std::numeric_limits<uint_multiprecision_t>::max());
-    EXPECT_EQ(x.representation()[1], 0ULL);
-    EXPECT_EQ(x.capacity() > 0U, true);
+    EXPECT_EQ(x, -big_int{std::numeric_limits<uint_multiprecision_t>::max()});
+    EXPECT_GT(x.capacity(), 0U);
 }
 
 TEST(IncrementDecrement, PrefixDecrementAllocatedBorrowChain) {
     big_int x{std::numeric_limits<uint_multiprecision_t>::max()};
     ++x;
 
-    EXPECT_EQ(x.capacity() > 0U, true);
-    ASSERT_EQ(x.representation().size(), 2U);
-    EXPECT_EQ(x.representation()[0], 0ULL);
-    EXPECT_EQ(x.representation()[1], 1ULL);
+    EXPECT_GT(x.capacity(), 0U);
+    EXPECT_EQ(x, big_int{1} << 64);
 
     --x;
 
-    EXPECT_EQ(x == big_int{std::numeric_limits<uint_multiprecision_t>::max()}, true);
-    ASSERT_EQ(x.representation().size(), 2U);
-    EXPECT_EQ(x.representation()[0], std::numeric_limits<uint_multiprecision_t>::max());
-    EXPECT_EQ(x.representation()[1], 0ULL);
-    EXPECT_EQ(x.capacity() > 0U, true);
+    EXPECT_EQ(x, big_int{std::numeric_limits<uint_multiprecision_t>::max()});
+    EXPECT_GT(x.capacity(), 0U);
 }
 
 TEST(IncrementDecrement, BitwiseNotSmallIntegers) {
@@ -169,14 +155,14 @@ TEST(IncrementDecrement, BitwiseNotSmallIntegers) {
     const big_int rd = ~d;
     const big_int re = ~e;
 
-    EXPECT_EQ(ra == -1, true);
-    EXPECT_EQ(rb == -2, true);
-    EXPECT_EQ(rc == 0, true);
-    EXPECT_EQ(rd == -43, true);
-    EXPECT_EQ(re == 41, true);
+    EXPECT_EQ(ra, -1);
+    EXPECT_EQ(rb, -2);
+    EXPECT_EQ(rc, 0);
+    EXPECT_EQ(rd, -43);
+    EXPECT_EQ(re, 41);
 
     const big_int rr = ~big_int{7};
-    EXPECT_EQ(rr == -8, true);
+    EXPECT_EQ(rr, -8);
 }
 
 TEST(IncrementDecrement, BitwiseNotBigInteger) {
@@ -186,17 +172,13 @@ TEST(IncrementDecrement, BitwiseNotBigInteger) {
     const big_int y = ~x;
 
     EXPECT_EQ((y <=> 0), std::strong_ordering::less);
-    EXPECT_EQ(y == (-x - 1), true);
+    EXPECT_EQ(y, -x - 1);
 
     big_int       n = -x;
     const big_int z = ~n;
 
     EXPECT_EQ((z <=> 0), std::strong_ordering::greater);
-    EXPECT_EQ(z == (x - 1), true);
-    ASSERT_EQ(z.representation().size(), 3U);
-    EXPECT_EQ(z.representation()[0], std::numeric_limits<uint_multiprecision_t>::max());
-    EXPECT_EQ(z.representation()[1], std::numeric_limits<uint_multiprecision_t>::max());
-    EXPECT_EQ(z.representation()[2], 3ULL);
+    EXPECT_EQ(z, x - 1);
 }
 
 TEST(IncrementDecrement, BitwiseNotCanAllocate) {
@@ -205,12 +187,9 @@ TEST(IncrementDecrement, BitwiseNotCanAllocate) {
 
     const big_int y = ~x;
 
-    EXPECT_EQ(y == (-x - 1), true);
+    EXPECT_EQ(y, -x - 1);
     EXPECT_EQ((y <=> 0), std::strong_ordering::less);
-    ASSERT_EQ(y.representation().size(), 2U);
-    EXPECT_EQ(y.representation()[0], 0ULL);
-    EXPECT_EQ(y.representation()[1], 1ULL);
-    EXPECT_EQ(y.capacity() > 0U, true);
+    EXPECT_GT(y.capacity(), 0U);
 }
 
 } // namespace

--- a/tests/beman/big_int/integer_assignment.test.cpp
+++ b/tests/beman/big_int/integer_assignment.test.cpp
@@ -4,6 +4,8 @@
 #include <beman/big_int/big_int.hpp>
 #include <gtest/gtest.h>
 
+#include "testing.hpp"
+
 TEST(IntegerAssignment, AssignPositive) {
     beman::big_int::big_int x;
     x = 42;

--- a/tests/beman/big_int/karatsuba.test.cpp
+++ b/tests/beman/big_int/karatsuba.test.cpp
@@ -11,6 +11,8 @@
 
 #include <beman/big_int/big_int.hpp>
 
+#include "testing.hpp"
+
 using beman::big_int::big_int;
 using beman::big_int::uint_multiprecision_t;
 

--- a/tests/beman/big_int/karatsuba_edge.test.cpp
+++ b/tests/beman/big_int/karatsuba_edge.test.cpp
@@ -10,6 +10,8 @@
     #include <string>
 #endif
 
+#include "testing.hpp"
+
 TEST(Multiplication, KaratsubaEdge01) {
     using beman::big_int::big_int;
 #if !defined(BEMAN_BIG_INT_MSVC)

--- a/tests/beman/big_int/karatsuba_exercise.test.cpp
+++ b/tests/beman/big_int/karatsuba_exercise.test.cpp
@@ -6,6 +6,8 @@
 
 #include <gtest/gtest.h>
 
+#include "testing.hpp"
+
 namespace bmp = ::beman::big_int::boost_mp_testing;
 
 namespace local {

--- a/tests/beman/big_int/karatsuba_mersenne.test.cpp
+++ b/tests/beman/big_int/karatsuba_mersenne.test.cpp
@@ -8,6 +8,8 @@
 #include <array>
 #include <span>
 
+#include "testing.hpp"
+
 namespace local {
 
 template <class IntegralType>
@@ -70,7 +72,7 @@ auto run_one_mersenne(const unsigned p2) -> void {
 
     const bool result_length_is_ok{big_int_sig == cpp_int_sig};
 
-    EXPECT_EQ(result_length_is_ok, true);
+    EXPECT_TRUE(result_length_is_ok);
 
     bool result_is_ok{result_length_is_ok};
 
@@ -87,11 +89,11 @@ auto run_one_mersenne(const unsigned p2) -> void {
         }
     }
 
-    EXPECT_EQ(result_bytes_same_is_ok, true);
+    EXPECT_TRUE(result_bytes_same_is_ok);
 
     result_is_ok = (result_bytes_same_is_ok && result_is_ok);
 
-    EXPECT_EQ(result_is_ok, true);
+    EXPECT_TRUE(result_is_ok);
 }
 
 // Note: We test millons of decimal digits, since

--- a/tests/beman/big_int/modulus.test.cpp
+++ b/tests/beman/big_int/modulus.test.cpp
@@ -8,6 +8,8 @@
 
 #include <beman/big_int/big_int.hpp>
 
+#include "testing.hpp"
+
 namespace {
 
 using beman::big_int::basic_big_int;

--- a/tests/beman/big_int/multiplication.test.cpp
+++ b/tests/beman/big_int/multiplication.test.cpp
@@ -11,6 +11,8 @@
 
 #include <beman/big_int/big_int.hpp>
 
+#include "testing.hpp"
+
 namespace {
 
 using beman::big_int::basic_big_int;
@@ -111,31 +113,21 @@ TEST(Multiplication, SingleLimbOverflow) {
     const big_int a{max_val};
     const big_int b{2};
     const big_int r = a * b;
-    // max_val * 2 = 2^65 - 2 = [0xFFFFFFFFFFFFFFFE, 1]
-    ASSERT_EQ(r.representation().size(), 2u);
-    EXPECT_EQ(r.representation()[0], max_val - 1);
-    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+    EXPECT_EQ(r, (big_int{1} << 65) + big_int{-2});
 }
 
 TEST(Multiplication, SingleLimbTimesMultiLimb) {
     // (2^64) * 3 = 3 * 2^64
     const big_int two_64 = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
     const big_int r      = two_64 * big_int{3};
-    // 3 * 2^64 = [0, 3]
-    ASSERT_EQ(r.representation().size(), 2u);
-    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
-    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{3});
+    EXPECT_EQ(r, big_int{3} << 64);
 }
 
 TEST(Multiplication, MultiLimbTimesMultiLimb) {
     // (2^64) * (2^64) = 2^128
     const big_int two_64 = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
     const big_int r      = two_64 * two_64;
-    // 2^128 = [0, 0, 1] in 64-bit limbs
-    ASSERT_EQ(r.representation().size(), 3u);
-    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
-    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{0});
-    EXPECT_EQ(r.representation()[2], uint_multiprecision_t{1});
+    EXPECT_EQ(r, big_int{1} << 128);
 }
 
 TEST(Multiplication, SelfMultiplication) {
@@ -234,10 +226,7 @@ TEST(Multiplication, CompoundAssignmentSelf) {
 TEST(Multiplication, CompoundAssignmentMultiLimb) {
     big_int a = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1}; // 2^64
     a *= big_int{2};
-    // 2^65 = [0, 2]
-    ASSERT_EQ(a.representation().size(), 2u);
-    EXPECT_EQ(a.representation()[0], uint_multiprecision_t{0});
-    EXPECT_EQ(a.representation()[1], uint_multiprecision_t{2});
+    EXPECT_EQ(a, big_int{1} << 65);
 }
 
 TEST(Multiplication, LargeMultiLimbLongMul) {

--- a/tests/beman/big_int/subtraction.test.cpp
+++ b/tests/beman/big_int/subtraction.test.cpp
@@ -8,6 +8,8 @@
 
 #include <beman/big_int/big_int.hpp>
 
+#include "testing.hpp"
+
 namespace {
 
 using beman::big_int::basic_big_int;
@@ -86,9 +88,7 @@ TEST(Subtraction, BorrowAcrossLimbPromotesToHeap) {
     const big_int b{-1};
     // a - b = a + 1 = 2^64 → two-limb result, must promote to heap.
     const big_int r = a - b;
-    ASSERT_EQ(r.representation().size(), 2u);
-    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
-    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+    EXPECT_EQ(r, big_int{1} << 64);
     EXPECT_GT(r.capacity(), 0u);
 }
 
@@ -96,26 +96,22 @@ TEST(Subtraction, NoAllocationWhenInlineFits) {
     using big_int_256 = basic_big_int<256>;
     const big_int_256 a{std::numeric_limits<std::uint64_t>::max()};
     const big_int_256 b{-1};
-    const big_int_256 r = a - b; // 2^64 — still fits inline in a 256-bit inline buffer.
+    const big_int_256 r        = a - b; // 2^64 — still fits inline in a 256-bit inline buffer.
+    const big_int_256 expected = big_int_256{1} << 64;
     EXPECT_EQ(r.capacity(), 0u);
-    ASSERT_EQ(r.representation().size(), 2u);
-    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
-    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+    EXPECT_EQ(r, expected);
 }
 
 TEST(Subtraction, MultiLimbSameSignTrimsLeadingZeros) {
     // 2^64 - 1 = UINT64_MAX → must trim back to one limb.
     const big_int two_64 = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
     const big_int r      = two_64 - big_int{1};
-    ASSERT_EQ(r.representation().size(), 1u);
-    EXPECT_EQ(r.representation()[0], std::numeric_limits<std::uint64_t>::max());
+    EXPECT_EQ(r, std::numeric_limits<std::uint64_t>::max());
 }
 
 TEST(Subtraction, MultiLimbCancelsToZero) {
     const big_int two_64 = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
     const big_int r      = two_64 - two_64;
-    ASSERT_EQ(r.representation().size(), 1u);
-    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
     EXPECT_EQ(r, 0);
     EXPECT_FALSE(r < 0);
 }
@@ -125,9 +121,7 @@ TEST(Subtraction, MultiLimbSameSignCrossesLimbBoundary) {
     const big_int two_64 = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
     const big_int two_65 = two_64 + two_64;
     const big_int r      = two_65 - two_64;
-    ASSERT_EQ(r.representation().size(), 2u);
-    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
-    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+    EXPECT_EQ(r, big_int{1} << 64);
 }
 
 TEST(Subtraction, BigIntMinusPrimitiveUnsigned) {
@@ -163,9 +157,7 @@ TEST(Subtraction, PrimitiveSignedMinusBigInt) {
 TEST(Subtraction, PrimitiveBorrowAcrossLimb) {
     // big_int{UINT64_MAX} - (-1) = 2^64 via primitive rhs.
     const big_int r = big_int{std::numeric_limits<std::uint64_t>::max()} - -1;
-    ASSERT_EQ(r.representation().size(), 2u);
-    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{0});
-    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+    EXPECT_EQ(r, big_int{1} << 64);
 }
 
 TEST(Subtraction, UnequalLengthMultiLimb) {
@@ -173,15 +165,11 @@ TEST(Subtraction, UnequalLengthMultiLimb) {
     const big_int two_64 = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
     const big_int a      = two_64 + big_int{10};
     const big_int r      = a - big_int{3};
-    ASSERT_EQ(r.representation().size(), 2u);
-    EXPECT_EQ(r.representation()[0], uint_multiprecision_t{7});
-    EXPECT_EQ(r.representation()[1], uint_multiprecision_t{1});
+    EXPECT_EQ(r, (big_int{1} << 64) + big_int{7});
 
     // (2^64 + 10) - (-3) = 2^64 + 13: long minus negative short, same-sign add path.
     const big_int r2 = a - big_int{-3};
-    ASSERT_EQ(r2.representation().size(), 2u);
-    EXPECT_EQ(r2.representation()[0], uint_multiprecision_t{13});
-    EXPECT_EQ(r2.representation()[1], uint_multiprecision_t{1});
+    EXPECT_EQ(r2, (big_int{1} << 64) + big_int{13});
 }
 
 TEST(Subtraction, AgreesWithAdditionOfNegated) {
@@ -212,8 +200,7 @@ TEST(Subtraction, RvalueLhsReusesStorage) {
     ASSERT_GT(a.capacity(), 0u);
     const big_int r = std::move(a) - big_int{1}; // 2^64 - 1 trims to one limb
     EXPECT_EQ(r.representation().data(), a_data);
-    ASSERT_EQ(r.representation().size(), 1u);
-    EXPECT_EQ(r.representation()[0], std::numeric_limits<std::uint64_t>::max());
+    EXPECT_EQ(r, std::numeric_limits<std::uint64_t>::max());
 }
 
 TEST(Subtraction, RvalueRhsReusesStorage) {
@@ -223,8 +210,7 @@ TEST(Subtraction, RvalueRhsReusesStorage) {
     ASSERT_GT(b.capacity(), 0u);
     const big_int r = small - std::move(b); // 1 - 2^64 = -(2^64 - 1)
     EXPECT_EQ(r.representation().data(), b_data);
-    ASSERT_EQ(r.representation().size(), 1u);
-    EXPECT_EQ(r.representation()[0], std::numeric_limits<std::uint64_t>::max());
+    EXPECT_EQ(r, -big_int{std::numeric_limits<std::uint64_t>::max()});
     EXPECT_TRUE(r < 0);
 }
 
@@ -292,16 +278,14 @@ TEST(Subtraction, RvaluePrimitiveMix) {
     const auto*   a_data = a.representation().data();
     const big_int r      = std::move(a) - 1U;
     EXPECT_EQ(r.representation().data(), a_data);
-    ASSERT_EQ(r.representation().size(), 1u);
-    EXPECT_EQ(r.representation()[0], std::numeric_limits<std::uint64_t>::max());
+    EXPECT_EQ(r, std::numeric_limits<std::uint64_t>::max());
 
     // primitive minus rvalue big_int: should reuse rhs (via negate + add).
     big_int       b      = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
     const auto*   b_data = b.representation().data();
     const big_int r2     = 1 - std::move(b); // 1 - 2^64 = -(2^64 - 1)
     EXPECT_EQ(r2.representation().data(), b_data);
-    ASSERT_EQ(r2.representation().size(), 1u);
-    EXPECT_EQ(r2.representation()[0], std::numeric_limits<std::uint64_t>::max());
+    EXPECT_EQ(r2, -big_int{std::numeric_limits<std::uint64_t>::max()});
     EXPECT_TRUE(r2 < 0);
 }
 

--- a/tests/beman/big_int/testing.hpp
+++ b/tests/beman/big_int/testing.hpp
@@ -1,0 +1,22 @@
+#ifndef BEMAN_BIG_INT_TEST_HPP
+#define BEMAN_BIG_INT_TEST_HPP
+
+#include <ostream>
+
+#include <beman/big_int/big_int.hpp>
+
+namespace beman::big_int {
+
+template <std::size_t b, class A>
+std::ostream& operator<<(std::ostream& out, const basic_big_int<b, A>& x) {
+    return out << to_string(x);
+}
+
+template <class T>
+std::ostream& operator<<(std::ostream& out, const div_result<T>& x) {
+    return out << "{.quotient = " << x.quotient << ", .remainder = " << x.remainder << '}';
+}
+
+} // namespace beman::big_int
+
+#endif // BEMAN_BIG_INT_TEST_HPP

--- a/tests/beman/big_int/vs_cpp_int.test.cpp
+++ b/tests/beman/big_int/vs_cpp_int.test.cpp
@@ -6,6 +6,8 @@
 #include <cstddef>
 #include <functional>
 
+#include "testing.hpp"
+
 namespace {
 
 namespace bmp = ::beman::big_int::boost_mp_testing;

--- a/tests/beman/big_int/wide_ops.test.cpp
+++ b/tests/beman/big_int/wide_ops.test.cpp
@@ -6,6 +6,8 @@
 
 #include <limits>
 
+#include "testing.hpp"
+
 namespace {
 
 using beman::big_int::uint_multiprecision_t;
@@ -77,18 +79,18 @@ TEST(WideOps, WideEquality) {
     constexpr wide<uint_multiprecision_t> c{.low_bits = 2ull, .high_bits = 2ull};
     constexpr wide<uint_multiprecision_t> d{.low_bits = 1ull, .high_bits = 3ull};
 
-    EXPECT_EQ(a == b, true);
-    EXPECT_EQ(b == a, true);
-    EXPECT_EQ(a == c, false);
-    EXPECT_EQ(c == a, false);
-    EXPECT_EQ(a == d, false);
-    EXPECT_EQ(d == a, false);
-    EXPECT_EQ(b == c, false);
-    EXPECT_EQ(c == b, false);
-    EXPECT_EQ(b == d, false);
-    EXPECT_EQ(d == b, false);
-    EXPECT_EQ(c == d, false);
-    EXPECT_EQ(d == c, false);
+    EXPECT_EQ(a, b);
+    EXPECT_EQ(b, a);
+    EXPECT_NE(a, c);
+    EXPECT_NE(c, a);
+    EXPECT_NE(a, d);
+    EXPECT_NE(d, a);
+    EXPECT_NE(b, c);
+    EXPECT_NE(c, b);
+    EXPECT_NE(b, d);
+    EXPECT_NE(d, b);
+    EXPECT_NE(c, d);
+    EXPECT_NE(d, c);
 }
 
 TEST(WideOps, WideningMulInt) {
@@ -243,17 +245,17 @@ TEST(WideOps, OverflowingAddInt) {
     const auto r6 = overflowing_add<int_multiprecision_t>(std::numeric_limits<int_multiprecision_t>::max(), -1);
 
     EXPECT_EQ(r1.value, static_cast<int_multiprecision_t>(0));
-    EXPECT_EQ(r1.overflow, false);
+    EXPECT_FALSE(r1.overflow);
     EXPECT_EQ(r2.value, static_cast<int_multiprecision_t>(12));
-    EXPECT_EQ(r2.overflow, false);
+    EXPECT_FALSE(r2.overflow);
     EXPECT_EQ(r3.value, static_cast<int_multiprecision_t>(-12));
-    EXPECT_EQ(r3.overflow, false);
+    EXPECT_FALSE(r3.overflow);
     EXPECT_EQ(r4.value, std::numeric_limits<int_multiprecision_t>::min());
-    EXPECT_EQ(r4.overflow, true);
+    EXPECT_TRUE(r4.overflow);
     EXPECT_EQ(r5.value, std::numeric_limits<int_multiprecision_t>::max());
-    EXPECT_EQ(r5.overflow, true);
+    EXPECT_TRUE(r5.overflow);
     EXPECT_EQ(r6.value, std::numeric_limits<int_multiprecision_t>::max() - 1);
-    EXPECT_EQ(r6.overflow, false);
+    EXPECT_FALSE(r6.overflow);
 }
 
 TEST(WideOps, OverflowingAddUint) {
@@ -268,17 +270,17 @@ TEST(WideOps, OverflowingAddUint) {
         overflowing_add<uint_multiprecision_t>(std::numeric_limits<uint_multiprecision_t>::max() - 1ull, 1ull);
 
     EXPECT_EQ(r1.value, 0ull);
-    EXPECT_EQ(r1.overflow, false);
+    EXPECT_FALSE(r1.overflow);
     EXPECT_EQ(r2.value, 3ull);
-    EXPECT_EQ(r2.overflow, false);
+    EXPECT_FALSE(r2.overflow);
     EXPECT_EQ(r3.value, 12ull);
-    EXPECT_EQ(r3.overflow, false);
+    EXPECT_FALSE(r3.overflow);
     EXPECT_EQ(r4.value, 0ull);
-    EXPECT_EQ(r4.overflow, true);
+    EXPECT_TRUE(r4.overflow);
     EXPECT_EQ(r5.value, std::numeric_limits<uint_multiprecision_t>::max());
-    EXPECT_EQ(r5.overflow, false);
+    EXPECT_FALSE(r5.overflow);
     EXPECT_EQ(r6.value, std::numeric_limits<uint_multiprecision_t>::max());
-    EXPECT_EQ(r6.overflow, false);
+    EXPECT_FALSE(r6.overflow);
 }
 
 TEST(WideOps, OverflowingSubInt) {
@@ -292,17 +294,17 @@ TEST(WideOps, OverflowingSubInt) {
     const auto r6 = overflowing_sub<int_multiprecision_t>(std::numeric_limits<int_multiprecision_t>::min(), -1);
 
     EXPECT_EQ(r1.value, static_cast<int_multiprecision_t>(0));
-    EXPECT_EQ(r1.overflow, false);
+    EXPECT_FALSE(r1.overflow);
     EXPECT_EQ(r2.value, static_cast<int_multiprecision_t>(2));
-    EXPECT_EQ(r2.overflow, false);
+    EXPECT_FALSE(r2.overflow);
     EXPECT_EQ(r3.value, static_cast<int_multiprecision_t>(-2));
-    EXPECT_EQ(r3.overflow, false);
+    EXPECT_FALSE(r3.overflow);
     EXPECT_EQ(r4.value, std::numeric_limits<int_multiprecision_t>::max());
-    EXPECT_EQ(r4.overflow, true);
+    EXPECT_TRUE(r4.overflow);
     EXPECT_EQ(r5.value, std::numeric_limits<int_multiprecision_t>::min());
-    EXPECT_EQ(r5.overflow, true);
+    EXPECT_TRUE(r5.overflow);
     EXPECT_EQ(r6.value, std::numeric_limits<int_multiprecision_t>::min() + 1);
-    EXPECT_EQ(r6.overflow, false);
+    EXPECT_FALSE(r6.overflow);
 }
 
 TEST(WideOps, OverflowingSubUint) {
@@ -317,17 +319,17 @@ TEST(WideOps, OverflowingSubUint) {
                                                            std::numeric_limits<uint_multiprecision_t>::max());
 
     EXPECT_EQ(r1.value, 0ull);
-    EXPECT_EQ(r1.overflow, false);
+    EXPECT_FALSE(r1.overflow);
     EXPECT_EQ(r2.value, 2ull);
-    EXPECT_EQ(r2.overflow, false);
+    EXPECT_FALSE(r2.overflow);
     EXPECT_EQ(r3.value, std::numeric_limits<uint_multiprecision_t>::max());
-    EXPECT_EQ(r3.overflow, true);
+    EXPECT_TRUE(r3.overflow);
     EXPECT_EQ(r4.value, 1ull);
-    EXPECT_EQ(r4.overflow, false);
+    EXPECT_FALSE(r4.overflow);
     EXPECT_EQ(r5.value, 0ull);
-    EXPECT_EQ(r5.overflow, false);
+    EXPECT_FALSE(r5.overflow);
     EXPECT_EQ(r6.value, 0ull);
-    EXPECT_EQ(r6.overflow, false);
+    EXPECT_FALSE(r6.overflow);
 }
 
 TEST(WideOps, OverflowingMulUint) {
@@ -342,17 +344,17 @@ TEST(WideOps, OverflowingMulUint) {
                                                            std::numeric_limits<uint_multiprecision_t>::max());
 
     EXPECT_EQ(r1.value, 0ull);
-    EXPECT_EQ(r1.overflow, false);
+    EXPECT_FALSE(r1.overflow);
     EXPECT_EQ(r2.value, 1ull);
-    EXPECT_EQ(r2.overflow, false);
+    EXPECT_FALSE(r2.overflow);
     EXPECT_EQ(r3.value, 35ull);
-    EXPECT_EQ(r3.overflow, false);
+    EXPECT_FALSE(r3.overflow);
     EXPECT_EQ(r4.value, 0ull);
-    EXPECT_EQ(r4.overflow, true);
+    EXPECT_TRUE(r4.overflow);
     EXPECT_EQ(r5.value, std::numeric_limits<uint_multiprecision_t>::max() - 1ull);
-    EXPECT_EQ(r5.overflow, true);
+    EXPECT_TRUE(r5.overflow);
     EXPECT_EQ(r6.value, 1ull);
-    EXPECT_EQ(r6.overflow, true);
+    EXPECT_TRUE(r6.overflow);
 }
 
 TEST(WideOps, CarryingAddUint) {
@@ -368,17 +370,17 @@ TEST(WideOps, CarryingAddUint) {
     const auto r6 = carrying_add<uint_multiprecision_t>(42ull, 58ull, false);
 
     EXPECT_EQ(r1.value, 0ull);
-    EXPECT_EQ(r1.carry, false);
+    EXPECT_FALSE(r1.carry);
     EXPECT_EQ(r2.value, 3ull);
-    EXPECT_EQ(r2.carry, false);
+    EXPECT_FALSE(r2.carry);
     EXPECT_EQ(r3.value, 0ull);
-    EXPECT_EQ(r3.carry, true);
+    EXPECT_TRUE(r3.carry);
     EXPECT_EQ(r4.value, std::numeric_limits<uint_multiprecision_t>::max() - 1ull);
-    EXPECT_EQ(r4.carry, true);
+    EXPECT_TRUE(r4.carry);
     EXPECT_EQ(r5.value, std::numeric_limits<uint_multiprecision_t>::max());
-    EXPECT_EQ(r5.carry, true);
+    EXPECT_TRUE(r5.carry);
     EXPECT_EQ(r6.value, 100ull);
-    EXPECT_EQ(r6.carry, false);
+    EXPECT_FALSE(r6.carry);
 }
 
 TEST(WideOps, BorrowingSubUint) {
@@ -392,17 +394,17 @@ TEST(WideOps, BorrowingSubUint) {
     const auto r6 = borrowing_sub<uint_multiprecision_t>(100ull, 58ull, false);
 
     EXPECT_EQ(r1.value, 0ull);
-    EXPECT_EQ(r1.borrow, false);
+    EXPECT_FALSE(r1.borrow);
     EXPECT_EQ(r2.value, 2ull);
-    EXPECT_EQ(r2.borrow, false);
+    EXPECT_FALSE(r2.borrow);
     EXPECT_EQ(r3.value, std::numeric_limits<uint_multiprecision_t>::max());
-    EXPECT_EQ(r3.borrow, true);
+    EXPECT_TRUE(r3.borrow);
     EXPECT_EQ(r4.value, std::numeric_limits<uint_multiprecision_t>::max());
-    EXPECT_EQ(r4.borrow, true);
+    EXPECT_TRUE(r4.borrow);
     EXPECT_EQ(r5.value, 0ull);
-    EXPECT_EQ(r5.borrow, false);
+    EXPECT_FALSE(r5.borrow);
     EXPECT_EQ(r6.value, 42ull);
-    EXPECT_EQ(r6.borrow, false);
+    EXPECT_FALSE(r6.borrow);
 }
 
 TEST(WideOps, NarrowingDivUint) {


### PR DESCRIPTION
A lot of the tests were written before we had `operator==` and `operator<=>` implemented, so they couldn't use `EXPECT_EQ` yet and stuff.

Now that we also have `to_string`, it is hugely better to use `EXPECT_NE` because `EXPECT_EQ` not only works, but also prints out the integer value on failure, greatly improving test ergonomics.