### PR TITLE
Benchmark conversion to `double`

### DIFF
--- a/include/beman/big_int/detail/config.hpp
+++ b/include/beman/big_int/detail/config.hpp
@@ -351,6 +351,16 @@ inline constexpr std::size_t width_v = width<T>::value;
     #define BEMAN_BIG_INT_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #endif
 
+// Noinline ====================================================================
+
+#if defined(BEMAN_BIG_INT_GNUC)
+    #define BEMAN_BIG_INT_NOINLINE [[gnu::noinline]]
+#elif defined(BEMAN_BIG_INT_MSVC)
+    #define BEMAN_BIG_INT_NOINLINE __declspec(noinline)
+#else
+    #define BEMAN_BIG_INT_NOINLINE
+#endif
+
 // assert ======================================================================
 
 #include <cstdlib>
@@ -360,7 +370,7 @@ inline constexpr std::size_t width_v = width<T>::value;
 
 // LCOV_EXCL_START
 // GCOVR_EXCL_START
-namespace beman::big_int {
+namespace beman::big_int::detail {
 
 [[noreturn]] inline void assert_fail(const char* const          source,
                                      const std::source_location location = std::source_location::current()) {
@@ -378,9 +388,9 @@ namespace beman::big_int {
 #endif
 }
 
-} // namespace beman::big_int
+} // namespace beman::big_int::detail
 
-#define BEMAN_BIG_INT_ASSERT(...) (__VA_ARGS__ ? void() : assert_fail(#__VA_ARGS__))
+#define BEMAN_BIG_INT_ASSERT(...) (__VA_ARGS__ ? void() : ::beman::big_int::detail::assert_fail(#__VA_ARGS__))
 // GCOVR_EXCL_STOP
 // LCOV_EXCL_STOP
 

--- a/tests/beman/big_int/addition_bench.test.cpp
+++ b/tests/beman/big_int/addition_bench.test.cpp
@@ -6,49 +6,9 @@
 #include <gtest/gtest.h>
 #include <span>
 
+#include "benchmark_testing.hpp"
+
 namespace local {
-
-namespace concurrency {
-
-struct stopwatch {
-  public:
-    using time_point_type = std::uintmax_t;
-
-    auto reset() -> void { m_start = now(); }
-
-    template <typename RepresentationRequestedTimeType>
-    static auto elapsed_time(const stopwatch& my_stopwatch) noexcept -> RepresentationRequestedTimeType {
-        using local_time_type = RepresentationRequestedTimeType;
-
-        return local_time_type{static_cast<local_time_type>(my_stopwatch.elapsed()) /
-                               local_time_type{UINTMAX_C(1000000000)}};
-    }
-
-  private:
-    time_point_type m_start{now()}; // NOLINT(readability-identifier-naming)
-
-    [[nodiscard]] static auto now() -> time_point_type {
-        timespec ts{};
-
-        const int ntsp{timespec_get(&ts, TIME_UTC)};
-
-        static_cast<void>(ntsp);
-
-        return static_cast<time_point_type>(ts.tv_sec) * UINTMAX_C(1000000000) +
-               static_cast<time_point_type>(ts.tv_nsec);
-    }
-
-    [[nodiscard]] auto elapsed() const -> time_point_type {
-        const time_point_type stop{now()};
-
-        const time_point_type elapsed_ns{stop - m_start};
-
-        return elapsed_ns;
-    }
-};
-
-} // namespace concurrency
-
 template <typename BigIntType>
 BigIntType fibonacci(unsigned int n) {
     if (n == 0)
@@ -84,7 +44,7 @@ bool run_benchmarks() {
         boost::multiprecision::number<boost::multiprecision::cpp_int_backend<>, boost::multiprecision::et_off>;
     using big_int_type = beman::big_int::big_int;
 
-    using local_stopwatch_type = local::concurrency::stopwatch;
+    using local_stopwatch_type = beman::big_int::benchmark_testing::stopwatch;
 
     local_stopwatch_type my_stopwatch{};
 

--- a/tests/beman/big_int/benchmark_testing.hpp
+++ b/tests/beman/big_int/benchmark_testing.hpp
@@ -15,36 +15,35 @@ struct stopwatch {
   public:
     using time_point_type = std::uintmax_t;
 
-    auto reset() -> void { m_start = now(); }
+    void reset() { m_start = now(); }
 
     template <class Time>
     BEMAN_BIG_INT_NOINLINE static Time elapsed_time(const stopwatch& my_stopwatch) noexcept {
-        return Time{static_cast<Time>(my_stopwatch.elapsed()) / Time{1000000000}};
+        return Time{static_cast<Time>(my_stopwatch.elapsed()) / Time{1'000'000'000}};
     }
 
     template <class Time = double, class F>
-    BEMAN_BIG_INT_NOINLINE static Time measure_time(const F& f) noexcept {
+    BEMAN_BIG_INT_NOINLINE static Time measure_time(const F& f) {
         const time_point_type start = now();
         f();
         const time_point_type end = now();
-        return static_cast<Time>(end - start) / Time{1000000000};
+        return static_cast<Time>(end - start) / Time{1'000'000'000};
     }
 
   private:
     time_point_type m_start{now()}; // NOLINT(readability-identifier-naming)
 
-    BEMAN_BIG_INT_NOINLINE [[nodiscard]] static auto now() -> time_point_type {
+    BEMAN_BIG_INT_NOINLINE [[nodiscard]] static time_point_type now() {
         timespec ts{};
 
         const int ntsp{timespec_get(&ts, TIME_UTC)};
+        BEMAN_BIG_INT_ASSERT(ntsp);
 
-        static_cast<void>(ntsp);
-
-        return static_cast<time_point_type>(ts.tv_sec) * time_point_type{1000000000} +
+        return static_cast<time_point_type>(ts.tv_sec) * time_point_type{1'000'000'000} +
                static_cast<time_point_type>(ts.tv_nsec);
     }
 
-    [[nodiscard]] auto elapsed() const -> time_point_type {
+    [[nodiscard]] time_point_type elapsed() const {
         const time_point_type stop{now()};
 
         const time_point_type elapsed_ns{stop - m_start};

--- a/tests/beman/big_int/benchmark_testing.hpp
+++ b/tests/beman/big_int/benchmark_testing.hpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: BSL-1.0
+
+#ifndef BEMAN_BIG_INT_BENCHMARK_TESTING_HPP
+#define BEMAN_BIG_INT_BENCHMARK_TESTING_HPP
+
+#include <cstdint>
+#include <ctime>
+
+#include <beman/big_int/detail/config.hpp>
+
+namespace beman::big_int::benchmark_testing {
+
+struct stopwatch {
+  public:
+    using time_point_type = std::uintmax_t;
+
+    auto reset() -> void { m_start = now(); }
+
+    template <class Time>
+    BEMAN_BIG_INT_NOINLINE static Time elapsed_time(const stopwatch& my_stopwatch) noexcept {
+        return Time{static_cast<Time>(my_stopwatch.elapsed()) / Time{1000000000}};
+    }
+
+    template <class Time = double, class F>
+    BEMAN_BIG_INT_NOINLINE static Time measure_time(const F& f) noexcept {
+        const time_point_type start = now();
+        f();
+        const time_point_type end = now();
+        return static_cast<Time>(end - start) / Time{1000000000};
+    }
+
+  private:
+    time_point_type m_start{now()}; // NOLINT(readability-identifier-naming)
+
+    BEMAN_BIG_INT_NOINLINE [[nodiscard]] static auto now() -> time_point_type {
+        timespec ts{};
+
+        const int ntsp{timespec_get(&ts, TIME_UTC)};
+
+        static_cast<void>(ntsp);
+
+        return static_cast<time_point_type>(ts.tv_sec) * time_point_type{1000000000} +
+               static_cast<time_point_type>(ts.tv_nsec);
+    }
+
+    [[nodiscard]] auto elapsed() const -> time_point_type {
+        const time_point_type stop{now()};
+
+        const time_point_type elapsed_ns{stop - m_start};
+
+        return elapsed_ns;
+    }
+};
+
+} // namespace beman::big_int::benchmark_testing
+
+#endif // BEMAN_BIG_INT_BENCHMARK_TESTING_HPP

--- a/tests/beman/big_int/conversion_bench.test.cpp
+++ b/tests/beman/big_int/conversion_bench.test.cpp
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: BSL-1.0
+
+#include <boost/multiprecision/cpp_int.hpp>
+#include <gtest/gtest.h>
+
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "benchmark_testing.hpp"
+#include "boost_mp_testing.hpp"
+
+namespace local {
+
+struct conversion_input_buffers {
+    using big_int_type = beman::big_int::big_int;
+    using cpp_int_type =
+        boost::multiprecision::number<boost::multiprecision::cpp_int_backend<>, boost::multiprecision::et_off>;
+
+    std::vector<big_int_type> big_int_values;
+    std::vector<cpp_int_type> cpp_int_values;
+};
+
+[[nodiscard]] conversion_input_buffers make_random_conversion_input_buffers(const std::size_t count,
+                                                                            const std::size_t max_bits) {
+    // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) - deterministic seed for stable benchmark inputs.
+    std::mt19937_64                            rng{20260427};
+    std::uniform_int_distribution<std::size_t> bit_dist(1, max_bits);
+    std::bernoulli_distribution                sign_dist(0.5);
+
+    conversion_input_buffers out;
+    out.big_int_values.reserve(count);
+    out.cpp_int_values.reserve(count);
+
+    for (std::size_t i = 0; i < count; ++i) {
+        const std::string hex = beman::big_int::boost_mp_testing::random_big_int(bit_dist(rng), sign_dist(rng));
+        out.big_int_values.push_back(beman::big_int::boost_mp_testing::detail::parse_big_int(hex));
+        out.cpp_int_values.push_back(beman::big_int::boost_mp_testing::detail::parse_cpp_int(hex));
+    }
+
+    return out;
+}
+
+[[nodiscard]] bool run_conversion_benchmarks(const std::size_t max_bits) {
+    using local_stopwatch_type = beman::big_int::benchmark_testing::stopwatch;
+
+    constexpr std::uint64_t hash_offset_basis = 1469598103934665603;
+    constexpr std::uint64_t hash_prime        = 1099511628211;
+
+    constexpr std::size_t buffer_size = 4096;
+    constexpr std::size_t passes      = 4096;
+
+    const conversion_input_buffers inputs       = make_random_conversion_input_buffers(buffer_size, max_bits);
+    std::uint64_t                  big_int_sink = hash_offset_basis;
+    std::uint64_t                  cpp_int_sink = hash_offset_basis;
+
+    const auto bench_big_int = [&] {
+        for (std::size_t pass = 0; pass < passes; ++pass) {
+            std::uint64_t big_int_pass_sink = 0;
+            for (const auto& value : inputs.big_int_values) {
+                big_int_pass_sink ^= std::bit_cast<std::uint64_t>(static_cast<double>(value));
+            }
+            big_int_sink ^= (big_int_pass_sink + static_cast<std::uint64_t>(pass));
+            big_int_sink *= hash_prime;
+        }
+    };
+
+    const auto bench_cpp_int = [&] {
+        for (std::size_t pass = 0; pass < passes; ++pass) {
+            std::uint64_t cpp_int_pass_sink = 0;
+            for (const auto& value : inputs.cpp_int_values) {
+                cpp_int_pass_sink ^= std::bit_cast<std::uint64_t>(static_cast<double>(value));
+            }
+            cpp_int_sink ^= (cpp_int_pass_sink + static_cast<std::uint64_t>(pass));
+            cpp_int_sink *= hash_prime;
+        }
+    };
+
+    std::cout << "stopwatch big_int->double: " << local_stopwatch_type::measure_time(bench_big_int) << std::endl;
+    BEMAN_BIG_INT_ASSERT(big_int_sink != hash_offset_basis);
+
+    std::cout << "stopwatch cpp_int->double: " << local_stopwatch_type::measure_time(bench_cpp_int) << std::endl;
+    BEMAN_BIG_INT_ASSERT(cpp_int_sink != hash_offset_basis);
+
+    // We expect bitwise identical results because both `big_int` and `cpp_int` use roundTiesToEven.
+    return big_int_sink == cpp_int_sink;
+}
+
+} // namespace local
+
+// The 64-bit benchmark is mostly just measuring whether there exists a fast path
+// to delegate to the `uint64_t->double` conversions.
+TEST(Conversion, ConversionToDoubleBench64) {
+#ifdef BEMAN_BIG_INT_RUN_BENCHMARKS
+    EXPECT_TRUE(local::run_conversion_benchmarks(64));
+#else
+    GTEST_SKIP() << "Benchmarks not run" << std::endl;
+#endif
+}
+
+// The 128-bit benchmark is mostly just measuring whether there exists a fast path
+// to delegate to the `uint128_t->double` conversions.
+TEST(Conversion, ConversionToDoubleBench128) {
+#ifdef BEMAN_BIG_INT_RUN_BENCHMARKS
+    EXPECT_TRUE(local::run_conversion_benchmarks(128));
+#else
+    GTEST_SKIP() << "Benchmarks not run" << std::endl;
+#endif
+}
+
+// At 256 bits, the "custom implementation" kicks in for both types.
+TEST(Conversion, ConversionToDoubleBench256) {
+#ifdef BEMAN_BIG_INT_RUN_BENCHMARKS
+    EXPECT_TRUE(local::run_conversion_benchmarks(256));
+#else
+    GTEST_SKIP() << "Benchmarks not run" << std::endl;
+#endif
+}
+
+TEST(Conversion, ConversionToDoubleBench512) {
+#ifdef BEMAN_BIG_INT_RUN_BENCHMARKS
+    EXPECT_TRUE(local::run_conversion_benchmarks(512));
+#else
+    GTEST_SKIP() << "Benchmarks not run" << std::endl;
+#endif
+}
+
+TEST(Conversion, ConversionToDoubleBench1024) {
+#ifdef BEMAN_BIG_INT_RUN_BENCHMARKS
+    EXPECT_TRUE(local::run_conversion_benchmarks(1024));
+#else
+    GTEST_SKIP() << "Benchmarks not run" << std::endl;
+#endif
+}
+
+TEST(Conversion, ConversionToDoubleBench2048) {
+#ifdef BEMAN_BIG_INT_RUN_BENCHMARKS
+    EXPECT_TRUE(local::run_conversion_benchmarks(2048));
+#else
+    GTEST_SKIP() << "Benchmarks not run" << std::endl;
+#endif
+}

--- a/tests/beman/big_int/conversion_bench.test.cpp
+++ b/tests/beman/big_int/conversion_bench.test.cpp
@@ -1,6 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-License-Identifier: BSL-1.0
 
+#include <beman/big_int/detail/config.hpp>
+
+BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
+BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Warray-bounds") // This causes way too many problems.
+BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Wstringop-overflow")
+BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Wstringop-overread")
+
 #include <boost/multiprecision/cpp_int.hpp>
 #include <gtest/gtest.h>
 
@@ -14,11 +21,6 @@
 
 #include "benchmark_testing.hpp"
 #include "boost_mp_testing.hpp"
-
-BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
-BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Warray-bounds") // This causes way too many problems.
-BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Wstringop-overflow")
-BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Wstringop-overread")
 
 namespace local {
 

--- a/tests/beman/big_int/conversion_bench.test.cpp
+++ b/tests/beman/big_int/conversion_bench.test.cpp
@@ -59,8 +59,8 @@ struct conversion_input_buffers {
     constexpr std::uint64_t hash_offset_basis = 1469598103934665603;
     constexpr std::uint64_t hash_prime        = 1099511628211;
 
-    constexpr std::size_t buffer_size = 4096;
-    constexpr std::size_t passes      = 4096;
+    constexpr std::size_t buffer_size = 20'000'000;
+    constexpr std::size_t passes      = 5;
 
     const conversion_input_buffers inputs       = make_random_conversion_input_buffers(buffer_size, max_bits);
     std::uint64_t                  big_int_sink = hash_offset_basis;

--- a/tests/beman/big_int/conversion_bench.test.cpp
+++ b/tests/beman/big_int/conversion_bench.test.cpp
@@ -15,6 +15,11 @@
 #include "benchmark_testing.hpp"
 #include "boost_mp_testing.hpp"
 
+BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
+BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Warray-bounds") // This causes way too many problems.
+BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Wstringop-overflow")
+BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Wstringop-overread")
+
 namespace local {
 
 struct conversion_input_buffers {
@@ -145,3 +150,5 @@ TEST(Conversion, ConversionToDoubleBench2048) {
     GTEST_SKIP() << "Benchmarks not run" << std::endl;
 #endif
 }
+
+BEMAN_BIG_INT_DIAGNOSTIC_POP()

--- a/tests/beman/big_int/conversion_bench.test.cpp
+++ b/tests/beman/big_int/conversion_bench.test.cpp
@@ -59,7 +59,7 @@ struct conversion_input_buffers {
     constexpr std::uint64_t hash_offset_basis = 1469598103934665603;
     constexpr std::uint64_t hash_prime        = 1099511628211;
 
-    constexpr std::size_t buffer_size = 20'000'000;
+    constexpr std::size_t buffer_size = 1'000'000;
     constexpr std::size_t passes      = 5;
 
     const conversion_input_buffers inputs       = make_random_conversion_input_buffers(buffer_size, max_bits);


### PR DESCRIPTION
```
[ RUN      ] Conversion.ConversionToDoubleBench64
stopwatch big_int->double: 0.720493
stopwatch cpp_int->double: 0.744844

[ RUN      ] Conversion.ConversionToDoubleBench128
stopwatch big_int->double: 0.840079
stopwatch cpp_int->double: 1.07825

[ RUN      ] Conversion.ConversionToDoubleBench256
stopwatch big_int->double: 1.25381
stopwatch cpp_int->double: 1.23328

[ RUN      ] Conversion.ConversionToDoubleBench512
stopwatch big_int->double: 1.39079
stopwatch cpp_int->double: 1.25781

[ RUN      ] Conversion.ConversionToDoubleBench1024
stopwatch big_int->double: 1.45654
stopwatch cpp_int->double: 1.29221

[ RUN      ] Conversion.ConversionToDoubleBench2048
stopwatch big_int->double: 1.20756
stopwatch cpp_int->double: 1.40179
```