### PR TITLE
Expand floating-point utils, make constexpr

### DIFF
--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -2612,7 +2612,7 @@ constexpr void basic_big_int<b, A>::assign_from_float(const F value) noexcept {
 #ifdef BEMAN_BIG_INT_UNSUPPORTED_LONG_DOUBLE
     static_assert(!std::is_same_v<F, long double>, "long double is not supported on this platform");
 #endif
-    BEMAN_BIG_INT_ASSERT(std::isfinite(value));
+    BEMAN_BIG_INT_ASSERT(detail::constexpr_isfinite(value));
 
     // In the happiest case, we can use the intrinsic conversion from binary32 to uint128_t.
     // Compilers have optimized routines for this,

--- a/include/beman/big_int/detail/config.hpp
+++ b/include/beman/big_int/detail/config.hpp
@@ -30,10 +30,17 @@
     #define BEMAN_BIG_INT_HAS_BUILTIN(...) 0
 #endif // __has_builtin
 
+// In addition to BEMAN_BIG_INT_HAS_CONSTEXPR_BUILTIN, which is an exact test,
+// `BEMAN_BIG_INT_HAS_CONSTEXPR_BUILTIN_OR_BUILTIN` falls back onto `BEMAN_BIG_INT_HAS_BUILTIN`
+// if constexpr builtin testing is not available.
+// This is useful for GCC, which supports __has_builtin but not __has_constexpr_builtin,
+// and many GCC intrinsics are usable during constant evaluation.
 #ifdef __has_constexpr_builtin
     #define BEMAN_BIG_INT_HAS_CONSTEXPR_BUILTIN(...) __has_constexpr_builtin(__VA_ARGS__)
+    #define BEMAN_BIG_INT_HAS_CONSTEXPR_BUILTIN_OR_BUILTIN(...) __has_constexpr_builtin(__VA_ARGS__)
 #else
     #define BEMAN_BIG_INT_HAS_CONSTEXPR_BUILTIN(...) 0
+    #define BEMAN_BIG_INT_HAS_CONSTEXPR_BUILTIN_OR_BUILTIN(...) BEMAN_BIG_INT_HAS_BUILTIN(__VA_ARGS__)
 #endif // __has_constexpr_builtin
 
 // Undefine min()/max() for MSVC ===============================================

--- a/include/beman/big_int/detail/config.hpp
+++ b/include/beman/big_int/detail/config.hpp
@@ -20,10 +20,21 @@
     // Separate case for any GNU-C-compliant compilers,
     // which is both GCC and Clang.
     #define BEMAN_BIG_INT_GNUC __GNUC__
+#endif // __GNUC__
+
+// Builtin detection ===========================================================
+
+#ifdef __has_builtin
     #define BEMAN_BIG_INT_HAS_BUILTIN(...) __has_builtin(__VA_ARGS__)
 #else
     #define BEMAN_BIG_INT_HAS_BUILTIN(...) 0
-#endif // __GNUC__
+#endif // __has_builtin
+
+#ifdef __has_constexpr_builtin
+    #define BEMAN_BIG_INT_HAS_CONSTEXPR_BUILTIN(...) __has_constexpr_builtin(__VA_ARGS__)
+#else
+    #define BEMAN_BIG_INT_HAS_CONSTEXPR_BUILTIN(...) 0
+#endif // __has_constexpr_builtin
 
 // Undefine min()/max() for MSVC ===============================================
 #ifdef min

--- a/include/beman/big_int/detail/floats.hpp
+++ b/include/beman/big_int/detail/floats.hpp
@@ -159,11 +159,10 @@ template <cv_unqualified_floating_point F>
     return static_cast<bool>(__builtin_isfinite(x));
 #else
     if BEMAN_BIG_INT_IS_CONSTEVAL {
-        if (x != x) {
-            return false; // NaN
-        }
-        // Sorry, constexpr infinity detection not implemented yet.
-        BEMAN_BIG_INT_ASSERT(false);
+        BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
+        BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Wfloat-equal")
+        return x == x && x != std::numeric_limits<F>::infinity() && x != -std::numeric_limits<F>::infinity();
+        BEMAN_BIG_INT_DIAGNOSTIC_POP()
     } else {
         return std::isfinite(x);
     }

--- a/include/beman/big_int/detail/floats.hpp
+++ b/include/beman/big_int/detail/floats.hpp
@@ -135,6 +135,75 @@ struct ieee_traits<long double> : ieee_traits<double> {};
     #define BEMAN_BIG_INT_UNSUPPORTED_LONG_DOUBLE
 #endif
 
+template <cv_unqualified_floating_point F>
+[[nodiscard]] constexpr bool constexpr_signbit(const F x) noexcept {
+#if defined(__cpp_lib_constexpr_cmath) && __cpp_lib_constexpr_cmath >= 202202L
+    return std::signbit(x);
+#elif BEMAN_BIG_INT_HAS_CONSTEXPR_BUILTIN(__builtin_signbit)
+    return static_cast<bool>(__builtin_signbit(x));
+#else
+    if BEMAN_BIG_INT_IS_CONSTEVAL {
+        // Sorry, not implemented yet.
+        BEMAN_BIG_INT_ASSERT(false);
+    } else {
+        return std::signbit(x);
+    }
+#endif
+}
+
+template <cv_unqualified_floating_point F>
+[[nodiscard]] constexpr bool constexpr_isfinite(const F x) noexcept {
+#if defined(__cpp_lib_constexpr_cmath) && __cpp_lib_constexpr_cmath >= 202202L
+    return std::isfinite(x);
+#elif BEMAN_BIG_INT_HAS_CONSTEXPR_BUILTIN(__builtin_isfinite)
+    return static_cast<bool>(__builtin_isfinite(x));
+#else
+    if BEMAN_BIG_INT_IS_CONSTEVAL {
+        if (x != x) {
+            return false; // NaN
+        }
+        // Sorry, constexpr infinity detection not implemented yet.
+        BEMAN_BIG_INT_ASSERT(false);
+    } else {
+        return std::isfinite(x);
+    }
+#endif
+}
+
+template <cv_unqualified_floating_point F>
+[[nodiscard]] constexpr F constexpr_fabs(const F x) noexcept {
+#if defined(__cpp_lib_constexpr_cmath) && __cpp_lib_constexpr_cmath >= 202202L
+    return std::fabs(x);
+#elif BEMAN_BIG_INT_HAS_CONSTEXPR_BUILTIN(__builtin_fabs)
+    if constexpr (std::is_same_v<decltype(__builtin_fabs(x)), F>) {
+        // The builtin is either generic or F is double.
+        return __builtin_fabs(x);
+    } else {
+        if BEMAN_BIG_INT_IS_CONSTEVAL {
+    #if BEMAN_BIG_INT_HAS_CONSTEXPR_BUILTIN(__builtin_fabsf)
+            if constexpr (std::is_same_v<F, float>) {
+                return __builtin_fabsf(x);
+            }
+    #endif
+    #if BEMAN_BIG_INT_HAS_CONSTEXPR_BUILTIN(__builtin_fabsl)
+            if constexpr (std::is_same_v<F, long double>) {
+                return __builtin_fabsl(x);
+            }
+    #endif
+            return constexpr_signbit(x) ? -x : x;
+        } else {
+            return std::fabs(x);
+        }
+    }
+#else
+    if BEMAN_BIG_INT_IS_CONSTEVAL {
+        return constexpr_signbit(x) ? -x : x;
+    } else {
+        return std::fabs(x);
+    }
+#endif
+}
+
 // A triple that represents a finite floating-point number.
 // The represented value is `(sign ? -1 : 1) * mantissa * pow(b, exponent)`,
 // where `b` is the radix (usually two) of the floating-point number.
@@ -146,6 +215,8 @@ struct float_representation {
     int exponent;
     // The significand or "mantissa" of the floating-point number.
     T mantissa;
+
+    friend bool operator==(const float_representation&, const float_representation&) = default;
 };
 
 // Decomposes a finite floating-point value into a `float_representation` object.
@@ -156,7 +227,7 @@ template <cv_unqualified_floating_point F>
     using bits_t     = typename traits::bits_type;
     using mantissa_t = typename traits::mantissa_type;
 
-    BEMAN_BIG_INT_DEBUG_ASSERT(std::isfinite(value));
+    BEMAN_BIG_INT_DEBUG_ASSERT(constexpr_isfinite(value));
 
     constexpr int mb   = traits::mantissa_bits;
     constexpr int bias = traits::bias;
@@ -200,19 +271,6 @@ template <cv_unqualified_floating_point F>
         .exponent = static_cast<int>(ieee_exp) - bias - mb,
         .mantissa = ieee_mantissa,
     };
