### PR TITLE
Test for round-tripping in `decompose_float`

### DIFF
--- a/include/beman/big_int/detail/floats.hpp
+++ b/include/beman/big_int/detail/floats.hpp
@@ -210,21 +210,24 @@ template <cv_unqualified_floating_point F>
 // A triple that represents a finite floating-point number.
 // The represented value is `(sign ? -1 : 1) * mantissa * pow(b, exponent)`,
 // where `b` is the radix (usually two) of the floating-point number.
-template <class T>
+template <class F>
 struct float_representation {
+    using exponent_type = int;
+    using mantissa_type = typename ieee_traits<F>::mantissa_type;
+
     // The sign bit, where `true` indicates a negative number.
     bool sign;
     // The unbiased exponent.
-    int exponent;
+    exponent_type exponent;
     // The significand or "mantissa" of the floating-point number.
-    T mantissa;
+    mantissa_type mantissa;
 
     friend bool operator==(const float_representation&, const float_representation&) = default;
 };
 
 // Decomposes a finite floating-point value into a `float_representation` object.
 template <cv_unqualified_floating_point F>
-[[nodiscard]] constexpr float_representation<typename ieee_traits<F>::mantissa_type> decompose_float(const F value) {
+[[nodiscard]] constexpr float_representation<F> decompose_float(const F value) {
     static_assert(std::numeric_limits<F>::radix == 2, "Only binary floating-point is supported.");
     using traits     = detail::ieee_traits<F>;
     using bits_t     = typename traits::bits_type;
@@ -271,6 +274,14 @@ template <cv_unqualified_floating_point F>
         .exponent = static_cast<int>(ieee_exp) - bias - mb,
         .mantissa = ieee_mantissa,
     };
+}
+
+template <cv_unqualified_floating_point F>
+[[nodiscard]] F compose_float(const float_representation<F> representation) {
+    static_assert(std::numeric_limits<F>::radix == 2, "Only binary floating-point is supported.");
+
+    const F magnitude = std::ldexp(static_cast<F>(representation.mantissa), representation.exponent);
+    return std::copysign(magnitude, representation.sign ? F{-1} : F{1});
 }
 
 } // namespace beman::big_int::detail

