### PR TITLE
Implement in-place short division for `operator/=` and `operator%=`

### DIFF
--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -245,11 +245,12 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     // This does not modify the contents of the representation,
     // only the `limb_count()` is equal to `1` after calling this function if the integer value is zero.
     // This function is safe to call on negative zero; the sign bit is not affected.
-    constexpr void                           unchecked_trim_magnitude() noexcept;
-    constexpr void                           negate() noexcept;
-    constexpr void                           set_zero() noexcept;
-    [[nodiscard]] constexpr limb_type*       limb_ptr() noexcept;
-    [[nodiscard]] constexpr const limb_type* limb_ptr() const noexcept;
+    constexpr void                                           unchecked_trim_magnitude() noexcept;
+    constexpr void                                           negate() noexcept;
+    constexpr void                                           set_zero() noexcept;
+    [[nodiscard]] constexpr limb_type*                       limb_ptr() noexcept;
+    [[nodiscard]] constexpr const limb_type*                 limb_ptr() const noexcept;
+    [[nodiscard]] constexpr std::span<uint_multiprecision_t> limb_span() noexcept;
 
   public:
     // [big.int.cons], construct/copy/destroy
@@ -513,6 +514,13 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
                                                       uint_multiprecision_t                            divisor,
                                                       bool                                             divisor_neg,
                                                       detail::division_op                              op);
+
+    // Single-limb divisor in-place fast path.
+    // Replaces `*this` with the quotient (for `div` / `div_rem`) or with the
+    // remainder (for `rem`), and returns the scalar remainder.
+    // Does not allocate.
+    constexpr uint_multiprecision_t
+    divmod_in_place_short(uint_multiprecision_t divisor, bool divisor_neg, detail::division_op op);
 
     // Shared implementation behind copy-assign, move-assign, and the lvalue
     // branches of `operator+` / `operator-`.
@@ -815,6 +823,11 @@ constexpr auto basic_big_int<b, A>::limb_ptr() noexcept -> limb_type* {
 template <std::size_t b, class A>
 constexpr auto basic_big_int<b, A>::limb_ptr() const noexcept -> const limb_type* {
     return is_representation_inplace() ? m_storage.limbs : m_storage.data;
+}
+
+template <std::size_t b, class A>
+constexpr std::span<uint_multiprecision_t> basic_big_int<b, A>::limb_span() noexcept {
+    return {limb_ptr(), limb_count()};
 }
 
 // [big.int.cons] — constructors
@@ -2510,6 +2523,26 @@ basic_big_int<b, A>::divmod_into_short(const std::span<const uint_multiprecision
     return remainder;
 }
 
+template <std::size_t b, class A>
+constexpr uint_multiprecision_t basic_big_int<b, A>::divmod_in_place_short(const uint_multiprecision_t divisor,
+                                                                           const bool                  divisor_neg,
+                                                                           const detail::division_op   op) {
+    BEMAN_BIG_INT_ASSERT(divisor != 0);
+
+    const bool                  want_quotient = op != detail::division_op::rem;
+    const bool                  result_neg    = want_quotient ? is_negative() != divisor_neg : is_negative();
+    const auto                  limbs         = limb_span();
+    const uint_multiprecision_t remainder     = detail::divide_unsigned_short(limbs, limbs, divisor);
+    if (want_quotient) {
+        unchecked_trim_magnitude();
+    } else {
+        limb_ptr()[0] = remainder;
+        unchecked_set_limb_count(1);
+    }
+    unchecked_set_sign(result_neg && !unchecked_is_magnitude_zero());
+    return remainder;
+}
+
 // Generic divide/modulus dispatcher.
 // Handles the four special cases:
 //   1) zero divisor,
@@ -2709,29 +2742,39 @@ constexpr auto basic_big_int<b, A>::operator/=(T&& rhs) -> basic_big_int&
 {
     if constexpr (detail::is_basic_big_int_v<std::remove_cvref_t<T>>) {
         if constexpr (std::is_same_v<std::remove_cvref_t<T>, basic_big_int>) {
-            // Self-division: `std::move(*this)` below would zero `rhs` when &rhs == this.
+            // Self-division: the multi-limb slow path below would zero `rhs`'s
+            // storage when `&rhs == this`.
             if (&rhs == this) {
                 BEMAN_BIG_INT_ASSERT(!is_zero());
                 *this = basic_big_int{1};
                 return *this;
             }
         }
-        const basic_big_int temp = std::move(*this);
-        *this                    = basic_big_int{};
-        divmod_into(temp.representation(),
-                    temp.is_negative(),
-                    rhs.representation(),
-                    rhs.is_negative(),
-                    detail::division_op::div);
+        if (rhs.limb_count() == 1) {
+            static_cast<void>(divmod_in_place_short(rhs.limb_ptr()[0], rhs.is_negative(), detail::division_op::div));
+        } else {
+            const basic_big_int temp = std::move(*this);
+            *this                    = basic_big_int{};
+            divmod_into(temp.representation(),
+                        temp.is_negative(),
+                        rhs.representation(),
+                        rhs.is_negative(),
+                        detail::division_op::div);
+        }
     } else {
-        const basic_big_int temp = std::move(*this);
-        *this                    = basic_big_int{};
-        const auto rhs_limbs     = detail::to_limbs(detail::uabs(rhs));
-        divmod_into(temp.representation(),
-                    temp.is_negative(),
-                    detail::to_fixed_span(rhs_limbs),
-                    detail::integer_signbit(rhs),
-                    detail::division_op::div);
+        const auto rhs_limbs = detail::to_limbs(detail::uabs(rhs));
+        if (detail::trimmed_size(rhs_limbs) == 1) {
+            static_cast<void>(
+                divmod_in_place_short(rhs_limbs[0], detail::integer_signbit(rhs), detail::division_op::div));
+        } else {
+            const basic_big_int temp = std::move(*this);
+            *this                    = basic_big_int{};
+            divmod_into(temp.representation(),
+                        temp.is_negative(),
+                        detail::to_fixed_span(rhs_limbs),
+                        detail::integer_signbit(rhs),
+                        detail::division_op::div);
+        }
     }
     return *this;
 }
@@ -2750,22 +2793,31 @@ constexpr auto basic_big_int<b, A>::operator%=(T&& rhs) -> basic_big_int&
                 return *this;
             }
         }
