### PR TITLE
Implement constexpr long double decomposition

### DIFF
--- a/include/beman/big_int/detail/floats.hpp
+++ b/include/beman/big_int/detail/floats.hpp
@@ -100,9 +100,8 @@ struct ieee_traits<std::float128_t> {
 #endif
 
 struct x87_extended_float_bits {
-    std::uint64_t mantissa : 64;
-    std::uint16_t exponent : 15;
-    std::uint16_t sign : 1;
+    std::uint64_t mantissa;
+    std::uint16_t sign_and_exponent;
 };
 
 #if __LDBL_MANT_DIG__ == 64 && __LDBL_MAX_EXP__ == 16384
@@ -238,13 +237,10 @@ template <cv_unqualified_floating_point F>
     mantissa_t    ieee_mantissa;
 
     if constexpr (std::is_same_v<bits_t, detail::x87_extended_float_bits>) {
-        // UB on x86 due to 6 padding bytes.
-        if BEMAN_BIG_INT_IS_CONSTEVAL {
-            BEMAN_BIG_INT_ASSERT(false);
-        }
-        __builtin_memcpy(&bits, &value, sizeof(bits));
-        sign          = bits.sign;
-        ieee_exp      = static_cast<std::uint32_t>(bits.exponent);
+        constexpr std::uint16_t exponent_mask = ((std::uint16_t{1} << traits::exponent_bits) - 1);
+        bits                                  = std::bit_cast<bits_t>(value);
+        sign          = static_cast<bool>((bits.sign_and_exponent >> traits::exponent_bits) & 1);
+        ieee_exp      = static_cast<std::uint32_t>(bits.sign_and_exponent & exponent_mask);
         ieee_mantissa = bits.mantissa;
     } else {
         constexpr mantissa_t mantissa_mask = (mantissa_t{1} << mb) - 1;

--- a/include/beman/big_int/detail/floats.hpp
+++ b/include/beman/big_int/detail/floats.hpp
@@ -7,6 +7,7 @@
 #include <bit>
 #include <type_traits>
 #include <cmath>
+#include <cfloat>
 #include <limits>
 #include <cstdint>
 
@@ -104,8 +105,11 @@ struct x87_extended_float_bits {
     std::uint16_t sign_and_exponent;
 };
 
-#if __LDBL_MANT_DIG__ == 64 && __LDBL_MAX_EXP__ == 16384
+#if !defined(LDBL_MANT_DIG) || !defined(LDBL_MAX_EXP)
+    #error Cannot define ieee_traits<long double> without LDBL_MANT_DIG and LDBL_MAX_EXP.
+#endif
 
+#if LDBL_MANT_DIG == 64 && LDBL_MAX_EXP == 16384
 template <>
 struct ieee_traits<long double> {
     using bits_type                        = x87_extended_float_bits;
@@ -116,7 +120,7 @@ struct ieee_traits<long double> {
     static constexpr int  bias             = 16383;
     static constexpr bool explicit_int_bit = true;
 };
-#elif __LDBL_MANT_DIG__ == 113 && __LDBL_MAX_EXP__ == 16384
+#elif LDBL_MANT_DIG == 113 && LDBL_MAX_EXP == 16384
 template <>
 struct ieee_traits<long double> {
     using bits_type                        = uint128_t;
@@ -127,7 +131,7 @@ struct ieee_traits<long double> {
     static constexpr int  bias             = 16383;
     static constexpr bool explicit_int_bit = false;
 };
-#elif __LDBL_MANT_DIG__ == 53 && __LDBL_MAX_EXP__ == 1024
+#elif LDBL_MANT_DIG == 53 && LDBL_MAX_EXP == 1024
 template <>
 struct ieee_traits<long double> : ieee_traits<double> {};
 #else

--- a/tests/beman/big_int/float_construction.test.cpp
+++ b/tests/beman/big_int/float_construction.test.cpp
@@ -13,11 +13,29 @@ using namespace beman::big_int::big_int_literals;
 
 // ----- compile-time sanity -----
 
+consteval bool ce_decompose_float_zero() {
+    const auto [sign, exponent, mantissa] = beman::big_int::detail::decompose_float(0.0f);
+    return !sign && mantissa == 0;
+}
+static_assert(ce_decompose_float_zero());
+
 consteval bool ce_decompose_double_zero() {
     const auto [sign, exponent, mantissa] = beman::big_int::detail::decompose_float(0.0);
     return !sign && mantissa == 0;
 }
 static_assert(ce_decompose_double_zero());
+
+consteval bool ce_decompose_long_double_zero() {
+    const auto [sign, exponent, mantissa] = beman::big_int::detail::decompose_float(0.0l);
+    return !sign && mantissa == 0;
+}
+static_assert(ce_decompose_long_double_zero());
+
+consteval bool ce_decompose_float_minus_zero() {
+    const auto [sign, exponent, mantissa] = beman::big_int::detail::decompose_float(-0.0f);
+    return sign && mantissa == 0;
+}
+static_assert(ce_decompose_float_minus_zero());
 
 consteval bool ce_decompose_double_minus_zero() {
     const auto [sign, exponent, mantissa] = beman::big_int::detail::decompose_float(-0.0);
@@ -25,17 +43,47 @@ consteval bool ce_decompose_double_minus_zero() {
 }
 static_assert(ce_decompose_double_minus_zero());
 
+consteval bool ce_decompose_long_double_minus_zero() {
+    const auto [sign, exponent, mantissa] = beman::big_int::detail::decompose_float(-0.0l);
+    return sign && mantissa == 0;
+}
+static_assert(ce_decompose_long_double_minus_zero());
+
+consteval bool ce_decompose_float_one() {
+    const auto [sign, exponent, mantissa] = beman::big_int::detail::decompose_float(1.0f);
+    return !sign && (mantissa >> -exponent) == 1;
+}
+static_assert(ce_decompose_float_one());
+
 consteval bool ce_decompose_double_one() {
     const auto [sign, exponent, mantissa] = beman::big_int::detail::decompose_float(1.0);
     return !sign && (mantissa >> -exponent) == 1;
 }
 static_assert(ce_decompose_double_one());
 
+consteval bool ce_decompose_long_double_one() {
+    const auto [sign, exponent, mantissa] = beman::big_int::detail::decompose_float(1.0l);
+    return !sign && (mantissa >> -exponent) == 1;
+}
+static_assert(ce_decompose_long_double_one());
+
+consteval bool ce_decompose_float_minus_one() {
+    const auto [sign, exponent, mantissa] = beman::big_int::detail::decompose_float(-1.0f);
+    return sign && (mantissa >> -exponent) == 1;
+}
+static_assert(ce_decompose_float_minus_one());
+
 consteval bool ce_decompose_double_minus_one() {
     const auto [sign, exponent, mantissa] = beman::big_int::detail::decompose_float(-1.0);
     return sign && (mantissa >> -exponent) == 1;
 }
 static_assert(ce_decompose_double_minus_one());
+
+consteval bool ce_decompose_long_double_minus_one() {
+    const auto [sign, exponent, mantissa] = beman::big_int::detail::decompose_float(-1.0l);
+    return sign && (mantissa >> -exponent) == 1;
+}
+static_assert(ce_decompose_long_double_minus_one());
 
 // ----- runtime tests -----
 


### PR DESCRIPTION
While bit-casting to bit-fields is not supported yet, bit-fields aren't necessary here. Everything can be done using `std::uint64_t` and `std::uint16_t`. Since all the padding bits of x87 `long double` fall into the padding bits of `x87_extended_float_bits`, it's also possible to cast without undefined behavior.

Also `__LDBL_MANT_DIG__` is not defined on MSVC, so the existing code wasn't portable.