### PR TITLE
Significant improvements to performance of addition

### DIFF
--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -2177,8 +2177,8 @@ constexpr void basic_big_int<b, A>::add_into(const std::span<const uint_multipre
             const alloc_result allocation = alloc_limbs(n);
             limb_type* const   limbs      = allocation.ptr;
 
-            [[maybe_unused]] const bool borrow = run_sub(
-                a, b_span, [limbs](std::size_t idx, limb_type v) { std::construct_at(limbs + idx, v); }, n);
+            [[maybe_unused]] const bool borrow =
+                run_sub(a, b_span, [limbs](std::size_t idx, limb_type v) { std::construct_at(limbs + idx, v); }, n);
             BEMAN_BIG_INT_DEBUG_ASSERT(!borrow);
             for (std::size_t i = n; i < allocation.count; ++i) {
                 std::construct_at(limbs + i);
@@ -2189,9 +2189,9 @@ constexpr void basic_big_int<b, A>::add_into(const std::span<const uint_multipre
             m_storage.data = allocation.ptr;
             finalize_trim_and_sign(limbs, n, a_neg);
         } else {
-            limb_type* const            limbs  = limb_ptr();
-            [[maybe_unused]] const bool borrow = run_sub(
-                a, b_span, [limbs](std::size_t idx, limb_type v) { limbs[idx] = v; }, n);
+            limb_type* const            limbs = limb_ptr();
+            [[maybe_unused]] const bool borrow =
+                run_sub(a, b_span, [limbs](std::size_t idx, limb_type v) { limbs[idx] = v; }, n);
             BEMAN_BIG_INT_DEBUG_ASSERT(!borrow);
             finalize_trim_and_sign(limbs, n, a_neg);
         }
@@ -2206,8 +2206,8 @@ constexpr void basic_big_int<b, A>::add_into(const std::span<const uint_multipre
         const alloc_result allocation = alloc_limbs(n);
         limb_type* const   limbs      = allocation.ptr;
 
-        [[maybe_unused]] const bool borrow = run_sub(
-            b_span, a, [limbs](std::size_t idx, limb_type v) { std::construct_at(limbs + idx, v); }, n);
+        [[maybe_unused]] const bool borrow =
+            run_sub(b_span, a, [limbs](std::size_t idx, limb_type v) { std::construct_at(limbs + idx, v); }, n);
         BEMAN_BIG_INT_DEBUG_ASSERT(!borrow);
         for (std::size_t i = n; i < allocation.count; ++i) {
             std::construct_at(limbs + i);
@@ -2218,9 +2218,9 @@ constexpr void basic_big_int<b, A>::add_into(const std::span<const uint_multipre
         m_storage.data = allocation.ptr;
         finalize_trim_and_sign(limbs, n, b_neg);
     } else {
-        limb_type* const            limbs  = limb_ptr();
-        [[maybe_unused]] const bool borrow = run_sub(
-            b_span, a, [limbs](std::size_t idx, limb_type v) { limbs[idx] = v; }, n);
+        limb_type* const            limbs = limb_ptr();
+        [[maybe_unused]] const bool borrow =
+            run_sub(b_span, a, [limbs](std::size_t idx, limb_type v) { limbs[idx] = v; }, n);
         BEMAN_BIG_INT_DEBUG_ASSERT(!borrow);
         finalize_trim_and_sign(limbs, n, b_neg);
     }

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -2044,7 +2044,7 @@ constexpr void basic_big_int<b, A>::add_into(const std::span<const uint_multipre
         const std::size_t common = b_span.size();
 
         // Unrolled addition loop
-        auto run_add = [&](auto store) {
+        const auto run_add = [&](auto store) {
             bool        carry = false;
             std::size_t i     = 0;
             for (; i + 4 <= common; i += 4) {
@@ -2124,7 +2124,7 @@ constexpr void basic_big_int<b, A>::add_into(const std::span<const uint_multipre
     // Both subtraction branches mirror the same-sign allocation strategy
     const std::size_t eff_cap = is_representation_inplace() ? inplace_capacity : m_capacity;
 
-    auto finalize_trim_and_sign = [this](limb_type* const limbs, const std::size_t n, const bool target_neg) {
+    const auto finalize_trim_and_sign = [this](const limb_type* const limbs, const std::size_t n, const bool target_neg) {
         unchecked_set_limb_count(static_cast<std::uint32_t>(n));
         while (limb_count() > 1 && limbs[limb_count() - 1] == 0) {
             unchecked_set_limb_count(limb_count() - 1);
@@ -2136,7 +2136,7 @@ constexpr void basic_big_int<b, A>::add_into(const std::span<const uint_multipre
     };
 
     // Unrolled subtract
-    auto run_sub = [&](auto larger, auto smaller, auto store, std::size_t total) {
+    const auto run_sub = [&](auto larger, auto smaller, auto store, const std::size_t total) {
         const std::size_t common = smaller.size();
         bool              borrow = false;
         std::size_t       i      = 0;

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -2121,13 +2121,14 @@ constexpr void basic_big_int<b, A>::add_into(const std::span<const uint_multipre
     // Both subtraction branches mirror the same-sign allocation strategy
     const std::size_t eff_cap = is_representation_inplace() ? inplace_capacity : m_capacity;
 
-    const auto finalize_trim_and_sign = [this](const limb_type* const limbs, const std::size_t n, const bool target_neg) {
-        unchecked_set_limb_count(static_cast<std::uint32_t>(n));
-        while (limb_count() > 1 && limbs[limb_count() - 1] == 0) {
-            unchecked_set_limb_count(limb_count() - 1);
-        }
-        unchecked_set_sign(target_neg && !unchecked_is_magnitude_zero());
-    };
+    const auto finalize_trim_and_sign =
+        [this](const limb_type* const limbs, const std::size_t n, const bool target_neg) {
+            unchecked_set_limb_count(static_cast<std::uint32_t>(n));
+            while (limb_count() > 1 && limbs[limb_count() - 1] == 0) {
+                unchecked_set_limb_count(limb_count() - 1);
+            }
+            unchecked_set_sign(target_neg && !unchecked_is_magnitude_zero());
+        };
 
     // Unrolled subtract
     const auto run_sub = [&](auto larger, auto smaller, auto store, const std::size_t total) {

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -475,6 +475,15 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     template <std::size_t extent_other>
     constexpr void add_in_place(std::span<const uint_multiprecision_t, extent_other> other, bool other_neg);
 
+    // Computes `(a, a_neg) + (b, b_neg)` directly into `*this`.
+    // Fuses copy and potential second allocation
+    // Precondition: `a.size() >= b.size()`
+    template <std::size_t extent_a, std::size_t extent_b>
+    constexpr void add_into(std::span<const uint_multiprecision_t, extent_a> a,
+                            bool                                             a_neg,
+                            std::span<const uint_multiprecision_t, extent_b> b,
+                            bool                                             b_neg);
+
     // Computes `a * b` and stores the result into `*this`.
     template <std::size_t extent_a, std::size_t extent_b>
     constexpr void multiply_into(std::span<const uint_multiprecision_t, extent_a> a,
@@ -1504,17 +1513,15 @@ constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y) {
         r.add_in_place(x.representation(), x.is_negative());
         return r;
     } else if constexpr (form == detail::binary_op_form::copy_copy) {
-        // Both lvalue `basic_big_int`s: copy the larger operand, then add the smaller.
-        // For inline sources no extra space is requested, so the copy stays inline
-        // The move to heap storage is deferred to add_in_place if required
+        // Use add_into which combines copy and addition allocations.
+        // Pre-order operands so the larger goes first — this lets the hot loop
+        // drop the `i < a.size()` bounds check on every iteration.
         Result r;
         if (x.limb_count() >= y.limb_count()) {
-            r.assign_value(x, !x.is_representation_inplace());
-            r.add_in_place(y.representation(), y.is_negative());
-            return r;
+            r.add_into(x.representation(), x.is_negative(), y.representation(), y.is_negative());
+        } else {
+            r.add_into(y.representation(), y.is_negative(), x.representation(), x.is_negative());
         }
-        r.assign_value(y, !y.is_representation_inplace());
-        r.add_in_place(x.representation(), x.is_negative());
         return r;
     } else if constexpr (form == detail::binary_op_form::move_int) {
         const auto y_limbs = detail::to_limbs(detail::uabs(y));
@@ -1573,17 +1580,16 @@ constexpr detail::common_big_int_type<L, R> operator-(L&& x, R&& y) {
         r.add_in_place(x.representation(), x.is_negative());
         return r;
     } else if constexpr (form == detail::binary_op_form::copy_copy) {
-        // Both lvalue `basic_big_int`s: copy the larger, then subtract the smaller.
-        // For inline sources no extra space is requested, so the copy stays inline.
+        // Both lvalue `basic_big_int`s: fold `x + (-y)` into a fresh buffer in a
+        // single pass via `add_into`, fusing the allocation with the subtract.
+        // Pre-order operands so the larger goes first — `add_into` relies on
+        // this to keep the hot loop free of a per-iteration bounds check.
         Result r;
         if (x.limb_count() >= y.limb_count()) {
-            r.assign_value(x, !x.is_representation_inplace());
-            r.add_in_place(y.representation(), !y.is_negative());
-            return r;
+            r.add_into(x.representation(), x.is_negative(), y.representation(), !y.is_negative());
+        } else {
+            r.add_into(y.representation(), !y.is_negative(), x.representation(), x.is_negative());
         }
-        r.assign_value(y, !y.is_representation_inplace());
-        r.negate();
-        r.add_in_place(x.representation(), x.is_negative());
         return r;
     } else if constexpr (form == detail::binary_op_form::move_int) {
         const auto y_limbs = detail::to_limbs(detail::uabs(y));
@@ -2014,6 +2020,210 @@ constexpr void basic_big_int<b, A>::add_in_place(const std::span<const uint_mult
 
     // `|other| > |*this|` strictly, so the magnitude is guaranteed nonzero.
     unchecked_set_sign(other_neg && !unchecked_is_magnitude_zero());
+}
+
+// Computes `(a, a_neg) + (b, b_neg)` directly into `*this`.
+// Fuses copy and potential second allocation
+// Precondition: `a.size() >= b.size()`
+template <std::size_t b, class A>
+template <std::size_t extent_a, std::size_t extent_b>
+constexpr void basic_big_int<b, A>::add_into(const std::span<const uint_multiprecision_t, extent_a> a,
+                                             const bool                                             a_neg,
+                                             const std::span<const uint_multiprecision_t, extent_b> b_span,
+                                             const bool                                             b_neg) {
+    BEMAN_BIG_INT_DEBUG_ASSERT(a.size() >= b_span.size());
+
+    if (a_neg == b_neg) {
+        // Same sign: add magnitudes.
+        // Sign of the result is `a_neg`.
+        const std::size_t big     = a.size();
+        const std::size_t eff_cap = is_representation_inplace() ? inplace_capacity : m_capacity;
+
+        // `common` is the range where both operands contribute,
+        // beyond it the remaining `a[i]` limbs just propagate the carry.
+        const std::size_t common = b_span.size();
+
+        // Unrolled addition loop
+        auto run_add = [&](auto store) {
+            bool        carry = false;
+            std::size_t i     = 0;
+            for (; i + 4 <= common; i += 4) {
+                const auto [v0, c0] = detail::carrying_add(a[i + 0], b_span[i + 0], carry);
+                const auto [v1, c1] = detail::carrying_add(a[i + 1], b_span[i + 1], c0);
+                const auto [v2, c2] = detail::carrying_add(a[i + 2], b_span[i + 2], c1);
+                const auto [v3, c3] = detail::carrying_add(a[i + 3], b_span[i + 3], c2);
+                store(i + 0, v0);
+                store(i + 1, v1);
+                store(i + 2, v2);
+                store(i + 3, v3);
+                carry = c3;
+            }
+            for (; i < common; ++i) {
+                const auto [v, c] = detail::carrying_add(a[i], b_span[i], carry);
+                store(i, v);
+                carry = c;
+            }
+            // Carry-propagation tail over `a[common..big)`. Once the ripple
+            // stops carrying, the rest is a straight copy of `a`'s limbs.
+            while (i < big && carry) {
+                const auto [v, c] = detail::carrying_add(a[i], limb_type{0}, true);
+                store(i, v);
+                carry = c;
+                ++i;
+            }
+            for (; i < big; ++i) {
+                store(i, a[i]);
+            }
+            return carry;
+        };
+
+        if (big > inplace_capacity && big + 1 > eff_cap) {
+            // Heap allocation required for the result body.
+            // Write directly into the raw buffer via `construct_at`,
+            // skipping the `copy_n_to_allocation` zero-fill of the portion we're about to overwrite.
+            // Reserve `big + 1` so the carry limb folds into the same allocation.
+            const alloc_result allocation = alloc_limbs(big + 1);
+            limb_type* const   limbs      = allocation.ptr;
+
+            const bool carry = run_add([limbs](std::size_t idx, limb_type v) { std::construct_at(limbs + idx, v); });
+
+            std::construct_at(limbs + big, carry ? limb_type{1} : limb_type{0});
+            for (std::size_t i = big + 1; i < allocation.count; ++i) {
+                std::construct_at(limbs + i);
+            }
+
+            free_storage();
+            m_capacity     = static_cast<std::uint32_t>(allocation.count);
+            m_storage.data = allocation.ptr;
+            unchecked_set_limb_count(static_cast<std::uint32_t>(carry ? big + 1 : big));
+        } else {
+            // Either we fit inline, or we already own a heap buffer big enough to hold the result.
+            // Reuse it and let `grow` (almost always a no-op) handle the rare carry-out grow call.
+            limb_type* const limbs = limb_ptr();
+
+            const bool carry = run_add([limbs](std::size_t idx, limb_type v) { limbs[idx] = v; });
+            unchecked_set_limb_count(static_cast<std::uint32_t>(big));
+
+            if (carry) {
+                grow(big + 1);
+                limb_ptr()[big] = limb_type{1};
+                unchecked_set_limb_count(static_cast<std::uint32_t>(big + 1));
+            }
+        }
+
+        unchecked_set_sign(false);
+        if (!is_zero()) {
+            unchecked_set_sign(a_neg);
+        }
+        return;
+    }
+
+    // Differing signs: subtract the smaller magnitude from the larger.
+    const auto magnitude_order = detail::compare_limb_magnitudes(a, b_span);
+
+    // Both subtraction branches mirror the same-sign allocation strategy
+    const std::size_t eff_cap = is_representation_inplace() ? inplace_capacity : m_capacity;
+
+    auto finalize_trim_and_sign = [this](limb_type* const limbs, const std::size_t n, const bool target_neg) {
+        unchecked_set_limb_count(static_cast<std::uint32_t>(n));
+        while (limb_count() > 1 && limbs[limb_count() - 1] == 0) {
+            unchecked_set_limb_count(limb_count() - 1);
+        }
+        unchecked_set_sign(false);
+        if (!is_zero()) {
+            unchecked_set_sign(target_neg);
+        }
+    };
+
+    // Unrolled subtract
+    auto run_sub = [&](auto larger, auto smaller, auto store, std::size_t total) {
+        const std::size_t common = smaller.size();
+        bool              borrow = false;
+        std::size_t       i      = 0;
+        for (; i + 4 <= common; i += 4) {
+            const auto [v0, b0] = detail::borrowing_sub(larger[i + 0], smaller[i + 0], borrow);
+            const auto [v1, b1] = detail::borrowing_sub(larger[i + 1], smaller[i + 1], b0);
+            const auto [v2, b2] = detail::borrowing_sub(larger[i + 2], smaller[i + 2], b1);
+            const auto [v3, b3] = detail::borrowing_sub(larger[i + 3], smaller[i + 3], b2);
+            store(i + 0, v0);
+            store(i + 1, v1);
+            store(i + 2, v2);
+            store(i + 3, v3);
+            borrow = b3;
+        }
+        for (; i < common; ++i) {
+            const auto [v, br] = detail::borrowing_sub(larger[i], smaller[i], borrow);
+            store(i, v);
+            borrow = br;
+        }
+        while (i < total && borrow) {
+            const auto [v, br] = detail::borrowing_sub(larger[i], limb_type{0}, true);
+            store(i, v);
+            borrow = br;
+            ++i;
+        }
+        for (; i < total; ++i) {
+            store(i, larger[i]);
+        }
+        return borrow;
+    };
+
+    if (std::is_gteq(magnitude_order)) {
+        // `|a| >= |b|`: compute `a - b` into our buffer.
+        // Target sign is `a_neg`.
+        const std::size_t n = a.size();
+
+        if (n > inplace_capacity && n > eff_cap) {
+            const alloc_result allocation = alloc_limbs(n);
+            limb_type* const   limbs      = allocation.ptr;
+
+            [[maybe_unused]] const bool borrow = run_sub(
+                a, b_span, [limbs](std::size_t idx, limb_type v) { std::construct_at(limbs + idx, v); }, n);
+            BEMAN_BIG_INT_DEBUG_ASSERT(!borrow);
+            for (std::size_t i = n; i < allocation.count; ++i) {
+                std::construct_at(limbs + i);
+            }
+
+            free_storage();
+            m_capacity     = static_cast<std::uint32_t>(allocation.count);
+            m_storage.data = allocation.ptr;
+            finalize_trim_and_sign(limbs, n, a_neg);
+        } else {
+            limb_type* const            limbs  = limb_ptr();
+            [[maybe_unused]] const bool borrow = run_sub(
+                a, b_span, [limbs](std::size_t idx, limb_type v) { limbs[idx] = v; }, n);
+            BEMAN_BIG_INT_DEBUG_ASSERT(!borrow);
+            finalize_trim_and_sign(limbs, n, a_neg);
+        }
+        return;
+    }
+
+    // `|b| > |a|`: compute `b - a` into our buffer.
+    // Target sign is `b_neg`.
+    const std::size_t n = b_span.size();
+
+    if (n > inplace_capacity && n > eff_cap) {
+        const alloc_result allocation = alloc_limbs(n);
+        limb_type* const   limbs      = allocation.ptr;
+
+        [[maybe_unused]] const bool borrow = run_sub(
+            b_span, a, [limbs](std::size_t idx, limb_type v) { std::construct_at(limbs + idx, v); }, n);
+        BEMAN_BIG_INT_DEBUG_ASSERT(!borrow);
+        for (std::size_t i = n; i < allocation.count; ++i) {
+            std::construct_at(limbs + i);
+        }
+
+        free_storage();
+        m_capacity     = static_cast<std::uint32_t>(allocation.count);
+        m_storage.data = allocation.ptr;
+        finalize_trim_and_sign(limbs, n, b_neg);
+    } else {
+        limb_type* const            limbs  = limb_ptr();
+        [[maybe_unused]] const bool borrow = run_sub(
+            b_span, a, [limbs](std::size_t idx, limb_type v) { limbs[idx] = v; }, n);
+        BEMAN_BIG_INT_DEBUG_ASSERT(!borrow);
+        finalize_trim_and_sign(limbs, n, b_neg);
+    }
 }
 
 // Computes `a * b` and stores the result into `*this`.

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -2111,10 +2111,7 @@ constexpr void basic_big_int<b, A>::add_into(const std::span<const uint_multipre
             }
         }
 
-        unchecked_set_sign(false);
-        if (!is_zero()) {
-            unchecked_set_sign(a_neg);
-        }
+        unchecked_set_sign(a_neg && !unchecked_is_magnitude_zero());
         return;
     }
 
@@ -2129,10 +2126,7 @@ constexpr void basic_big_int<b, A>::add_into(const std::span<const uint_multipre
         while (limb_count() > 1 && limbs[limb_count() - 1] == 0) {
             unchecked_set_limb_count(limb_count() - 1);
         }
-        unchecked_set_sign(false);
-        if (!is_zero()) {
-            unchecked_set_sign(target_neg);
-        }
+        unchecked_set_sign(target_neg && !unchecked_is_magnitude_zero());
     };
 
     // Unrolled subtract

--- a/tests/beman/big_int/addition_bench.test.cpp
+++ b/tests/beman/big_int/addition_bench.test.cpp
@@ -8,81 +8,62 @@
 
 namespace local {
 
-  namespace concurrency {
+namespace concurrency {
 
-  struct stopwatch
-  {
+struct stopwatch {
   public:
     using time_point_type = std::uintmax_t;
 
-    auto reset() -> void
-    {
-      m_start = now();
-    }
+    auto reset() -> void { m_start = now(); }
 
-    template<typename RepresentationRequestedTimeType>
-    static auto elapsed_time(const stopwatch& my_stopwatch) noexcept -> RepresentationRequestedTimeType
-    {
-      using local_time_type = RepresentationRequestedTimeType;
+    template <typename RepresentationRequestedTimeType>
+    static auto elapsed_time(const stopwatch& my_stopwatch) noexcept -> RepresentationRequestedTimeType {
+        using local_time_type = RepresentationRequestedTimeType;
 
-      return
-        local_time_type
-        {
-            static_cast<local_time_type>(my_stopwatch.elapsed())
-          / local_time_type { UINTMAX_C(1000000000) }
-        };
+        return local_time_type{static_cast<local_time_type>(my_stopwatch.elapsed()) /
+                               local_time_type{UINTMAX_C(1000000000)}};
     }
 
   private:
-    time_point_type m_start { now() }; // NOLINT(readability-identifier-naming)
+    time_point_type m_start{now()}; // NOLINT(readability-identifier-naming)
 
-    [[nodiscard]] static auto now() -> time_point_type
-    {
-      timespec ts { };
+    [[nodiscard]] static auto now() -> time_point_type {
+        timespec ts{};
 
-      const int ntsp { timespec_get(&ts, TIME_UTC) };
+        const int ntsp{timespec_get(&ts, TIME_UTC)};
 
-      static_cast<void>(ntsp);
+        static_cast<void>(ntsp);
 
-      return
-        static_cast<time_point_type>
-        (
-            static_cast<time_point_type>(static_cast<time_point_type>(ts.tv_sec) * UINTMAX_C(1000000000))
-          + static_cast<time_point_type>(ts.tv_nsec)
-        );
+        return static_cast<time_point_type>(
+            static_cast<time_point_type>(static_cast<time_point_type>(ts.tv_sec) * UINTMAX_C(1000000000)) +
+            static_cast<time_point_type>(ts.tv_nsec));
     }
 
-    [[nodiscard]] auto elapsed() const -> time_point_type
-    {
-      const time_point_type stop { now() };
+    [[nodiscard]] auto elapsed() const -> time_point_type {
+        const time_point_type stop{now()};
 
-      const time_point_type
-        elapsed_ns
-        {
-          static_cast<time_point_type>
-          (
-            stop - m_start
-          )
-        };
+        const time_point_type elapsed_ns{static_cast<time_point_type>(stop - m_start)};
 
-      return elapsed_ns;
+        return elapsed_ns;
     }
-  };
+};
 
-  } // namespace concurrency
+} // namespace concurrency
 
 template <typename BigIntType>
 BigIntType fibonacci(unsigned int n) {
-    if (n == 0) return BigIntType(0);
-    if (n == 1) return BigIntType(1);
+    if (n == 0)
+        return BigIntType(0);
+    if (n == 1)
+        return BigIntType(1);
 
     BigIntType a = 0;
     BigIntType b = 1;
 
     for (unsigned int i = 2; i <= n; ++i) {
         BigIntType next = a + b;
-        a = b;
-        b = next;
+        a               = b;
+        b               = next;
     }
 
     return b;
@@ -99,8 +80,7 @@ BigIntType fibonacci(unsigned int n) {
 
 } // namespace local
 
-bool run_benchmarks()
-{
+bool run_benchmarks() {
     using cpp_int_type =
         boost::multiprecision::number<boost::multiprecision::cpp_int_backend<>, boost::multiprecision::et_off>;
     using big_int_type = beman::big_int::big_int;
@@ -154,9 +134,9 @@ bool run_benchmarks()
 }
 
 TEST(Addition, AdditionBench) {
-    #ifdef BEMAN_BIG_INT_RUN_BENCHMARKS
+#ifdef BEMAN_BIG_INT_RUN_BENCHMARKS
     EXPECT_TRUE(run_benchmarks());
-    #else
+#else
     GTEST_SKIP() << "Benchmarks not run" << std::endl;
-    #endif
+#endif
 }

--- a/tests/beman/big_int/addition_bench.test.cpp
+++ b/tests/beman/big_int/addition_bench.test.cpp
@@ -34,15 +34,14 @@ struct stopwatch {
 
         static_cast<void>(ntsp);
 
-        return static_cast<time_point_type>(
-            static_cast<time_point_type>(static_cast<time_point_type>(ts.tv_sec) * UINTMAX_C(1000000000)) +
-            static_cast<time_point_type>(ts.tv_nsec));
+        return static_cast<time_point_type>(ts.tv_sec) * UINTMAX_C(1000000000) +
+               static_cast<time_point_type>(ts.tv_nsec);
     }
 
     [[nodiscard]] auto elapsed() const -> time_point_type {
         const time_point_type stop{now()};
 
-        const time_point_type elapsed_ns{static_cast<time_point_type>(stop - m_start)};
+        const time_point_type elapsed_ns{stop - m_start};
 
         return elapsed_ns;
     }

--- a/tests/beman/big_int/addition_bench.test.cpp
+++ b/tests/beman/big_int/addition_bench.test.cpp
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: BSL-1.0
+
+#include <boost/multiprecision/cpp_int.hpp>
+#include <beman/big_int/big_int.hpp>
+#include <gtest/gtest.h>
+#include <span>
+
+namespace local {
+
+  namespace concurrency {
+
+  struct stopwatch
+  {
+  public:
+    using time_point_type = std::uintmax_t;
+
+    auto reset() -> void
+    {
+      m_start = now();
+    }
+
+    template<typename RepresentationRequestedTimeType>
+    static auto elapsed_time(const stopwatch& my_stopwatch) noexcept -> RepresentationRequestedTimeType
+    {
+      using local_time_type = RepresentationRequestedTimeType;
+
+      return
+        local_time_type
+        {
+            static_cast<local_time_type>(my_stopwatch.elapsed())
+          / local_time_type { UINTMAX_C(1000000000) }
+        };
+    }
+
+  private:
+    time_point_type m_start { now() }; // NOLINT(readability-identifier-naming)
+
+    [[nodiscard]] static auto now() -> time_point_type
+    {
+      timespec ts { };
+
+      const int ntsp { timespec_get(&ts, TIME_UTC) };
+
+      static_cast<void>(ntsp);
+
+      return
+        static_cast<time_point_type>
+        (
+            static_cast<time_point_type>(static_cast<time_point_type>(ts.tv_sec) * UINTMAX_C(1000000000))
+          + static_cast<time_point_type>(ts.tv_nsec)
+        );
+    }
+
+    [[nodiscard]] auto elapsed() const -> time_point_type
+    {
+      const time_point_type stop { now() };
+
+      const time_point_type
+        elapsed_ns
+        {
+          static_cast<time_point_type>
+          (
+            stop - m_start
+          )
+        };
+
+      return elapsed_ns;
+    }
+  };
+
+  } // namespace concurrency
+
+template <typename BigIntType>
+BigIntType fibonacci(unsigned int n) {
+    if (n == 0) return BigIntType(0);
+    if (n == 1) return BigIntType(1);
+
+    BigIntType a = 0;
+    BigIntType b = 1;
+
+    for (unsigned int i = 2; i <= n; ++i) {
+        BigIntType next = a + b;
+        a = b;
+        b = next;
+    }
+
+    return b;
+}
+
+// Returns the number of bytes before the trailing run of zero bytes.
+[[nodiscard]] inline auto significant_byte_len(const std::span<const std::byte> bytes) noexcept -> std::size_t {
+    std::size_t n = bytes.size();
+    while (n > 0 && bytes[n - 1] == std::byte{0}) {
+        --n;
+    }
+    return n;
+}
+
+} // namespace local
+
+bool run_benchmarks()
+{
+    using cpp_int_type =
+        boost::multiprecision::number<boost::multiprecision::cpp_int_backend<>, boost::multiprecision::et_off>;
+    using big_int_type = beman::big_int::big_int;
+
+    using local_stopwatch_type = local::concurrency::stopwatch;
+
+    local_stopwatch_type my_stopwatch{};
+
+    const big_int_type big_int_fibonacci{local::fibonacci<big_int_type>(1000000)};
+    std::cout << "stopwatch big_int: " << local_stopwatch_type::elapsed_time<double>(my_stopwatch) << std::endl;
+
+    my_stopwatch.reset();
+
+    const cpp_int_type cpp_int_fibonacci{local::fibonacci<cpp_int_type>(1000000)};
+    std::cout << "stopwatch cpp_int: " << local_stopwatch_type::elapsed_time<double>(my_stopwatch) << std::endl;
+
+    const std::span<const ::boost::multiprecision::limb_type> cpp_int_rep{cpp_int_fibonacci.backend().limbs(),
+                                                                          cpp_int_fibonacci.backend().size()};
+    const auto big_int_bytes = std::as_bytes(big_int_fibonacci.representation());
+    const auto cpp_int_bytes = std::as_bytes(cpp_int_rep);
+
+    const auto big_int_sig = local::significant_byte_len(big_int_bytes);
+    const auto cpp_int_sig = local::significant_byte_len(cpp_int_bytes);
+
+    const bool result_length_is_ok{big_int_sig == cpp_int_sig};
+
+    std::cout << "result_length_is_ok    : " << result_length_is_ok << std::endl;
+
+    bool result_is_ok{result_length_is_ok};
+
+    bool result_bytes_same_is_ok{false};
+
+    if (result_is_ok) {
+        for (std::size_t i = 0; i < big_int_sig; ++i) {
+            if (big_int_bytes[i] != cpp_int_bytes[i]) {
+                result_bytes_same_is_ok = false;
+                break;
+            } else {
+                result_bytes_same_is_ok = true;
+            }
+        }
+    }
+
+    std::cout << "result_bytes_same_is_ok: " << result_bytes_same_is_ok << std::endl;
+
+    result_is_ok = (result_bytes_same_is_ok && result_is_ok);
+
+    std::cout << "result_is_ok           : " << result_is_ok << std::endl;
+
+    return result_is_ok;
+}
+
+TEST(Addition, AdditionBench) {
+    EXPECT_TRUE(run_benchmarks());
+}

--- a/tests/beman/big_int/addition_bench.test.cpp
+++ b/tests/beman/big_int/addition_bench.test.cpp
@@ -154,5 +154,9 @@ bool run_benchmarks()
 }
 
 TEST(Addition, AdditionBench) {
+    #ifdef BEMAN_BIG_INT_RUN_BENCHMARKS
     EXPECT_TRUE(run_benchmarks());
+    #else
+    GTEST_SKIP() << "Benchmarks not run" << std::endl;
+    #endif
 }


### PR DESCRIPTION
- Combine copy and add
- Manually unroll some of the loops
- Ensure we have at most 1 allocation. In the borrowed storage case this is still deferred to the end

See: #122 and https://github.com/eisenwave/std-big-int/issues/122#issuecomment-4328313614