-        const basic_big_int temp = std::move(*this);
-        *this                    = basic_big_int{};
-        divmod_into(temp.representation(),
-                    temp.is_negative(),
-                    rhs.representation(),
-                    rhs.is_negative(),
-                    detail::division_op::rem);
+        if (rhs.limb_count() == 1) {
+            static_cast<void>(divmod_in_place_short(rhs.limb_ptr()[0], rhs.is_negative(), detail::division_op::rem));
+        } else {
+            const basic_big_int temp = std::move(*this);
+            *this                    = basic_big_int{};
+            divmod_into(temp.representation(),
+                        temp.is_negative(),
+                        rhs.representation(),
+                        rhs.is_negative(),
+                        detail::division_op::rem);
+        }
     } else {
-        const basic_big_int temp = std::move(*this);
-        *this                    = basic_big_int{};
-        const auto rhs_limbs     = detail::to_limbs(detail::uabs(rhs));
-        divmod_into(temp.representation(),
-                    temp.is_negative(),
-                    detail::to_fixed_span(rhs_limbs),
-                    detail::integer_signbit(rhs),
-                    detail::division_op::rem);
+        const auto rhs_limbs = detail::to_limbs(detail::uabs(rhs));
+        if (detail::trimmed_size(rhs_limbs) == 1) {
+            static_cast<void>(
+                divmod_in_place_short(rhs_limbs[0], detail::integer_signbit(rhs), detail::division_op::rem));
+        } else {
+            const basic_big_int temp = std::move(*this);
+            *this                    = basic_big_int{};
+            divmod_into(temp.representation(),
+                        temp.is_negative(),
+                        detail::to_fixed_span(rhs_limbs),
+                        detail::integer_signbit(rhs),
+                        detail::division_op::rem);
+        }
     }
     return *this;
 }

