### PR TITLE
Add a copy to runtime function

### DIFF
--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -3828,11 +3828,8 @@ BEMAN_BIG_INT_DIAGNOSTIC_POP()
 
 BEMAN_BIG_INT_DIAGNOSTIC_POP()
 
-// Convenience macros that wrap an expression in a stateless lambda for the user
+// A convenience macro rather than calling a stateless lambda
 #define BEMAN_BIG_INT_COPY_TO_RUNTIME(...) \
-    (::beman::big_int::copy_to_runtime<decltype([]() { return (__VA_ARGS__); })>())
-
-#define BEMAN_BIG_INT_COPY_VALUE_TO_RUNTIME(...) \
     (::beman::big_int::copy_to_runtime<decltype([]() { return (__VA_ARGS__); })>())
 
 #endif // BEMAN_BIG_INT_BIG_INT_HPP

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -269,6 +269,16 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
         : m_capacity{0}, m_size_and_sign{1}, m_storage{}, m_alloc{} {
         if constexpr (std::is_floating_point_v<std::remove_cvref_t<T>>) {
             assign_from_float(value);
+        } else if constexpr (detail::is_basic_big_int_v<std::remove_cvref_t<T>>) {
+            const auto count = value.limb_count();
+            grow(count);
+            auto* dst = limb_ptr();
+            std::copy_n(value.limb_ptr(), count, dst);
+            for (size_type i = count; i < limb_count(); ++i) {
+                dst[i] = 0;
+            }
+            unchecked_set_limb_count(count);
+            unchecked_set_sign(value.is_negative());
         } else {
             if constexpr (std::is_signed_v<std::remove_cvref_t<T>>) {
                 unchecked_set_sign(value < std::remove_cvref_t<T>{0});
@@ -897,6 +907,16 @@ constexpr basic_big_int<b, A>::basic_big_int(const T& value, const allocator_typ
     : m_capacity{0}, m_size_and_sign{1}, m_storage{}, m_alloc{a} {
     if constexpr (std::is_floating_point_v<std::remove_cvref_t<T>>) {
         assign_from_float(value);
+    } else if constexpr (detail::is_basic_big_int_v<std::remove_cvref_t<T>>) {
+        const auto count = value.limb_count();
+        grow(count);
+        auto* dst = limb_ptr();
+        std::copy_n(value.limb_ptr(), count, dst);
+        for (size_type i = count; i < limb_count(); ++i) {
+            dst[i] = 0;
+        }
+        unchecked_set_limb_count(count);
+        unchecked_set_sign(value.is_negative());
     } else {
         if constexpr (std::is_signed_v<std::remove_cvref_t<T>>) {
             unchecked_set_sign(value < 0);

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -3028,6 +3028,28 @@ constexpr void basic_big_int<b, A>::push_back_limb(limb_type limb) {
     unchecked_set_limb_count(static_cast<std::uint32_t>(count + 1));
 }
 
+// Snapshot the value produced by `F` into a `basic_big_int<N, A>`,
+// whose inline storage is large enough to hold the value without any heap allocation.
+// Bridges consteval-computed values to runtime
+// The result is heap-free and constexpr-storable.
+// The result preserves the source's allocator type and instance.
+template <auto F>
+[[nodiscard]] consteval auto copy_to_runtime() {
+    constexpr std::size_t bits_per_limb = sizeof(uint_multiprecision_t) * CHAR_BIT;
+
+    constexpr std::size_t target_bits = []() consteval {
+        const auto v = F();
+        const auto w = v.width_mag();
+        return w == 0 ? bits_per_limb : ((w + bits_per_limb - 1) / bits_per_limb) * bits_per_limb;
+    }();
+
+    using source_type = std::remove_cvref_t<decltype(F())>;
+    using result_type = basic_big_int<target_bits, typename source_type::allocator_type>;
+
+    auto src = F();
+    return result_type{src, src.get_allocator()};
+}
+
 // Standard public alias for defaulted type
 using big_int = basic_big_int<64, std::allocator<uint_multiprecision_t>>;
 
@@ -3805,5 +3827,8 @@ BEMAN_BIG_INT_DIAGNOSTIC_POP()
 } // namespace beman::big_int
 
 BEMAN_BIG_INT_DIAGNOSTIC_POP()
+
+// A convenience macro rather than calling a stateless lambda
+#define BEMAN_BIG_INT_COPY_TO_RUNTIME(...) (::beman::big_int::copy_to_runtime<+[]() { return (__VA_ARGS__); }>())
 
 #endif // BEMAN_BIG_INT_BIG_INT_HPP

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -3028,25 +3028,25 @@ constexpr void basic_big_int<b, A>::push_back_limb(limb_type limb) {
     unchecked_set_limb_count(static_cast<std::uint32_t>(count + 1));
 }
 
-// Snapshot the value produced by `F` into a `basic_big_int<N, A>`,
-// whose inline storage is large enough to hold the value without any heap allocation.
-// Bridges consteval-computed values to runtime
-// The result is heap-free and constexpr-storable.
+// Snapshot the value produced by a stateless `Generator` callable into a
+// `basic_big_int<N, A>` whose inline storage is large enough to hold the value
+// without any heap allocation.
+// Bridges consteval-computed values to runtime.
 // The result preserves the source's allocator type and instance.
-template <auto F>
+template <typename Generator>
 [[nodiscard]] consteval auto copy_to_runtime() {
     constexpr std::size_t bits_per_limb = sizeof(uint_multiprecision_t) * CHAR_BIT;
 
     constexpr std::size_t target_bits = []() consteval {
-        const auto v = F();
+        const auto v = Generator{}();
         const auto w = v.width_mag();
         return w == 0 ? bits_per_limb : ((w + bits_per_limb - 1) / bits_per_limb) * bits_per_limb;
     }();
 
-    using source_type = std::remove_cvref_t<decltype(F())>;
+    using source_type = std::remove_cvref_t<decltype(Generator{}())>;
     using result_type = basic_big_int<target_bits, typename source_type::allocator_type>;
 
-    auto src = F();
+    auto src = Generator{}();
     return result_type{src, src.get_allocator()};
 }
 
@@ -3828,7 +3828,11 @@ BEMAN_BIG_INT_DIAGNOSTIC_POP()
 
 BEMAN_BIG_INT_DIAGNOSTIC_POP()
 
-// A convenience macro rather than calling a stateless lambda
-#define BEMAN_BIG_INT_COPY_TO_RUNTIME(...) (::beman::big_int::copy_to_runtime<+[]() { return (__VA_ARGS__); }>())
+// Convenience macros that wrap an expression in a stateless lambda for the user
+#define BEMAN_BIG_INT_COPY_TO_RUNTIME(...) \
+    (::beman::big_int::copy_to_runtime<decltype([]() { return (__VA_ARGS__); })>())
+
+#define BEMAN_BIG_INT_COPY_VALUE_TO_RUNTIME(...) \
+    (::beman::big_int::copy_to_runtime<decltype([]() { return (__VA_ARGS__); })>())
 
 #endif // BEMAN_BIG_INT_BIG_INT_HPP

--- a/tests/beman/big_int/CMakeLists.txt
+++ b/tests/beman/big_int/CMakeLists.txt
@@ -75,7 +75,7 @@ foreach(test_source ${TEST_SOURCES})
         # /WX = -Werror
         target_compile_options(${test_target} PRIVATE /WX /W4)
     endif()
-    gtest_discover_tests(${test_target})
+    gtest_discover_tests(${test_target} DISCOVERY_TIMEOUT 60)
 endforeach()
 
 if(BEMAN_BIG_INT_FUZZ)

--- a/tests/beman/big_int/copy_to_runtime.test.cpp
+++ b/tests/beman/big_int/copy_to_runtime.test.cpp
@@ -36,8 +36,8 @@ consteval bool test_heap_required_value() {
     // allocate on the heap during consteval evaluation.
     // The result must hold all those limbs inline.
     constexpr auto v = beman::big_int::copy_to_runtime<decltype([]() {
-        return 1'000'000'000'000'000'000'000'000'000'000'000'000'000_n
-             * 1'000'000'000'000'000'000'000'000'000'000'000'000'000_n;
+        return 1'000'000'000'000'000'000'000'000'000'000'000'000'000_n *
+               1'000'000'000'000'000'000'000'000'000'000'000'000'000_n;
     })>();
     static_assert(v.capacity() == 0);
     static_assert(decltype(v)::inplace_capacity >= 4);
@@ -66,7 +66,7 @@ static_assert(test_value_macro_with_heap_value());
 
 consteval bool test_allocator_preserved() {
     using custom_big_int = beman::big_int::basic_big_int<32, std::allocator<beman::big_int::uint_multiprecision_t>>;
-    constexpr auto v = beman::big_int::copy_to_runtime<decltype([]() { return custom_big_int{42}; })>();
+    constexpr auto v     = beman::big_int::copy_to_runtime<decltype([]() { return custom_big_int{42}; })>();
     static_assert(std::is_same_v<typename decltype(v)::allocator_type, custom_big_int::allocator_type>);
     return v.representation()[0] == 42U;
 }
@@ -87,31 +87,28 @@ TEST(CopyToRuntime, BridgesHeapValueToRuntime) {
 }
 
 TEST(CopyToRuntime, NegativeRoundTrip) {
-    constexpr auto kVal = beman::big_int::copy_to_runtime<decltype([]() {
-        return beman::big_int::big_int{-1} * (1_n << 200);
-    })>();
+    constexpr auto kVal =
+        beman::big_int::copy_to_runtime<decltype([]() { return beman::big_int::big_int{-1} * (1_n << 200); })>();
     beman::big_int::big_int as_default{kVal};
     EXPECT_LT(as_default, beman::big_int::big_int{0});
     EXPECT_EQ(-as_default, beman::big_int::big_int{1} << 200);
 }
 
 TEST(CopyToRuntime, ZeroIsCanonical) {
-    constexpr auto kZero =
-        beman::big_int::copy_to_runtime<decltype([]() { return beman::big_int::big_int{0}; })>();
+    constexpr auto kZero = beman::big_int::copy_to_runtime<decltype([]() { return beman::big_int::big_int{0}; })>();
     EXPECT_EQ(kZero.width_mag(), 0U);
     beman::big_int::big_int as_default{kZero};
     EXPECT_EQ(as_default, beman::big_int::big_int{0});
 }
 
 TEST(CopyToRuntime, ConstexprCanBeUsedForComparison) {
-    constexpr auto kThreshold = BEMAN_BIG_INT_COPY_TO_RUNTIME(1_n << 100);
-    beman::big_int::big_int input = (beman::big_int::big_int{1} << 99) + beman::big_int::big_int{1};
+    constexpr auto          kThreshold = BEMAN_BIG_INT_COPY_TO_RUNTIME(1_n << 100);
+    beman::big_int::big_int input      = (beman::big_int::big_int{1} << 99) + beman::big_int::big_int{1};
     EXPECT_LT(input, beman::big_int::big_int{kThreshold});
 }
 
 TEST(CopyToRuntime, MacroExpression) {
-    constexpr auto kVal = BEMAN_BIG_INT_COPY_TO_RUNTIME(
-        1'000'000'000'000'000'000'000_n * 1'000'000'000'000'000'000_n);
+    constexpr auto kVal = BEMAN_BIG_INT_COPY_TO_RUNTIME(1'000'000'000'000'000'000'000_n * 1'000'000'000'000'000'000_n);
     beman::big_int::big_int as_default{kVal};
     EXPECT_EQ(as_default, 1'000'000'000'000'000'000'000_n * 1'000'000'000'000'000'000_n);
 }

--- a/tests/beman/big_int/copy_to_runtime.test.cpp
+++ b/tests/beman/big_int/copy_to_runtime.test.cpp
@@ -11,21 +11,21 @@ using namespace beman::big_int::literals;
 // ----- compile-time tests -----
 
 consteval bool test_small_value() {
-    constexpr auto v = beman::big_int::copy_to_runtime<+[]() { return beman::big_int::big_int{42}; }>();
+    constexpr auto v = beman::big_int::copy_to_runtime<decltype([]() { return beman::big_int::big_int{42}; })>();
     static_assert(v.capacity() == 0);
     return v.width_mag() == 6 && v.representation()[0] == 42U;
 }
 static_assert(test_small_value());
 
 consteval bool test_zero_value() {
-    constexpr auto v = beman::big_int::copy_to_runtime<+[]() { return beman::big_int::big_int{0}; }>();
+    constexpr auto v = beman::big_int::copy_to_runtime<decltype([]() { return beman::big_int::big_int{0}; })>();
     static_assert(v.capacity() == 0);
     return v.width_mag() == 0 && v.representation().size() == 1;
 }
 static_assert(test_zero_value());
 
 consteval bool test_negative_value() {
-    constexpr auto v = beman::big_int::copy_to_runtime<+[]() { return beman::big_int::big_int{-42}; }>();
+    constexpr auto v = beman::big_int::copy_to_runtime<decltype([]() { return beman::big_int::big_int{-42}; })>();
     static_assert(v.capacity() == 0);
     return v.width_mag() == 6 && v.representation()[0] == 42U;
 }
@@ -35,10 +35,10 @@ consteval bool test_heap_required_value() {
     // 10^40 * 10^40 = 10^80 needs ~266 bits, so the source big_int must
     // allocate on the heap during consteval evaluation.
     // The result must hold all those limbs inline.
-    constexpr auto v = beman::big_int::copy_to_runtime<+[]() {
+    constexpr auto v = beman::big_int::copy_to_runtime<decltype([]() {
         return 1'000'000'000'000'000'000'000'000'000'000'000'000'000_n
              * 1'000'000'000'000'000'000'000'000'000'000'000'000'000_n;
-    }>();
+    })>();
     static_assert(v.capacity() == 0);
     static_assert(decltype(v)::inplace_capacity >= 4);
     return v.representation().size() >= 4;
@@ -51,9 +51,22 @@ consteval bool test_macro_form() {
 }
 static_assert(test_macro_form());
 
+consteval bool test_value_macro_form() {
+    constexpr auto v = BEMAN_BIG_INT_COPY_VALUE_TO_RUNTIME(beman::big_int::big_int{99});
+    return v.representation()[0] == 99U;
+}
+static_assert(test_value_macro_form());
+
+consteval bool test_value_macro_with_heap_value() {
+    constexpr auto v = BEMAN_BIG_INT_COPY_VALUE_TO_RUNTIME(1_n << 200);
+    static_assert(v.capacity() == 0);
+    return v.representation().size() >= 4;
+}
+static_assert(test_value_macro_with_heap_value());
+
 consteval bool test_allocator_preserved() {
     using custom_big_int = beman::big_int::basic_big_int<32, std::allocator<beman::big_int::uint_multiprecision_t>>;
-    constexpr auto v = beman::big_int::copy_to_runtime<+[]() { return custom_big_int{42}; }>();
+    constexpr auto v = beman::big_int::copy_to_runtime<decltype([]() { return custom_big_int{42}; })>();
     static_assert(std::is_same_v<typename decltype(v)::allocator_type, custom_big_int::allocator_type>);
     return v.representation()[0] == 42U;
 }
@@ -62,9 +75,9 @@ static_assert(test_allocator_preserved());
 // ----- runtime tests -----
 
 TEST(CopyToRuntime, BridgesHeapValueToRuntime) {
-    constexpr auto kVal = beman::big_int::copy_to_runtime<+[]() {
+    constexpr auto kVal = beman::big_int::copy_to_runtime<decltype([]() {
         return 1'000'000'000'000'000'000'000'000'000'000'000'000'000_n;
-    }>();
+    })>();
 
     auto runtime_copy = kVal;
     EXPECT_EQ(runtime_copy.width_mag(), kVal.width_mag());
@@ -74,9 +87,9 @@ TEST(CopyToRuntime, BridgesHeapValueToRuntime) {
 }
 
 TEST(CopyToRuntime, NegativeRoundTrip) {
-    constexpr auto kVal = beman::big_int::copy_to_runtime<+[]() {
+    constexpr auto kVal = beman::big_int::copy_to_runtime<decltype([]() {
         return beman::big_int::big_int{-1} * (1_n << 200);
-    }>();
+    })>();
     beman::big_int::big_int as_default{kVal};
     EXPECT_LT(as_default, beman::big_int::big_int{0});
     EXPECT_EQ(-as_default, beman::big_int::big_int{1} << 200);
@@ -84,7 +97,7 @@ TEST(CopyToRuntime, NegativeRoundTrip) {
 
 TEST(CopyToRuntime, ZeroIsCanonical) {
     constexpr auto kZero =
-        beman::big_int::copy_to_runtime<+[]() { return beman::big_int::big_int{0}; }>();
+        beman::big_int::copy_to_runtime<decltype([]() { return beman::big_int::big_int{0}; })>();
     EXPECT_EQ(kZero.width_mag(), 0U);
     beman::big_int::big_int as_default{kZero};
     EXPECT_EQ(as_default, beman::big_int::big_int{0});
@@ -104,7 +117,7 @@ TEST(CopyToRuntime, MacroExpression) {
 }
 
 TEST(CopyToRuntime, ResultLimbCountMatchesValue) {
-    constexpr auto kVal = beman::big_int::copy_to_runtime<+[]() { return 1_n << 200; }>();
+    constexpr auto kVal = beman::big_int::copy_to_runtime<decltype([]() { return 1_n << 200; })>();
     EXPECT_EQ(kVal.representation().size(), decltype(kVal)::inplace_capacity);
     EXPECT_GE(decltype(kVal)::inplace_capacity, 4U);
 }

--- a/tests/beman/big_int/copy_to_runtime.test.cpp
+++ b/tests/beman/big_int/copy_to_runtime.test.cpp
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: BSL-1.0
+
+#include <beman/big_int/big_int.hpp>
+#include <gtest/gtest.h>
+
+#include "testing.hpp"
+
+using namespace beman::big_int::literals;
+
+// ----- compile-time tests -----
+
+consteval bool test_small_value() {
+    constexpr auto v = beman::big_int::copy_to_runtime<+[]() { return beman::big_int::big_int{42}; }>();
+    static_assert(v.capacity() == 0);
+    return v.width_mag() == 6 && v.representation()[0] == 42U;
+}
+static_assert(test_small_value());
+
+consteval bool test_zero_value() {
+    constexpr auto v = beman::big_int::copy_to_runtime<+[]() { return beman::big_int::big_int{0}; }>();
+    static_assert(v.capacity() == 0);
+    return v.width_mag() == 0 && v.representation().size() == 1;
+}
+static_assert(test_zero_value());
+
+consteval bool test_negative_value() {
+    constexpr auto v = beman::big_int::copy_to_runtime<+[]() { return beman::big_int::big_int{-42}; }>();
+    static_assert(v.capacity() == 0);
+    return v.width_mag() == 6 && v.representation()[0] == 42U;
+}
+static_assert(test_negative_value());
+
+consteval bool test_heap_required_value() {
+    // 10^40 * 10^40 = 10^80 needs ~266 bits, so the source big_int must
+    // allocate on the heap during consteval evaluation.
+    // The result must hold all those limbs inline.
+    constexpr auto v = beman::big_int::copy_to_runtime<+[]() {
+        return 1'000'000'000'000'000'000'000'000'000'000'000'000'000_n
+             * 1'000'000'000'000'000'000'000'000'000'000'000'000'000_n;
+    }>();
+    static_assert(v.capacity() == 0);
+    static_assert(decltype(v)::inplace_capacity >= 4);
+    return v.representation().size() >= 4;
+}
+static_assert(test_heap_required_value());
+
+consteval bool test_macro_form() {
+    constexpr auto v = BEMAN_BIG_INT_COPY_TO_RUNTIME(beman::big_int::big_int{42});
+    return v.representation()[0] == 42U;
+}
+static_assert(test_macro_form());
+
+consteval bool test_allocator_preserved() {
+    using custom_big_int = beman::big_int::basic_big_int<32, std::allocator<beman::big_int::uint_multiprecision_t>>;
+    constexpr auto v = beman::big_int::copy_to_runtime<+[]() { return custom_big_int{42}; }>();
+    static_assert(std::is_same_v<typename decltype(v)::allocator_type, custom_big_int::allocator_type>);
+    return v.representation()[0] == 42U;
+}
+static_assert(test_allocator_preserved());
+
+// ----- runtime tests -----
+
+TEST(CopyToRuntime, BridgesHeapValueToRuntime) {
+    constexpr auto kVal = beman::big_int::copy_to_runtime<+[]() {
+        return 1'000'000'000'000'000'000'000'000'000'000'000'000'000_n;
+    }>();
+
+    auto runtime_copy = kVal;
+    EXPECT_EQ(runtime_copy.width_mag(), kVal.width_mag());
+
+    beman::big_int::big_int as_default{kVal};
+    EXPECT_EQ(as_default, 1'000'000'000'000'000'000'000'000'000'000'000'000'000_n);
+}
+
+TEST(CopyToRuntime, NegativeRoundTrip) {
+    constexpr auto kVal = beman::big_int::copy_to_runtime<+[]() {
+        return beman::big_int::big_int{-1} * (1_n << 200);
+    }>();
+    beman::big_int::big_int as_default{kVal};
+    EXPECT_LT(as_default, beman::big_int::big_int{0});
+    EXPECT_EQ(-as_default, beman::big_int::big_int{1} << 200);
+}
+
+TEST(CopyToRuntime, ZeroIsCanonical) {
+    constexpr auto kZero =
+        beman::big_int::copy_to_runtime<+[]() { return beman::big_int::big_int{0}; }>();
+    EXPECT_EQ(kZero.width_mag(), 0U);
+    beman::big_int::big_int as_default{kZero};
+    EXPECT_EQ(as_default, beman::big_int::big_int{0});
+}
+
+TEST(CopyToRuntime, ConstexprCanBeUsedForComparison) {
+    constexpr auto kThreshold = BEMAN_BIG_INT_COPY_TO_RUNTIME(1_n << 100);
+    beman::big_int::big_int input = (beman::big_int::big_int{1} << 99) + beman::big_int::big_int{1};
+    EXPECT_LT(input, beman::big_int::big_int{kThreshold});
+}
+
+TEST(CopyToRuntime, MacroExpression) {
+    constexpr auto kVal = BEMAN_BIG_INT_COPY_TO_RUNTIME(
+        1'000'000'000'000'000'000'000_n * 1'000'000'000'000'000'000_n);
+    beman::big_int::big_int as_default{kVal};
+    EXPECT_EQ(as_default, 1'000'000'000'000'000'000'000_n * 1'000'000'000'000'000'000_n);
+}
+
+TEST(CopyToRuntime, ResultLimbCountMatchesValue) {
+    constexpr auto kVal = beman::big_int::copy_to_runtime<+[]() { return 1_n << 200; }>();
+    EXPECT_EQ(kVal.representation().size(), decltype(kVal)::inplace_capacity);
+    EXPECT_GE(decltype(kVal)::inplace_capacity, 4U);
+}

--- a/tests/beman/big_int/copy_to_runtime.test.cpp
+++ b/tests/beman/big_int/copy_to_runtime.test.cpp
@@ -51,19 +51,6 @@ consteval bool test_macro_form() {
 }
 static_assert(test_macro_form());
 
-consteval bool test_value_macro_form() {
-    constexpr auto v = BEMAN_BIG_INT_COPY_VALUE_TO_RUNTIME(beman::big_int::big_int{99});
-    return v.representation()[0] == 99U;
-}
-static_assert(test_value_macro_form());
-
-consteval bool test_value_macro_with_heap_value() {
-    constexpr auto v = BEMAN_BIG_INT_COPY_VALUE_TO_RUNTIME(1_n << 200);
-    static_assert(v.capacity() == 0);
-    return v.representation().size() >= 4;
-}
-static_assert(test_value_macro_with_heap_value());
-
 consteval bool test_allocator_preserved() {
     using custom_big_int = beman::big_int::basic_big_int<32, std::allocator<beman::big_int::uint_multiprecision_t>>;
     constexpr auto v     = beman::big_int::copy_to_runtime<decltype([]() { return custom_big_int{42}; })>();


### PR DESCRIPTION
The `copy_to_runtime` function takes a stateless lambda generator, determines the number of bits that are required to hold the entire value inline, and then creates that statically allocated return value. This allows us to bridge the gap between constant evaluation and runtime. The macro is a much cleaner way to use this functionality, but I recognize that macro functions aren't the most popular thing available.

Closes: #17 