--- a/tests/beman/big_int/float_construction.test.cpp
+++ b/tests/beman/big_int/float_construction.test.cpp
@@ -154,7 +154,6 @@ TEST(DecomposeFloat, RoundTripLongDouble) {
                 BEMAN_BIG_INT_DIAGNOSTIC_POP()
             }
         } else if constexpr (sizeof(LongDouble) == sizeof(double)) {
-            static_assert(false);
             for (std::size_t i = 0; i < 20'000; ++i) {
                 const auto bits = rng();
                 const auto x    = std::bit_cast<LongDouble>(bits);

--- a/tests/beman/big_int/float_construction.test.cpp
+++ b/tests/beman/big_int/float_construction.test.cpp
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: BSL-1.0
 
 #include <climits>
+#include <bit>
+#include <cmath>
+#include <cstdint>
+#include <random>
 #include <beman/big_int/big_int.hpp>
 #include <gtest/gtest.h>
 
@@ -86,6 +90,68 @@ consteval bool ce_decompose_long_double_minus_one() {
 static_assert(ce_decompose_long_double_minus_one());
 
 // ----- runtime tests -----
+
+TEST(DecomposeFloat, RoundTrip) {
+    // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp)
+    std::mt19937 rng{42};
+
+    for (std::size_t i = 0; i < 20000; ++i) {
+        const auto bits = static_cast<std::uint32_t>(rng());
+        const auto x    = std::bit_cast<float>(bits);
+        if (!std::isfinite(x)) {
+            continue;
+        }
+
+        const auto rep = beman::big_int::detail::decompose_float(x);
+        const auto y   = beman::big_int::detail::compose_float(rep);
+
+        ASSERT_EQ(std::bit_cast<std::uint32_t>(y), bits);
+    }
+}
+
+TEST(DecomposeFloat, RoundTripDouble) {
+    // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp)
+    std::mt19937_64 rng{42};
+
+    for (std::size_t i = 0; i < 20'000; ++i) {
+        const auto bits = rng();
+        const auto x    = std::bit_cast<double>(bits);
+        if (!std::isfinite(x)) {
+            continue;
+        }
+
+        const auto rep = beman::big_int::detail::decompose_float(x);
+        const auto y   = beman::big_int::detail::compose_float(rep);
+
+        ASSERT_EQ(std::bit_cast<std::uint64_t>(y), bits);
+    }
+}
+
+TEST(DecomposeFloat, RoundTripLongDouble) {
+    using beman::big_int::detail::wide;
+
+    // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp)
+    std::mt19937_64 rng{42};
+    static_assert(sizeof(long double) == 16);
+
+    for (std::size_t i = 0; i < 20'000; ++i) {
+        const wide<std::uint64_t> bits{.low_bits = rng(), .high_bits = rng()};
+        const auto                x = std::bit_cast<long double>(bits);
+        if (!std::isfinite(x)) {
+            continue;
+        }
+
+        const auto rep = beman::big_int::detail::decompose_float(x);
+        const auto y   = beman::big_int::detail::compose_float(rep);
+
+        // We cannot do a bitwise comparison because some of the bits are padding,
+        // but we can do an equality comparison with the generated long double.
+        BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
+        BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Wfloat-equal")
+        ASSERT_EQ(x, y);
+        BEMAN_BIG_INT_DIAGNOSTIC_POP()
+    }
+}
 
 TEST(FloatConstruction, DoubleZero) {
     beman::big_int::big_int x(0.0);

--- a/tests/beman/big_int/float_construction.test.cpp
+++ b/tests/beman/big_int/float_construction.test.cpp
@@ -131,26 +131,44 @@ TEST(DecomposeFloat, RoundTripLongDouble) {
     using beman::big_int::detail::wide;
 
     // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp)
-    std::mt19937_64 rng{42};
-    static_assert(sizeof(long double) == 16);
+    [[maybe_unused]] std::mt19937_64 rng{42};
 
-    for (std::size_t i = 0; i < 20'000; ++i) {
-        const wide<std::uint64_t> bits{.low_bits = rng(), .high_bits = rng()};
-        const auto                x = std::bit_cast<long double>(bits);
-        if (!std::isfinite(x)) {
-            continue;
+    // IILE is necessary to get a dependent type and prevent errors despite if constexpr.
+    [&]<class LongDouble = long double>() {
+        if constexpr (sizeof(LongDouble) == 2 * sizeof(std::uint64_t)) {
+            for (std::size_t i = 0; i < 20'000; ++i) {
+                const wide<std::uint64_t> bits{.low_bits = rng(), .high_bits = rng()};
+                const auto                x = std::bit_cast<LongDouble>(bits);
+                if (!std::isfinite(x)) {
+                    continue;
+                }
+
+                const auto rep = beman::big_int::detail::decompose_float(x);
+                const auto y   = beman::big_int::detail::compose_float(rep);
+
+                // We cannot do a bitwise comparison because some of the bits are padding,
+                // but we can do an equality comparison with the generated long double.
+                BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
+                BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Wfloat-equal")
+                ASSERT_EQ(x, y);
+                BEMAN_BIG_INT_DIAGNOSTIC_POP()
+            }
+        } else if constexpr (sizeof(LongDouble) == sizeof(double)) {
+            static_assert(false);
+            for (std::size_t i = 0; i < 20'000; ++i) {
+                const auto bits = rng();
+                const auto x    = std::bit_cast<LongDouble>(bits);
+                if (!std::isfinite(x)) {
+                    continue;
+                }
+
+                const auto rep = beman::big_int::detail::decompose_float(x);
+                const auto y   = beman::big_int::detail::compose_float(rep);
+
+                ASSERT_EQ(std::bit_cast<std::uint64_t>(y), bits);
+            }
         }
-
-        const auto rep = beman::big_int::detail::decompose_float(x);
-        const auto y   = beman::big_int::detail::compose_float(rep);
-
-        // We cannot do a bitwise comparison because some of the bits are padding,
-        // but we can do an equality comparison with the generated long double.
-        BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
-        BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Wfloat-equal")
-        ASSERT_EQ(x, y);
-        BEMAN_BIG_INT_DIAGNOSTIC_POP()
-    }
+    }();
 }
 
 TEST(FloatConstruction, DoubleZero) {


### PR DESCRIPTION
This also restructures `float_representation` slightly to take the floating-point type as a template parameter rather than the mantissa type. Doing so allows deducing the floating-point type from `float_representation`, and it leaves open the door for floating-point types with massive exponents that don't fit into `int` (which is really only plausible if `int` is 16-bit).