### PR TITLE
Test with multi-limb divisors

### DIFF
--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -114,8 +114,8 @@ struct allocation_result {
 // where the result is an unsigned integer.
 // Unlike `std::abs`, this function has no undefined behavior in e.g. `uabs(INT_MIN)`.
 template <signed_integer T>
-[[nodiscard]] constexpr std::make_unsigned_t<T> uabs(const T x) noexcept {
-    using U = std::make_unsigned_t<T>;
+[[nodiscard]] constexpr detail::make_unsigned_t<T> uabs(const T x) noexcept {
+    using U = detail::make_unsigned_t<T>;
     BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
     BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_MSVC(4146) // unary minus on unsigned is intentional
     return x < 0 ? -static_cast<U>(x) : static_cast<U>(x);
@@ -315,7 +315,7 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
             unchecked_set_limb_count(count);
             unchecked_set_sign(x.is_negative());
         } else {
-            using U                 = std::make_unsigned_t<std::remove_cvref_t<T>>;
+            using U                 = detail::make_unsigned_t<std::remove_cvref_t<T>>;
             const bool          neg = std::is_signed_v<std::remove_cvref_t<T>> && x < std::remove_cvref_t<T>{0};
             const U             mag = neg ? static_cast<U>(U{0} - static_cast<U>(x)) : static_cast<U>(x);
             constexpr size_type n   = detail::div_to_pos_inf(sizeof(U), sizeof(limb_type));
@@ -918,7 +918,7 @@ constexpr basic_big_int<b, A>::basic_big_int(I begin, S end, const allocator_typ
         std::size_t i   = 0;
         auto* const dst = limb_ptr();
         for (; begin != end; ++begin) {
-            using U = std::make_unsigned_t<std::iter_value_t<I>>;
+            using U = detail::make_unsigned_t<std::iter_value_t<I>>;
             std::construct_at(dst + i++, static_cast<limb_type>(static_cast<U>(*begin)));
         }
         if (i == 0) {
@@ -929,7 +929,7 @@ constexpr basic_big_int<b, A>::basic_big_int(I begin, S end, const allocator_typ
         }
     } else {
         for (; begin != end; ++begin) {
-            using U = std::make_unsigned_t<std::iter_value_t<I>>;
+            using U = detail::make_unsigned_t<std::iter_value_t<I>>;
             push_back_limb(static_cast<limb_type>(static_cast<U>(*begin)));
         }
         unchecked_trim_magnitude();
@@ -950,7 +950,7 @@ constexpr auto basic_big_int<b, A>::operator>>=(const S s) -> basic_big_int& {
     // This would convert to another type and signal whether the result is exactly representable.
     if constexpr (std::is_signed_v<S>) {
         BEMAN_BIG_INT_DEBUG_ASSERT(s >= 0);
-        BEMAN_BIG_INT_DEBUG_ASSERT(static_cast<std::make_unsigned_t<S>>(s) <= shift_max);
+        BEMAN_BIG_INT_DEBUG_ASSERT(static_cast<detail::make_unsigned_t<S>>(s) <= shift_max);
     } else {
         BEMAN_BIG_INT_DEBUG_ASSERT(s <= shift_max);
     }
@@ -963,7 +963,7 @@ template <detail::signed_or_unsigned S>
 constexpr auto basic_big_int<b, A>::operator<<=(const S s) -> basic_big_int& {
     if constexpr (std::is_signed_v<S>) {
         BEMAN_BIG_INT_DEBUG_ASSERT(s >= 0);
-        BEMAN_BIG_INT_DEBUG_ASSERT(static_cast<std::make_unsigned_t<S>>(s) <= shift_max);
+        BEMAN_BIG_INT_DEBUG_ASSERT(static_cast<detail::make_unsigned_t<S>>(s) <= shift_max);
     } else {
         BEMAN_BIG_INT_DEBUG_ASSERT(s <= shift_max);
     }
@@ -1326,7 +1326,7 @@ constexpr T basic_big_int<b, A>::to() const noexcept {
                 return static_cast<T>(inplace_to_sbit_int());
             }
         }
-        using U = std::make_unsigned_t<T>;
+        using U = detail::make_unsigned_t<T>;
         U                 mag{0};
         constexpr auto    n     = detail::div_to_pos_inf(sizeof(U), sizeof(limb_type));
         const auto* const limbs = limb_ptr();
@@ -1679,7 +1679,7 @@ constexpr std::remove_cvref_t<T> operator<<(T&& x, const S s) {
 
     if constexpr (std::is_signed_v<S>) {
         BEMAN_BIG_INT_DEBUG_ASSERT(s >= 0);
-        BEMAN_BIG_INT_DEBUG_ASSERT(static_cast<std::make_unsigned_t<S>>(s) <= Result::shift_max);
+        BEMAN_BIG_INT_DEBUG_ASSERT(static_cast<detail::make_unsigned_t<S>>(s) <= Result::shift_max);
     } else {
         BEMAN_BIG_INT_DEBUG_ASSERT(s <= Result::shift_max);
     }
@@ -1715,7 +1715,7 @@ constexpr std::remove_cvref_t<T> operator>>(T&& x, const S s) {
 
     if constexpr (std::is_signed_v<S>) {
         BEMAN_BIG_INT_DEBUG_ASSERT(s >= 0);
-        BEMAN_BIG_INT_DEBUG_ASSERT(static_cast<std::make_unsigned_t<S>>(s) <= Result::shift_max);
+        BEMAN_BIG_INT_DEBUG_ASSERT(static_cast<detail::make_unsigned_t<S>>(s) <= Result::shift_max);
     } else {
         BEMAN_BIG_INT_DEBUG_ASSERT(s <= Result::shift_max);
     }

--- a/include/beman/big_int/detail/config.hpp
+++ b/include/beman/big_int/detail/config.hpp
@@ -275,13 +275,96 @@ static_assert(unsigned_integer<unsigned _BitInt(32)>);
 static_assert(signed_integer<_BitInt(32)>);
 #endif
 
+// Like `std::make_signed`, but also supports bit-precise integers (`_BitInt`).
+template <class T>
+struct make_unsigned : std::make_unsigned<T> {};
+
+#ifdef BEMAN_BIG_INT_HAS_INT128_CLASS
+template <>
+struct make_unsigned<int128_t> {
+    using type = uint128_t;
+};
+template <>
+struct make_unsigned<uint128_t> {
+    using type = uint128_t;
+};
+#endif // BEMAN_BIG_INT_HAS_INT128_CLASS
+
+#ifdef BEMAN_BIG_INT_HAS_BITINT
+template <std::size_t N>
+struct make_unsigned<_BitInt(N)> {
+    using type = unsigned _BitInt(N);
+};
+template <std::size_t N>
+struct make_unsigned<unsigned _BitInt(N)> {
+    using type = unsigned _BitInt(N);
+};
+#endif // BEMAN_BIG_INT_HAS_BITINT
+
+template <class T>
+struct make_unsigned<const T> {
+    using type = const typename make_unsigned<T>::type;
+};
+template <class T>
+struct make_unsigned<volatile T> {
+    using type = volatile typename make_unsigned<T>::type;
+};
+template <class T>
+struct make_unsigned<const volatile T> {
+    using type = const volatile typename make_unsigned<T>::type;
+};
+
+template <class T>
+using make_unsigned_t = typename make_unsigned<T>::type;
+
+// Like `std::make_signed`, but also supports bit-precise integers (`_BitInt`).
+template <class T>
+struct make_signed : std::make_signed<T> {};
+
+#ifdef BEMAN_BIG_INT_HAS_INT128_CLASS
+template <>
+struct make_signed<int128_t> {
+    using type = int128_t;
+};
+template <>
+struct make_signed<uint128_t> {
+    using type = int128_t;
+};
+#endif // BEMAN_BIG_INT_HAS_INT128_CLASS
+
+#ifdef BEMAN_BIG_INT_HAS_BITINT
+template <std::size_t N>
+struct make_signed<_BitInt(N)> {
+    using type = _BitInt(N);
+};
+template <std::size_t N>
+struct make_signed<unsigned _BitInt(N)> {
+    using type = _BitInt(N);
+};
+#endif // BEMAN_BIG_INT_HAS_BITINT
+
+template <class T>
+struct make_signed<const T> : make_signed<T> {
+    using type = const typename make_signed<T>::type;
+};
+template <class T>
+struct make_signed<volatile T> {
+    using type = volatile typename make_signed<T>::type;
+};
+template <class T>
+struct make_signed<const volatile T> {
+    using type = const volatile typename make_signed<T>::type;
+};
+
+template <class T>
+using make_signed_t = typename make_signed<T>::type;
+
 // Alias template that maps a cv-unqualified integral type onto the underlying
 // signed or unsigned integer type.
 // For example, this converts `char8_t` to `unsigned char`, `int` to `int`, etc.
 // The goal is to reduce redundant template instantiations.
 template <cv_unqualified_integral T>
-using make_signed_or_unsigned_t =
-    std::conditional_t<std::is_signed_v<T>, std::make_signed_t<T>, std::make_unsigned_t<T>>;
+using make_signed_or_unsigned_t = std::conditional_t<std::is_signed_v<T>, make_signed_t<T>, make_unsigned_t<T>>;
 
 template <class T>
 concept cv_unqualified_floating_point = cv_unqualified<T> && std::floating_point<T>;
@@ -313,8 +396,8 @@ struct width<const volatile T> : width<T> {};
 
 template <cv_unqualified_integral T>
 struct width<T>
-    : std::integral_constant<std::size_t,
-                             static_cast<std::size_t>(std::numeric_limits<std::make_unsigned_t<T>>::digits)> {};
+    : std::integral_constant<std::size_t, static_cast<std::size_t>(std::numeric_limits<make_unsigned_t<T>>::digits)> {
+};
 
 #ifdef BEMAN_BIG_INT_HAS_INT128_CLASS
 template <>

--- a/include/beman/big_int/detail/wide_ops.hpp
+++ b/include/beman/big_int/detail/wide_ops.hpp
@@ -242,7 +242,7 @@ template <signed_or_unsigned T>
             }
         }
     #endif
-        using U = std::make_unsigned_t<T>;
+        using U = detail::make_unsigned_t<T>;
         return {
             .low_bits  = static_cast<T>(static_cast<U>(x) * static_cast<U>(y)),
             .high_bits = high_mul(x, y),

--- a/tests/beman/big_int/division.test.cpp
+++ b/tests/beman/big_int/division.test.cpp
@@ -236,6 +236,79 @@ TEST(Division, CompoundAssignmentMultiLimb) {
     EXPECT_EQ(a, expected);
 }
 
+TEST(Division, CompoundAssignmentMultiLimbDivisorBigInt) {
+    // Multi-limb dividend, multi-limb basic_big_int divisor: exercises the
+    // generic divmod_into slow path in operator/=.
+    const big_int divisor  = (big_int{1} << 100) + big_int{12345};
+    const big_int dividend = (big_int{1} << 250) + big_int{67890};
+
+    big_int       a        = dividend;
+    const big_int expected = dividend / divisor;
+    a /= divisor;
+    EXPECT_EQ(a, expected);
+
+    // Negative dividend, positive multi-limb divisor.
+    big_int       b     = -dividend;
+    const big_int b_exp = (-dividend) / divisor;
+    b /= divisor;
+    EXPECT_EQ(b, b_exp);
+
+    // Positive dividend, negative multi-limb divisor.
+    big_int       c     = dividend;
+    const big_int c_exp = dividend / (-divisor);
+    c /= -divisor;
+    EXPECT_EQ(c, c_exp);
+
+    // Both negative.
+    big_int       d     = -dividend;
+    const big_int d_exp = (-dividend) / (-divisor);
+    d /= -divisor;
+    EXPECT_EQ(d, d_exp);
+
+    // Quotient that trims back to a single limb after division.
+    big_int       e     = (big_int{1} << 200);
+    const big_int e_div = (big_int{1} << 100);
+    const big_int e_exp = e / e_div;
+    e /= e_div;
+    EXPECT_EQ(e, e_exp);
+
+    // |dividend| < |divisor|: quotient is exactly zero, sign must canonicalize.
+    big_int f = (big_int{1} << 100) + big_int{1};
+    f /= -((big_int{1} << 200));
+    EXPECT_EQ(f, big_int{0});
+    EXPECT_FALSE(f < big_int{0});
+}
+
+TEST(Division, CompoundAssignmentMultiLimbDivisorPrimitive) {
+#ifndef BEMAN_BIG_INT_HAS_INT128
+    GTEST_SKIP() << "Requires 128-bit integer support.";
+#else
+    // uint128_t spans multiple limbs: exercises the integer-rhs slow path in
+    // operator/= where to_limbs(...) yields a multi-limb span.
+    using beman::big_int::detail::uint128_t;
+
+    const uint128_t divisor  = (static_cast<uint128_t>(1) << 100) + uint128_t{12345};
+    const big_int   big_div  = big_int{divisor};
+    const big_int   dividend = (big_int{1} << 250) + big_int{67890};
+
+    big_int       a        = dividend;
+    const big_int expected = dividend / big_div;
+    a /= divisor;
+    EXPECT_EQ(a, expected);
+
+    // Negative dividend; uint128_t divisor is unsigned, so sign comes from dividend.
+    big_int       b     = -dividend;
+    const big_int b_exp = (-dividend) / big_div;
+    b /= divisor;
+    EXPECT_EQ(b, b_exp);
+
+    // |dividend| < |divisor|: quotient zero.
+    big_int c = (big_int{1} << 50);
+    c /= divisor;
+    EXPECT_EQ(c, big_int{0});
+#endif // BEMAN_BIG_INT_HAS_INT128
+}
+
 TEST(Division, CompoundAssignmentSingleLimbDivisorBigInt) {
     // Multi-limb dividend, single-limb basic_big_int divisor: exercises the
     // in-place divide_unsigned_short_inplace fast path in operator/=.

--- a/tests/beman/big_int/division.test.cpp
+++ b/tests/beman/big_int/division.test.cpp
@@ -280,7 +280,7 @@ TEST(Division, CompoundAssignmentMultiLimbDivisorBigInt) {
 }
 
 TEST(Division, CompoundAssignmentMultiLimbDivisorPrimitive) {
-#ifndef BEMAN_BIG_INT_HAS_INT128
+#ifndef BEMAN_BIG_INT_HAS_INT128_FUNDAMENTAL
     GTEST_SKIP() << "Requires 128-bit integer support.";
 #else
     // uint128_t spans multiple limbs: exercises the integer-rhs slow path in

--- a/tests/beman/big_int/modulus.test.cpp
+++ b/tests/beman/big_int/modulus.test.cpp
@@ -177,6 +177,85 @@ TEST(Modulus, CompoundAssignmentMultiLimb) {
     EXPECT_EQ(a, 4);
 }
 
+TEST(Modulus, CompoundAssignmentMultiLimbDivisorBigInt) {
+    // Multi-limb dividend, multi-limb basic_big_int divisor: exercises the
+    // generic divmod_into slow path in operator%=.
+    const big_int divisor  = (big_int{1} << 100) + big_int{12345};
+    const big_int dividend = (big_int{1} << 250) + big_int{67890};
+
+    big_int       a        = dividend;
+    const big_int expected = dividend % divisor;
+    a %= divisor;
+    EXPECT_EQ(a, expected);
+    EXPECT_EQ((dividend / divisor) * divisor + a, dividend);
+
+    // Negative dividend, positive multi-limb divisor — remainder follows dividend sign.
+    big_int       b     = -dividend;
+    const big_int b_exp = (-dividend) % divisor;
+    b %= divisor;
+    EXPECT_EQ(b, b_exp);
+    EXPECT_TRUE(b <= big_int{0});
+
+    // Positive dividend, negative multi-limb divisor — remainder still follows dividend sign.
+    big_int       c     = dividend;
+    const big_int c_exp = dividend % (-divisor);
+    c %= -divisor;
+    EXPECT_EQ(c, c_exp);
+    EXPECT_TRUE(c >= big_int{0});
+
+    // Both negative.
+    big_int       d     = -dividend;
+    const big_int d_exp = (-dividend) % (-divisor);
+    d %= -divisor;
+    EXPECT_EQ(d, d_exp);
+
+    // |dividend| < |divisor|: remainder equals dividend, sign canonical.
+    big_int       e_div  = (big_int{1} << 200);
+    big_int       e      = (big_int{1} << 100) + big_int{1};
+    const big_int e_orig = e;
+    e %= e_div;
+    EXPECT_EQ(e, e_orig);
+
+    // Result becomes zero — sign must not be left as negative zero.
+    const big_int multiple = divisor * ((big_int{1} << 64) + big_int{3});
+    big_int       f        = -multiple;
+    f %= -divisor;
+    EXPECT_EQ(f, big_int{0});
+    EXPECT_FALSE(f < big_int{0});
+}
+
+TEST(Modulus, CompoundAssignmentMultiLimbDivisorPrimitive) {
+#ifndef BEMAN_BIG_INT_HAS_INT128
+    GTEST_SKIP() << "Requires 128-bit integer support.";
+#else
+    // uint128_t spans multiple limbs: exercises the integer-rhs slow path in
+    // operator%= where to_limbs(...) yields a multi-limb span.
+    using beman::big_int::detail::uint128_t;
+
+    const uint128_t divisor  = (static_cast<uint128_t>(1) << 100) + uint128_t{12345};
+    const big_int   big_div  = big_int{divisor};
+    const big_int   dividend = (big_int{1} << 250) + big_int{67890};
+
+    big_int       a        = dividend;
+    const big_int expected = dividend % big_div;
+    a %= divisor;
+    EXPECT_EQ(a, expected);
+    EXPECT_EQ((dividend / big_div) * big_div + a, dividend);
+
+    // Negative dividend.
+    big_int       b     = -dividend;
+    const big_int b_exp = (-dividend) % big_div;
+    b %= divisor;
+    EXPECT_EQ(b, b_exp);
+
+    // |dividend| < |divisor|: remainder equals dividend.
+    big_int       c      = (big_int{1} << 50);
+    const big_int c_orig = c;
+    c %= divisor;
+    EXPECT_EQ(c, c_orig);
+#endif // BEMAN_BIG_INT_HAS_INT128
+}
+
 TEST(Modulus, CompoundAssignmentSingleLimbDivisorBigInt) {
     // Multi-limb dividend, single-limb big_int divisor: hits divmod_in_place_short.
     big_int    a          = (big_int{1} << 200) + big_int{12345};

--- a/tests/beman/big_int/modulus.test.cpp
+++ b/tests/beman/big_int/modulus.test.cpp
@@ -225,7 +225,7 @@ TEST(Modulus, CompoundAssignmentMultiLimbDivisorBigInt) {
 }
 
 TEST(Modulus, CompoundAssignmentMultiLimbDivisorPrimitive) {
-#ifndef BEMAN_BIG_INT_HAS_INT128
+#ifndef BEMAN_BIG_INT_HAS_INT128_FUNDAMENTAL
     GTEST_SKIP() << "Requires 128-bit integer support.";
 #else
     // uint128_t spans multiple limbs: exercises the integer-rhs slow path in


### PR DESCRIPTION
This hopefully increases test coverage after hitting a regression.

I think the reason for the regression is that we don't have tests for multi-limb divisors that go through here.

Also, it seems like we've literally never tested something involving multi-limb integers (e.g. `_BitInt(128)`) so we've never noticed that `uabs` doesn't work with that.