-}
-
-template <cv_unqualified_floating_point F>
-[[nodiscard]] constexpr F constexpr_fabs(const F x) {
-#if defined(__cpp_lib_constexpr_cmath) && __cpp_lib_constexpr_cmath >= 202306L
-    return std::fabs(x);
-#else
-    if BEMAN_BIG_INT_IS_CONSTEVAL {
-        return x < 0 ? -x : x;
-    } else {
-        return std::fabs(x);
-    }
-#endif
 }
 
 } // namespace beman::big_int::detail

--- a/include/beman/big_int/detail/floats.hpp
+++ b/include/beman/big_int/detail/floats.hpp
@@ -139,7 +139,7 @@ template <cv_unqualified_floating_point F>
 [[nodiscard]] constexpr bool constexpr_signbit(const F x) noexcept {
 #if defined(__cpp_lib_constexpr_cmath) && __cpp_lib_constexpr_cmath >= 202202L
     return std::signbit(x);
-#elif BEMAN_BIG_INT_HAS_CONSTEXPR_BUILTIN(__builtin_signbit)
+#elif BEMAN_BIG_INT_HAS_CONSTEXPR_BUILTIN_OR_BUILTIN(__builtin_signbit)
     return static_cast<bool>(__builtin_signbit(x));
 #else
     if BEMAN_BIG_INT_IS_CONSTEVAL {
@@ -156,7 +156,7 @@ template <cv_unqualified_floating_point F>
 [[nodiscard]] constexpr bool constexpr_isfinite(const F x) noexcept {
 #if defined(__cpp_lib_constexpr_cmath) && __cpp_lib_constexpr_cmath >= 202202L
     return std::isfinite(x);
-#elif BEMAN_BIG_INT_HAS_CONSTEXPR_BUILTIN(__builtin_isfinite)
+#elif BEMAN_BIG_INT_HAS_CONSTEXPR_BUILTIN_OR_BUILTIN(__builtin_isfinite)
     return static_cast<bool>(__builtin_isfinite(x));
 #else
     if BEMAN_BIG_INT_IS_CONSTEVAL {
@@ -174,7 +174,7 @@ template <cv_unqualified_floating_point F>
 [[nodiscard]] constexpr F constexpr_fabs(const F x) noexcept {
 #if defined(__cpp_lib_constexpr_cmath) && __cpp_lib_constexpr_cmath >= 202202L
     return std::fabs(x);
-#elif BEMAN_BIG_INT_HAS_CONSTEXPR_BUILTIN(__builtin_fabs)
+#elif BEMAN_BIG_INT_HAS_CONSTEXPR_BUILTIN_OR_BUILTIN(__builtin_fabs)
     if constexpr (std::is_same_v<decltype(__builtin_fabs(x)), F>) {
         // The builtin is either generic or F is double.
         return __builtin_fabs(x);

--- a/include/beman/big_int/detail/floats.hpp
+++ b/include/beman/big_int/detail/floats.hpp
@@ -143,8 +143,9 @@ template <cv_unqualified_floating_point F>
     return static_cast<bool>(__builtin_signbit(x));
 #else
     if BEMAN_BIG_INT_IS_CONSTEVAL {
-        // Sorry, not implemented yet.
-        BEMAN_BIG_INT_ASSERT(false);
+        // This implementation assumes that the sign bit is always the most significant bit.
+        const auto bits = std::bit_cast<typename ieee_traits<F>::bits_type>(x);
+        return ((bits >> (ieee_traits<F>::width - 1)) & 1) != 0;
     } else {
         return std::signbit(x);
     }

--- a/tests/beman/big_int/float_construction.test.cpp
+++ b/tests/beman/big_int/float_construction.test.cpp
@@ -11,6 +11,34 @@ namespace {
 
 using namespace beman::big_int::big_int_literals;
 
+// ----- compile-time sanity -----
+
+consteval bool ce_decompose_double_zero() {
+    const auto [sign, exponent, mantissa] = beman::big_int::detail::decompose_float(0.0);
+    return !sign && mantissa == 0;
+}
+static_assert(ce_decompose_double_zero());
+
+consteval bool ce_decompose_double_minus_zero() {
+    const auto [sign, exponent, mantissa] = beman::big_int::detail::decompose_float(-0.0);
+    return sign && mantissa == 0;
+}
+static_assert(ce_decompose_double_minus_zero());
+
+consteval bool ce_decompose_double_one() {
+    const auto [sign, exponent, mantissa] = beman::big_int::detail::decompose_float(1.0);
+    return !sign && (mantissa >> -exponent) == 1;
+}
+static_assert(ce_decompose_double_one());
+
+consteval bool ce_decompose_double_minus_one() {
+    const auto [sign, exponent, mantissa] = beman::big_int::detail::decompose_float(-1.0);
+    return sign && (mantissa >> -exponent) == 1;
+}
+static_assert(ce_decompose_double_minus_one());
+
+// ----- runtime tests -----
+
 TEST(FloatConstruction, DoubleZero) {
     beman::big_int::big_int x(0.0);
     EXPECT_EQ(x, 0);


### PR DESCRIPTION
It looks like we didn't have any `constexpr` tests for our floating-point stuff yet, and some of the code (namely the `isfinite` assertions) relies on `std::isfinite` always being `constexpr`, which is not the case.

This PR cleans up a bunch of these problems.