### PR TITLE
Add more fast paths and remove inf detection

### DIFF
--- a/include/beman/big_int/detail/config.hpp
+++ b/include/beman/big_int/detail/config.hpp
@@ -137,14 +137,17 @@ namespace beman::big_int::detail {
 
 #if BEMAN_BIG_INT_BITINT_MAXWIDTH >= 128
     #define BEMAN_BIG_INT_HAS_INT128 1
+    #define BEMAN_BIG_INT_HAS_INT128_FUNDAMENTAL 1
 using int128_t  = _BitInt(128);
 using uint128_t = unsigned _BitInt(128);
 #elif defined(__SIZEOF_INT128__)
     #define BEMAN_BIG_INT_HAS_INT128 1
+    #define BEMAN_BIG_INT_HAS_INT128_FUNDAMENTAL 1
 using int128_t  = __int128;
 using uint128_t = unsigned __int128;
 #elif defined(BEMAN_BIG_INT_MSVC)
     #define BEMAN_BIG_INT_HAS_INT128 1
+    #define BEMAN_BIG_INT_HAS_INT128_CLASS 1
 using int128_t  = std::_Signed128;
 using uint128_t = std::_Unsigned128;
 #endif
@@ -294,28 +297,41 @@ template <class T>
     return static_cast<make_signed_or_unsigned_t<T>>(x);
 }
 
-template <integral T>
-struct width : std::integral_constant<std::size_t,
-                                      static_cast<std::size_t>(std::numeric_limits<std::make_unsigned_t<T>>::digits)> {
-};
+// A type trait with a `static constexpr std::size_t value` member storing the width of the type `T`.
+// That is, the number of bits in the value representation.
+// The trait is complete only if `T` is an integral type or (if supported)
+// an integer class type such as MSVC `std::_Signed128`.
+template <class T>
+struct width;
 
-#ifdef BEMAN_BIG_INT_HAS_BITINT
-template <std::size_t N>
-struct width<_BitInt(N)> : std::integral_constant<std::size_t, N> {};
-template <std::size_t N>
-struct width<unsigned _BitInt(N)> : std::integral_constant<std::size_t, N> {};
 template <class T>
 struct width<const T> : width<T> {};
 template <class T>
 struct width<volatile T> : width<T> {};
 template <class T>
 struct width<const volatile T> : width<T> {};
+
+template <cv_unqualified_integral T>
+struct width<T>
+    : std::integral_constant<std::size_t,
+                             static_cast<std::size_t>(std::numeric_limits<std::make_unsigned_t<T>>::digits)> {};
+
+#ifdef BEMAN_BIG_INT_HAS_INT128_CLASS
+template <>
+struct width<int128_t> : std::integral_constant<std::size_t, 128> {};
+template <>
+struct width<uint128_t> : std::integral_constant<std::size_t, 128> {};
+#endif // BEMAN_BIG_INT_HAS_INT128_CLASS
+
+#ifdef BEMAN_BIG_INT_HAS_BITINT
+template <std::size_t N>
+struct width<_BitInt(N)> : std::integral_constant<std::size_t, N> {};
+template <std::size_t N>
+struct width<unsigned _BitInt(N)> : std::integral_constant<std::size_t, N> {};
+#endif // BEMAN_BIG_INT_HAS_BITINT
+
 template <integral T>
 inline constexpr std::size_t width_v = width<T>::value;
-#else
-template <integral T>
-inline constexpr std::size_t width_v = std::numeric_limits<std::make_unsigned_t<T>>::digits;
-#endif // BEMAN_BIG_INT_HAS_BITINT
 
 } // namespace beman::big_int::detail
 

--- a/include/beman/big_int/detail/config.hpp
+++ b/include/beman/big_int/detail/config.hpp
@@ -330,7 +330,7 @@ template <std::size_t N>
 struct width<unsigned _BitInt(N)> : std::integral_constant<std::size_t, N> {};
 #endif // BEMAN_BIG_INT_HAS_BITINT
 
-template <integral T>
+template <class T>
 inline constexpr std::size_t width_v = width<T>::value;
 
 } // namespace beman::big_int::detail

--- a/include/beman/big_int/detail/floats.hpp
+++ b/include/beman/big_int/detail/floats.hpp
@@ -398,8 +398,26 @@ template <cv_unqualified_floating_point F>
     while (limb_count > 0 && limbs[limb_count - 1] == 0) {
         --limb_count;
     }
-    if (limb_count == 0) {
+    switch (limb_count) {
+    case 0:
+        // Value is zero: return correctly signed zero.
         return constexpr_copysign(F{0}, sign_value);
+    case 1:
+        // Single limb can be coverted via static_cast directly.
+        return constexpr_copysign(static_cast<F>(limbs[0]), sign_value);
+#if BEMAN_BIG_INT_HAS_WIDE_INT
+    case 2:
+        // Two limbs can be joined to an integer,
+        // unless `uint_wide_t` is a class type without floating-point converions.
+        if constexpr (std::is_convertible_v<uint_wide_t, F>) {
+            const auto wide_value = uint_wide_t{limbs[1]} << width_v<uint_multiprecision_t> | limbs[0];
+            return constexpr_copysign(static_cast<F>(wide_value), sign_value);
+        } else {
+            break;
+        }
+#endif
+    default:
+        break;
     }
 
     const std::size_t top_limb_bits = limb_width - static_cast<std::size_t>(std::countl_zero(limbs[limb_count - 1]));
@@ -493,12 +511,6 @@ template <cv_unqualified_floating_point F>
                 }
             }
         }