--- a/include/beman/big_int/detail/div_impl.hpp
+++ b/include/beman/big_int/detail/div_impl.hpp
@@ -73,7 +73,10 @@ compare_unsigned_spans(const std::span<const uint_multiprecision_t> a,
 // ---------------------------------------------------------------------------
 // Single-limb short division.
 // `quotient[i]` := floor(([remainder, dividend[i]] as two limbs) / divisor)
-// scanning from the top limb down. Returns the scalar remainder.
+// scanning from the top limb down.
+// Returns the scalar remainder.
+// `quotient` and `dividend` may be the same range (i.e. alias each other),
+// but `quotient` may not be a strict subrange of `dividend`.
 //
 // Preconditions:
 //   - divisor != 0

--- a/tests/beman/big_int/division.test.cpp
+++ b/tests/beman/big_int/division.test.cpp
@@ -236,6 +236,69 @@ TEST(Division, CompoundAssignmentMultiLimb) {
     EXPECT_EQ(a, expected);
 }
 
+TEST(Division, CompoundAssignmentSingleLimbDivisorBigInt) {
+    // Multi-limb dividend, single-limb basic_big_int divisor: exercises the
+    // in-place divide_unsigned_short_inplace fast path in operator/=.
+    big_int       a        = (big_int{1} << 200) + big_int{12345};
+    const big_int expected = a / big_int{7};
+    a /= big_int{7};
+    EXPECT_EQ(a, expected);
+
+    // Negative dividend, positive divisor.
+    big_int    b    = -((big_int{1} << 200) + big_int{12345});
+    const auto bexp = b / big_int{7};
+    b /= big_int{7};
+    EXPECT_EQ(b, bexp);
+
+    // Positive dividend, negative divisor (sign flips).
+    big_int    c    = (big_int{1} << 200) + big_int{12345};
+    const auto cexp = c / big_int{-7};
+    c /= big_int{-7};
+    EXPECT_EQ(c, cexp);
+
+    // Both negative.
+    big_int    d    = -((big_int{1} << 200) + big_int{12345});
+    const auto dexp = d / big_int{-7};
+    d /= big_int{-7};
+    EXPECT_EQ(d, dexp);
+
+    // Result is exactly zero (dividend divides exactly into a smaller magnitude).
+    big_int e = big_int{42};
+    e /= big_int{100};
+    EXPECT_EQ(e, big_int{0});
+
+    // Single-limb dividend / single-limb divisor.
+    big_int f{123456789};
+    f /= big_int{1000};
+    EXPECT_EQ(f, big_int{123456});
+
+    // Result trims down from multi-limb to single-limb.
+    big_int g = (big_int{1} << 64);
+    g /= big_int{2};
+    EXPECT_EQ(g, big_int{1} << 63);
+}
+
+TEST(Division, CompoundAssignmentSingleLimbDivisorPrimitive) {
+    // Multi-limb dividend, primitive divisor that fits in a single limb.
+    big_int       a        = (big_int{1} << 200) + big_int{12345};
+    const big_int expected = a / 7U;
+    a /= 7U;
+    EXPECT_EQ(a, expected);
+
+    // Negative result via signed divisor.
+    big_int    b    = (big_int{1} << 200) + big_int{12345};
+    const auto bexp = b / -7;
+    b /= -7;
+    EXPECT_EQ(b, bexp);
+
+    // Wide unsigned divisor whose value still fits in one limb.
+    big_int             c          = (big_int{1} << 200) + big_int{99999};
+    const std::uint64_t d          = 1234567890123ULL;
+    const big_int       expected_c = c / d;
+    c /= d;
+    EXPECT_EQ(c, expected_c);
+}
+
 TEST(Division, SelfDivision) {
     // Exercises the move-into-temp aliasing guard in operator/=.
     big_int a{123456789};

--- a/tests/beman/big_int/modulus.test.cpp
+++ b/tests/beman/big_int/modulus.test.cpp
@@ -177,6 +177,48 @@ TEST(Modulus, CompoundAssignmentMultiLimb) {
     EXPECT_EQ(a, 4);
 }
 
+TEST(Modulus, CompoundAssignmentSingleLimbDivisorBigInt) {
+    // Multi-limb dividend, single-limb big_int divisor: hits divmod_in_place_short.
+    big_int    a          = (big_int{1} << 200) + big_int{12345};
+    const auto r_expected = a % big_int{7};
+    a %= big_int{7};
+    EXPECT_EQ(a, r_expected);
+    EXPECT_TRUE(a >= big_int{0});
+    EXPECT_TRUE(a < big_int{7});
+
+    // Negative dividend retains its sign per truncated modulus.
+    big_int b = -((big_int{1} << 200) + big_int{12345});
+    b %= big_int{7};
+    EXPECT_EQ(b, -r_expected);
+
+    // Negative single-limb divisor: remainder sign follows dividend.
+    big_int c = (big_int{1} << 200) + big_int{12345};
+    c %= big_int{-7};
+    EXPECT_EQ(c, r_expected);
+
+    // Result becomes zero — sign must not be left as negative zero.
+    big_int d = big_int{7} * ((big_int{1} << 128) + big_int{1});
+    d %= big_int{-7};
+    EXPECT_EQ(d, 0);
+    EXPECT_FALSE(d < big_int{0});
+}
+
+TEST(Modulus, CompoundAssignmentSingleLimbDivisorPrimitive) {
+    // Multi-limb dividend, primitive divisor: hits divmod_in_place_short.
+    big_int    a          = (big_int{1} << 200) + big_int{12345};
+    const auto r_expected = a % 7;
+    a %= 7;
+    EXPECT_EQ(a, r_expected);
+
+    big_int b = -((big_int{1} << 200) + big_int{12345});
+    b %= 7;
+    EXPECT_EQ(b, -r_expected);
+
+    big_int c = (big_int{1} << 200) + big_int{12345};
+    c %= -7;
+    EXPECT_EQ(c, r_expected);
+}
+
 TEST(Modulus, SelfMod) {
     // Exercises the move-into-temp aliasing guard in operator%=.
     big_int a{123456789};


### PR DESCRIPTION
This also adds a few tests.