### PR TITLE
Optimize `to_chars` for special powers of two, fix `limb_max_input_digits`

### DIFF
--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -2856,19 +2856,22 @@ inline constexpr auto digit_value_table = []() consteval {
 
 [[nodiscard]] consteval unsigned char limb_max_input_digits_naive(const int base) {
     BEMAN_BIG_INT_ASSERT(base >= 2);
+    const auto ubase = static_cast<uint_multiprecision_t>(base);
+    if (std::has_single_bit(ubase)) {
+        return detail::width_v<uint_multiprecision_t> / static_cast<unsigned char>(std::countr_zero(ubase));
+    }
 
     uint_multiprecision_t x      = 1;
     int                   result = 0;
     while (true) {
-        const auto [product, overflow] = overflowing_mul(x, static_cast<uint_multiprecision_t>(base));
+        const auto [product, overflow] = overflowing_mul(x, ubase);
         if (overflow) {
-            break;
+            return static_cast<unsigned char>(product == 0 ? result + 1 : result);
         }
         x = product;
         ++result;
         BEMAN_BIG_INT_ASSERT(product != 0);
     }
-    return static_cast<unsigned char>(result - 1);
 }
 
 inline constexpr auto limb_max_input_digits_table = []() consteval {

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -2918,7 +2918,8 @@ inline constexpr auto limb_max_power_table = []() consteval {
 template <size_t b, class A>
 constexpr std::to_chars_result
 to_chars(char* const begin, char* const end, const basic_big_int<b, A>& x, const int base) {
-    using size_type = typename basic_big_int<b, A>::size_type;
+    using size_type                   = typename basic_big_int<b, A>::size_type;
+    constexpr size_type bits_per_limb = basic_big_int<b, A>::bits_per_limb;
 
     BEMAN_BIG_INT_DEBUG_ASSERT(begin);
     BEMAN_BIG_INT_DEBUG_ASSERT(end);
@@ -2948,10 +2949,10 @@ to_chars(char* const begin, char* const end, const basic_big_int<b, A>& x, const
     // the entire implementation (regardless of base) can be delegated to `std::to_chars`.
     {
         constexpr bool ignore_sign = true;
-        if (width <= detail::width_v<uint_multiprecision_t>) {
+        if (width <= bits_per_limb) {
             // The super happy case is that we can use the std::to_chars implementation for a single limb.
             return std::to_chars(current_begin, end, x.template to<uint_multiprecision_t, ignore_sign>(), base);
-        } else if constexpr (detail::width_v<uint_multiprecision_t> < detail::width_v<std::uintmax_t>) {
+        } else if constexpr (bits_per_limb < detail::width_v<std::uintmax_t>) {
             // The slightly less happy case is that we need to use
             // the multiprecision implementation of `std::to_chars`.
             // While we could skip the previous "super happy" check, it may be cheaper to dispatch here
@@ -2977,7 +2978,7 @@ to_chars(char* const begin, char* const end, const basic_big_int<b, A>& x, const
         const auto bits_per_digit     = static_cast<size_type>(std::countr_zero(static_cast<unsigned char>(base)));
         const auto bits_per_iteration = static_cast<size_type>(std::countr_zero(max_pow));
         BEMAN_BIG_INT_DEBUG_ASSERT(bits_per_iteration != 0);
-        BEMAN_BIG_INT_DEBUG_ASSERT(bits_per_iteration <= detail::width_v<uint_multiprecision_t>);
+        BEMAN_BIG_INT_DEBUG_ASSERT(bits_per_iteration <= bits_per_limb);
         BEMAN_BIG_INT_DEBUG_ASSERT(bits_per_iteration % bits_per_digit == 0);
 
         const size_type leading_bits       = width % bits_per_iteration;
@@ -2997,33 +2998,55 @@ to_chars(char* const begin, char* const end, const basic_big_int<b, A>& x, const
             }
         }
 
-        // clang-format off
-        const auto chunk_mask = (bits_per_iteration == detail::width_v<uint_multiprecision_t>
-                              ? uint_multiprecision_t{}
-                              : (uint_multiprecision_t{1} << bits_per_iteration)) - 1;
         const auto digit_mask = (uint_multiprecision_t{1} << bits_per_digit) - 1;
-        // clang-format on
 
         // Once the head digits are printed out, every subsequent block of bits
         // has exactly the same amount of digits.
         // For example, when printing a 128-bit integer in octal, there are 126 bits left,
         // handled exactly 63 bits at a time.
-        while (current_bit_offset >= bits_per_iteration) {
-            current_bit_offset -= bits_per_iteration;
 
-            const uint_multiprecision_t chunk = x.get_bits_at(current_bit_offset) & chunk_mask;
+        if (max_pow == 0) {
+            // Special case for bases 2, 4, and 16 where we process one limb per iteration.
+            BEMAN_BIG_INT_DEBUG_ASSERT(bits_per_iteration == bits_per_limb);
+            BEMAN_BIG_INT_DEBUG_ASSERT(current_bit_offset % bits_per_limb == 0);
+            BEMAN_BIG_INT_DEBUG_ASSERT(current_bit_offset % bits_per_iteration == 0);
 
-            for (size_type i = max_digits_per_iteration; i-- > 0;) {
-                if (current_begin == end) {
-                    return {end, std::errc::value_too_large};
+            const auto* const limbs       = x.limb_ptr();
+            const size_type   whole_limbs = current_bit_offset / bits_per_limb;
+            for (size_type limb_index = whole_limbs; limb_index-- > 0;) {
+                const uint_multiprecision_t limb = limbs[limb_index];
+
+                for (size_type i = max_digits_per_iteration; i-- > 0;) {
+                    if (current_begin == end) {
+                        return {end, std::errc::value_too_large};
+                    }
+                    const uint_multiprecision_t digit_value = (limb >> (i * bits_per_digit)) & digit_mask;
+                    *current_begin                          = alphabet[digit_value];
+                    ++current_begin;
                 }
-                const uint_multiprecision_t digit_value = (chunk >> (i * bits_per_digit)) & digit_mask;
-                *current_begin                          = alphabet[digit_value];
-                ++current_begin;
             }
+        } else {
+            // General case for other powers of two.
+            BEMAN_BIG_INT_DEBUG_ASSERT(bits_per_iteration < bits_per_limb);
+            const auto chunk_mask = (uint_multiprecision_t{1} << bits_per_iteration) - 1;
+
+            while (current_bit_offset >= bits_per_iteration) {
+                current_bit_offset -= bits_per_iteration;
+
+                const uint_multiprecision_t chunk = x.get_bits_at(current_bit_offset) & chunk_mask;
+
+                for (size_type i = max_digits_per_iteration; i-- > 0;) {
+                    if (current_begin == end) {
+                        return {end, std::errc::value_too_large};
+                    }
+                    const uint_multiprecision_t digit_value = (chunk >> (i * bits_per_digit)) & digit_mask;
+                    *current_begin                          = alphabet[digit_value];
+                    ++current_begin;
+                }
+            }
+            BEMAN_BIG_INT_DEBUG_ASSERT(current_bit_offset == 0);
         }
 
-        BEMAN_BIG_INT_DEBUG_ASSERT(current_bit_offset == 0);
         return {current_begin, std::errc{}};
     }
 

--- a/tests/beman/big_int/charconv.test.cpp
+++ b/tests/beman/big_int/charconv.test.cpp
@@ -10,9 +10,7 @@ namespace {
 
 using namespace beman::big_int;
 
-constexpr std::size_t bits_per_limb = detail::width_v<uint_multiprecision_t>;
-
-static_assert(std::has_single_bit(bits_per_limb),
+static_assert(std::has_single_bit(detail::width_v<uint_multiprecision_t>),
               "The to_chars and from_chars implementations assume "
               "that the limb width is a power of two.");
 
@@ -36,7 +34,7 @@ static_assert(1234567890123456789012345678901234567890112233445566778899_n == pa
 static_assert(1234567890123456789012345678901234567890112233445566778899_n == parse("2443030312003032423221132100412422141210014133224140342114014311130233010043411044", 5));
 
 TEST(Charconv, LimbMaxInputDigits) {
-    if constexpr (bits_per_limb == 64) {
+    if constexpr (detail::width_v<uint_multiprecision_t> == 64) {
         EXPECT_EQ(detail::limb_max_input_digits(2), 64);
         EXPECT_EQ(detail::limb_max_input_digits(3), 40);
         EXPECT_EQ(detail::limb_max_input_digits(4), 32);
@@ -76,7 +74,7 @@ TEST(Charconv, LimbMaxInputDigits) {
 }
 
 TEST(Charconv, LimbMaxPower) {
-    if constexpr (bits_per_limb == 64) {
+    if constexpr (detail::width_v<uint_multiprecision_t> == 64) {
         EXPECT_EQ(detail::limb_max_power(2), 0ull);
         EXPECT_EQ(detail::limb_max_power(3), 12157665459056928801ull);
         EXPECT_EQ(detail::limb_max_power(4), 0ull);

--- a/tests/beman/big_int/charconv.test.cpp
+++ b/tests/beman/big_int/charconv.test.cpp
@@ -10,6 +10,12 @@ namespace {
 
 using namespace beman::big_int;
 
+constexpr std::size_t bits_per_limb = detail::width_v<uint_multiprecision_t>;
+
+static_assert(std::has_single_bit(bits_per_limb),
+              "The to_chars and from_chars implementations assume "
+              "that the limb width is a power of two.");
+
 [[nodiscard]] constexpr big_int parse(const std::string_view str, const int base) {
     BEMAN_BIG_INT_ASSERT(base >= 2 && base <= 36);
     big_int result;
@@ -28,6 +34,86 @@ static_assert(1234567890123456789012345678901234567890112233445566778899_n == pa
               "The tests in this file are meaningless because parsing of literals is broken.");
 // Powers of two are handled differently, so a second check makes sense.
 static_assert(1234567890123456789012345678901234567890112233445566778899_n == parse("2443030312003032423221132100412422141210014133224140342114014311130233010043411044", 5));
+
+TEST(Charconv, LimbMaxInputDigits) {
+    if constexpr (bits_per_limb == 64) {
+        EXPECT_EQ(detail::limb_max_input_digits(2), 64);
+        EXPECT_EQ(detail::limb_max_input_digits(3), 40);
+        EXPECT_EQ(detail::limb_max_input_digits(4), 32);
+        EXPECT_EQ(detail::limb_max_input_digits(5), 27);
+        EXPECT_EQ(detail::limb_max_input_digits(6), 24);
+        EXPECT_EQ(detail::limb_max_input_digits(7), 22);
+        EXPECT_EQ(detail::limb_max_input_digits(8), 21);
+        EXPECT_EQ(detail::limb_max_input_digits(9), 20);
+        EXPECT_EQ(detail::limb_max_input_digits(10), 19);
+        EXPECT_EQ(detail::limb_max_input_digits(11), 18);
+        EXPECT_EQ(detail::limb_max_input_digits(12), 17);
+        EXPECT_EQ(detail::limb_max_input_digits(13), 17);
+        EXPECT_EQ(detail::limb_max_input_digits(14), 16);
+        EXPECT_EQ(detail::limb_max_input_digits(15), 16);
+        EXPECT_EQ(detail::limb_max_input_digits(16), 16);
+        EXPECT_EQ(detail::limb_max_input_digits(17), 15);
+        EXPECT_EQ(detail::limb_max_input_digits(18), 15);
+        EXPECT_EQ(detail::limb_max_input_digits(19), 15);
+        EXPECT_EQ(detail::limb_max_input_digits(20), 14);
+        EXPECT_EQ(detail::limb_max_input_digits(21), 14);
+        EXPECT_EQ(detail::limb_max_input_digits(22), 14);
+        EXPECT_EQ(detail::limb_max_input_digits(23), 14);
+        EXPECT_EQ(detail::limb_max_input_digits(24), 13);
+        EXPECT_EQ(detail::limb_max_input_digits(25), 13);
+        EXPECT_EQ(detail::limb_max_input_digits(26), 13);
+        EXPECT_EQ(detail::limb_max_input_digits(27), 13);
+        EXPECT_EQ(detail::limb_max_input_digits(28), 13);
+        EXPECT_EQ(detail::limb_max_input_digits(29), 13);
+        EXPECT_EQ(detail::limb_max_input_digits(30), 13);
+        EXPECT_EQ(detail::limb_max_input_digits(31), 12);
+        EXPECT_EQ(detail::limb_max_input_digits(32), 12);
+        EXPECT_EQ(detail::limb_max_input_digits(33), 12);
+        EXPECT_EQ(detail::limb_max_input_digits(34), 12);
+        EXPECT_EQ(detail::limb_max_input_digits(35), 12);
+        EXPECT_EQ(detail::limb_max_input_digits(36), 12);
+    }
+}
+
+TEST(Charconv, LimbMaxPower) {
+    if constexpr (bits_per_limb == 64) {
+        EXPECT_EQ(detail::limb_max_power(2), 0ull);
+        EXPECT_EQ(detail::limb_max_power(3), 12157665459056928801ull);
+        EXPECT_EQ(detail::limb_max_power(4), 0ull);
+        EXPECT_EQ(detail::limb_max_power(5), 7450580596923828125ull);
+        EXPECT_EQ(detail::limb_max_power(6), 4738381338321616896ull);
+        EXPECT_EQ(detail::limb_max_power(7), 3909821048582988049ull);
+        EXPECT_EQ(detail::limb_max_power(8), 9223372036854775808ull);
+        EXPECT_EQ(detail::limb_max_power(9), 12157665459056928801ull);
+        EXPECT_EQ(detail::limb_max_power(10), 10000000000000000000ull);
+        EXPECT_EQ(detail::limb_max_power(11), 5559917313492231481ull);
+        EXPECT_EQ(detail::limb_max_power(12), 2218611106740436992ull);
+        EXPECT_EQ(detail::limb_max_power(13), 8650415919381337933ull);
+        EXPECT_EQ(detail::limb_max_power(14), 2177953337809371136ull);
+        EXPECT_EQ(detail::limb_max_power(15), 6568408355712890625ull);
+        EXPECT_EQ(detail::limb_max_power(16), 0ull);
+        EXPECT_EQ(detail::limb_max_power(17), 2862423051509815793ull);
+        EXPECT_EQ(detail::limb_max_power(18), 6746640616477458432ull);
+        EXPECT_EQ(detail::limb_max_power(19), 15181127029874798299ull);
+        EXPECT_EQ(detail::limb_max_power(20), 1638400000000000000ull);
+        EXPECT_EQ(detail::limb_max_power(21), 3243919932521508681ull);
+        EXPECT_EQ(detail::limb_max_power(22), 6221821273427820544ull);
+        EXPECT_EQ(detail::limb_max_power(23), 11592836324538749809ull);
+        EXPECT_EQ(detail::limb_max_power(24), 876488338465357824ull);
+        EXPECT_EQ(detail::limb_max_power(25), 1490116119384765625ull);
+        EXPECT_EQ(detail::limb_max_power(26), 2481152873203736576ull);
+        EXPECT_EQ(detail::limb_max_power(27), 4052555153018976267ull);
+        EXPECT_EQ(detail::limb_max_power(28), 6502111422497947648ull);
+        EXPECT_EQ(detail::limb_max_power(29), 10260628712958602189ull);
+        EXPECT_EQ(detail::limb_max_power(30), 15943230000000000000ull);
+        EXPECT_EQ(detail::limb_max_power(31), 787662783788549761ull);
+        EXPECT_EQ(detail::limb_max_power(32), 1152921504606846976ull);
+        EXPECT_EQ(detail::limb_max_power(33), 1667889514952984961ull);
+        EXPECT_EQ(detail::limb_max_power(34), 2386420683693101056ull);
+        EXPECT_EQ(detail::limb_max_power(35), 3379220508056640625ull);
+        EXPECT_EQ(detail::limb_max_power(36), 4738381338321616896ull);
+    }
+}
 
 TEST(FromChars, DigitValue) {
     EXPECT_EQ(detail::digit_value('0'), 0);


### PR DESCRIPTION
Closes #124
Fixes #140