-    }
-
-    // TODO(eisenwave): This seems like something that the other overload should handle anyway.
-    //                  We probably don't need this infinity detection.
-    if (exponent + static_cast<int>(precision_bits) > std::numeric_limits<F>::max_exponent) {
-        return constexpr_copysign(std::numeric_limits<F>::infinity(), sign_value);
     }
 
     return compose_float(float_representation<F>{

--- a/include/beman/big_int/detail/floats.hpp
+++ b/include/beman/big_int/detail/floats.hpp
@@ -404,14 +404,14 @@ template <cv_unqualified_floating_point F>
         // Value is zero: return correctly signed zero.
         return constexpr_copysign(F{0}, sign_value);
     case 1:
-        // Single limb can be coverted via static_cast directly.
+        // Single limb can be converted via static_cast directly.
         return constexpr_copysign(static_cast<F>(limbs[0]), sign_value);
 #if BEMAN_BIG_INT_HAS_WIDE_INT
     #define BEMAN_BIG_INT_COMPOSE_FLOAT_HAPPY_BITS_COVERED_IN_SWITCH \
         (std::is_convertible_v<uint_wide_t, F> ? width_v<uint_wide_t> : width_v<uint_multiprecision_t>)
     case 2:
         // Two limbs can be joined to an integer,
-        // unless `uint_wide_t` is a class type without floating-point converions.
+        // unless `uint_wide_t` is a class type without floating-point conversions.
         if constexpr (std::is_convertible_v<uint_wide_t, F>) {
             const auto wide_value = uint_wide_t{limbs[1]} << width_v<uint_multiprecision_t> | limbs[0];
             return constexpr_copysign(static_cast<F>(wide_value), sign_value);

--- a/include/beman/big_int/detail/floats.hpp
+++ b/include/beman/big_int/detail/floats.hpp
@@ -398,6 +398,7 @@ template <cv_unqualified_floating_point F>
     while (limb_count > 0 && limbs[limb_count - 1] == 0) {
         --limb_count;
     }
+
     switch (limb_count) {
     case 0:
         // Value is zero: return correctly signed zero.
@@ -406,6 +407,8 @@ template <cv_unqualified_floating_point F>
         // Single limb can be coverted via static_cast directly.
         return constexpr_copysign(static_cast<F>(limbs[0]), sign_value);
 #if BEMAN_BIG_INT_HAS_WIDE_INT
+    #define BEMAN_BIG_INT_COMPOSE_FLOAT_HAPPY_BITS_COVERED_IN_SWITCH \
+        (std::is_convertible_v<uint_wide_t, F> ? width_v<uint_wide_t> : width_v<uint_multiprecision_t>)
     case 2:
         // Two limbs can be joined to an integer,
         // unless `uint_wide_t` is a class type without floating-point converions.
@@ -415,7 +418,9 @@ template <cv_unqualified_floating_point F>
         } else {
             break;
         }
-#endif
+#else
+    #define BEMAN_BIG_INT_COMPOSE_FLOAT_HAPPY_BITS_COVERED_IN_SWITCH width_v<uint_multiprecision_t>
+#endif // BEMAN_BIG_INT_HAS_WIDE_INT
     default:
         break;
     }
@@ -430,17 +435,26 @@ template <cv_unqualified_floating_point F>
     }
 
     mantissa_t mantissa = 0;
-    if (total_bits <= precision_bits) {
-        // Happy case: the whole integer fits inside the mantissa; concat limbs into `mantissa`.
-        // No rounding logic is necessary.
-        for (std::size_t i = 0; i < limb_count; ++i) {
-            mantissa |= static_cast<mantissa_t>(limbs[i]) << (i * limb_width);
+
+    if constexpr (BEMAN_BIG_INT_COMPOSE_FLOAT_HAPPY_BITS_COVERED_IN_SWITCH < precision_bits) {
+        // We only attempt handling this special case if it wasn't already covered by the switch,
+        // which is quite likely.
+        // On 32-bit, it can happen if we convert three limbs (96 bits) to `float128_t`,
+        // which has 112 mantissa bits.
+        // No known real-world example on 64-bit exists because one limb is always covered by the switch,
+        // and two limbs (128 bits) exceed any non-academic format.
+        if (total_bits <= precision_bits) {
+            // Happy case: the whole integer fits inside the mantissa; concat limbs into `mantissa`.
+            // No rounding logic is necessary.
+            for (std::size_t i = 0; i < limb_count; ++i) {
+                mantissa |= static_cast<mantissa_t>(limbs[i]) << (i * limb_width);
+            }
+            return compose_float(float_representation<F>{
+                .sign     = sign,
+                .exponent = 0,
+                .mantissa = mantissa,
+            });
         }
-        return compose_float(float_representation<F>{
-            .sign     = sign,
-            .exponent = 0,
-            .mantissa = mantissa,
-        });
     }
 
     // For integers with more precision,


### PR DESCRIPTION
Single limbs and two limbs should be common cases, so it is worth detecting those and choosing a fast path. In particular, on 32-bit, two two-limb case would correspond to the builtin `uint64_t`-to-floating conversion.

The infinity detection at the end is redundant because the lower-level compose_float function will also produce infinity in the same case.