### PR TITLE
Add Toom-cook 3 multiplication

### DIFF
--- a/include/beman/big_int/detail/div_impl.hpp
+++ b/include/beman/big_int/detail/div_impl.hpp
@@ -25,27 +25,6 @@ enum class division_op : unsigned char {
 };
 
 // ---------------------------------------------------------------------------
-// Three-way compare of two little-endian unsigned spans.
-// Operands need not be trimmed: trailing zero limbs on either side are
-// treated as insignificant.
-// ---------------------------------------------------------------------------
-[[nodiscard]] constexpr std::strong_ordering
-compare_unsigned_spans(const std::span<const uint_multiprecision_t> a,
-                       const std::span<const uint_multiprecision_t> b) noexcept {
-    const std::size_t na = a.size();
-    const std::size_t nb = b.size();
-    const std::size_t n  = std::max(na, nb);
-    for (std::size_t i = n; i-- > 0;) {
-        const auto ai = i < na ? a[i] : uint_multiprecision_t{0};
-        const auto bi = i < nb ? b[i] : uint_multiprecision_t{0};
-        if (ai != bi) {
-            return ai < bi ? std::strong_ordering::less : std::strong_ordering::greater;
-        }
-    }
-    return std::strong_ordering::equal;
-}
-
-// ---------------------------------------------------------------------------
 // In-place +1 on a little-endian unsigned span. Returns true on carry out.
 // ---------------------------------------------------------------------------
 [[nodiscard]] constexpr bool increment_span(const std::span<uint_multiprecision_t> s) noexcept {
@@ -68,42 +47,6 @@ compare_unsigned_spans(const std::span<const uint_multiprecision_t> a,
         }
     }
     return true;
-}
-
-// ---------------------------------------------------------------------------
-// Single-limb short division.
-// `quotient[i]` := floor(([remainder, dividend[i]] as two limbs) / divisor)
-// scanning from the top limb down.
-// Returns the scalar remainder.
-// `quotient` and `dividend` may be the same range (i.e. alias each other),
-// but `quotient` may not be a strict subrange of `dividend`.
-//
-// Preconditions:
-//   - divisor != 0
-//   - quotient.size() >= dividend.size()
-//   - dividend.size() >= 1
-//   - quotient may alias dividend (we read dividend[i] before writing
-//     quotient[i]; subsequent iterations touch strictly lower indices).
-// ---------------------------------------------------------------------------
-[[nodiscard]] constexpr uint_multiprecision_t
-divide_unsigned_short(const std::span<uint_multiprecision_t>       quotient,
-                      const std::span<const uint_multiprecision_t> dividend,
-                      const uint_multiprecision_t                  divisor) noexcept {
-    BEMAN_BIG_INT_DEBUG_ASSERT(divisor != 0);
-    BEMAN_BIG_INT_DEBUG_ASSERT(quotient.size() >= dividend.size());
-    BEMAN_BIG_INT_DEBUG_ASSERT(!dividend.empty());
-
-    uint_multiprecision_t remainder = 0;
-    for (std::size_t i = dividend.size(); i-- > 0;) {
-        // narrowing_div requires x.high_bits < y; the previous remainder was
-        // taken mod divisor, so this invariant holds (and 0 < divisor on the
-        // first iteration).
-        const wide<uint_multiprecision_t> num{.low_bits = dividend[i], .high_bits = remainder};
-        const auto [q, r] = narrowing_div(num, divisor);
-        quotient[i]       = q;
-        remainder         = r;
-    }
-    return remainder;
 }
 
 // ---------------------------------------------------------------------------

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -489,16 +489,12 @@ constexpr void multiply_toom_cook_3(const std::span<uint_multiprecision_t> resul
 
     // Split each operand into three pieces. Empty pieces represent zero.
     const auto a0 = a.first(std::min(k, a.size()));
-    const auto a1 = a.size() > k ? a.subspan(k, std::min(k, a.size() - k))
-                                 : std::span<const uint_multiprecision_t>{};
-    const auto a2 = a.size() > 2 * k ? a.subspan(2 * k)
-                                     : std::span<const uint_multiprecision_t>{};
+    const auto a1 = a.size() > k ? a.subspan(k, std::min(k, a.size() - k)) : std::span<const uint_multiprecision_t>{};
+    const auto a2 = a.size() > 2 * k ? a.subspan(2 * k) : std::span<const uint_multiprecision_t>{};
 
     const auto b0 = b.first(std::min(k, b.size()));
-    const auto b1 = b.size() > k ? b.subspan(k, std::min(k, b.size() - k))
-                                 : std::span<const uint_multiprecision_t>{};
-    const auto b2 = b.size() > 2 * k ? b.subspan(2 * k)
-                                     : std::span<const uint_multiprecision_t>{};
+    const auto b1 = b.size() > k ? b.subspan(k, std::min(k, b.size() - k)) : std::span<const uint_multiprecision_t>{};
+    const auto b2 = b.size() > 2 * k ? b.subspan(2 * k) : std::span<const uint_multiprecision_t>{};
 
     // Carve scratch:
     //   tmpa, tmpb: k+2 limbs each
@@ -526,8 +522,8 @@ constexpr void multiply_toom_cook_3(const std::span<uint_multiprecision_t> resul
 
     // ---- Helper: in-place tmp[0..size) += addend; returns new size (may grow by 1) ----
     constexpr auto add_into_tmp = [](const std::span<uint_multiprecision_t>       tmp,
-                                 const std::size_t                            size,
-                                 const std::span<const uint_multiprecision_t> addend) -> std::size_t {
+                                     const std::size_t                            size,
+                                     const std::span<const uint_multiprecision_t> addend) -> std::size_t {
         if (addend.empty()) {
             return size;
         }
@@ -543,8 +539,7 @@ constexpr void multiply_toom_cook_3(const std::span<uint_multiprecision_t> resul
     };
 
     // ---- Helper: in-place tmp[0..size) <<= 1; returns new size (may grow by 1) ----
-    constexpr auto shift_left_one = [](const std::span<uint_multiprecision_t> tmp,
-                                   std::size_t                            size) -> std::size_t {
+    constexpr auto shift_left_one = [](const std::span<uint_multiprecision_t> tmp, std::size_t size) -> std::size_t {
         if (size == 0) {
             return 0;
         }
@@ -590,25 +585,27 @@ constexpr void multiply_toom_cook_3(const std::span<uint_multiprecision_t> resul
 
     // v1 = tmpa * tmpb
     std::ranges::fill(v1, uint_multiprecision_t{0});
-    multiply_toom_cook_3(v1, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
-                         std::span<const uint_multiprecision_t>{tmpb.data(), tmpb_size}, scratch);
+    multiply_toom_cook_3(v1,
+                         std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                         std::span<const uint_multiprecision_t>{tmpb.data(), tmpb_size},
+                         scratch);
 
     // ---- Evaluate at x = -1: tmpa = (a0 + a2) - a1 (signed); tmpb similarly ----
     std::ranges::copy(a0, tmpa.begin());
-    tmpa_size               = a0.size();
-    tmpa_size               = add_into_tmp(tmpa, tmpa_size, a2);
-    const auto sub_a        = subtract_unsigned_spans_signed(
-        tmpa, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size}, a1);
-    tmpa_size               = sub_a.size;
-    const bool sign_a       = sub_a.negative;
+    tmpa_size = a0.size();
+    tmpa_size = add_into_tmp(tmpa, tmpa_size, a2);
+    const auto sub_a =
+        subtract_unsigned_spans_signed(tmpa, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size}, a1);
+    tmpa_size         = sub_a.size;
+    const bool sign_a = sub_a.negative;
 
     std::ranges::copy(b0, tmpb.begin());
-    tmpb_size               = b0.size();
-    tmpb_size               = add_into_tmp(tmpb, tmpb_size, b2);
-    const auto sub_b        = subtract_unsigned_spans_signed(
-        tmpb, std::span<const uint_multiprecision_t>{tmpb.data(), tmpb_size}, b1);
-    tmpb_size               = sub_b.size;
-    const bool sign_b       = sub_b.negative;
+    tmpb_size = b0.size();
+    tmpb_size = add_into_tmp(tmpb, tmpb_size, b2);
+    const auto sub_b =
+        subtract_unsigned_spans_signed(tmpb, std::span<const uint_multiprecision_t>{tmpb.data(), tmpb_size}, b1);
+    tmpb_size         = sub_b.size;
+    const bool sign_b = sub_b.negative;
 
     // Sign of vm1 = sign of (p(-1)*q(-1)). Magnitude = |p(-1)| * |q(-1)|.
     const bool sign_vm1 = sign_a ^ sign_b;
@@ -641,8 +638,10 @@ constexpr void multiply_toom_cook_3(const std::span<uint_multiprecision_t> resul
 
     // v2 = p(2) * q(2)
     std::ranges::fill(v2, uint_multiprecision_t{0});
-    multiply_toom_cook_3(v2, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
-                         std::span<const uint_multiprecision_t>{tmpb.data(), tmpb_size}, scratch);
+    multiply_toom_cook_3(v2,
+                         std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                         std::span<const uint_multiprecision_t>{tmpb.data(), tmpb_size},
+                         scratch);
 
     // ---- Bodrato interpolation (in-place; full 2k+2 buffers throughout) ----
     // After this sequence: v0=c0 (in result), vm1=c1, v1=c2, v2=c3, vinf=c4 (in result).

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -189,7 +189,7 @@ constexpr signed_sub_result subtract_unsigned_spans_signed(const std::span<uint_
     const auto        a_view = a.first(a_trim);
     const auto        b_view = b.first(b_trim);
 
-    if (compare_unsigned_spans(a_view, b_view) >= 0) {
+    if (compare_unsigned_spans(a_view, b_view) != std::strong_ordering::less) {
         BEMAN_BIG_INT_DEBUG_ASSERT(result.size() >= a_trim);
         if (a_trim == 0) {
             return {0, false};

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -174,10 +174,15 @@ constexpr std::size_t subtract_unsigned_spans(const std::span<uint_multiprecisio
 // whether the result is negative (i.e. b > a, so result holds b - a).
 // `result` may alias `a` or `b`. Used by Toom-Cook 3 to evaluate at x = -1.
 // ---------------------------------------------------------------------------
+BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
+BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Wpadded")
+
 struct signed_sub_result {
     std::size_t size;
     bool        negative;
 };
+
+BEMAN_BIG_INT_DIAGNOSTIC_POP()
 
 constexpr signed_sub_result subtract_unsigned_spans_signed(const std::span<uint_multiprecision_t>       result,
                                                            const std::span<const uint_multiprecision_t> a,

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -737,10 +737,19 @@ constexpr std::size_t multiply_dispatch(const std::span<uint_multiprecision_t> r
         return multiply_single_limb(result, a, b[0]);
     }
 
-    // Use Karatsuba when both operands are large enough
-    // Also avoid using this function at compile time, because we can end up with high recursion depth
-    // Unlikely to matter, but long multiplication works just fine in this case
+    // Use Toom-Cook 3 above its cutoff, Karatsuba above its cutoff, and schoolbook below.
+    // Avoid these at compile time because the recursion depth could blow up consteval limits;
+    // long multiplication works just fine in that case.
     if BEMAN_BIG_INT_IS_NOT_CONSTEVAL {
+        if (a.size() >= toom_cook_3_cutoff && b.size() >= toom_cook_3_cutoff) {
+            const std::size_t s            = std::max(a.size(), b.size());
+            const std::size_t storage_size = toom_cook_3_storage_size(s);
+            const std::size_t result_total = a.size() + b.size();
+
+            scratch_allocator<Allocator> scratch(storage_size, alloc);
+            multiply_toom_cook_3(result.first(result_total), a, b, scratch);
+            return trimmed_size(std::span<const uint_multiprecision_t>{result.data(), result_total});
+        }
         if (a.size() >= karatsuba_cutoff && b.size() >= karatsuba_cutoff) {
             const std::size_t s            = std::max(a.size(), b.size());
             const std::size_t storage_size = karatsuba_storage_size(s);

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -179,10 +179,9 @@ struct signed_sub_result {
     bool        negative;
 };
 
-constexpr signed_sub_result
-subtract_unsigned_spans_signed(const std::span<uint_multiprecision_t>       result,
-                               const std::span<const uint_multiprecision_t> a,
-                               const std::span<const uint_multiprecision_t> b) noexcept {
+constexpr signed_sub_result subtract_unsigned_spans_signed(const std::span<uint_multiprecision_t>       result,
+                                                           const std::span<const uint_multiprecision_t> a,
+                                                           const std::span<const uint_multiprecision_t> b) noexcept {
     // Trim before comparing so the size relationship matches the value relationship,
     // satisfying subtract_unsigned_spans's a.size() >= b.size() invariant.
     const std::size_t a_trim = a.empty() ? 0 : trimmed_size(a);
@@ -485,13 +484,11 @@ constexpr void multiply_toom_cook_3(const std::span<uint_multiprecision_t> resul
 
     // Split each operand into three pieces. Empty pieces represent zero.
     const auto a0 = a.first(std::min(k, a.size()));
-    const auto a1 = a.size() > k     ? a.subspan(k, std::min(k, a.size() - k))
-                                     : std::span<const uint_multiprecision_t>{};
+    const auto a1 = a.size() > k ? a.subspan(k, std::min(k, a.size() - k)) : std::span<const uint_multiprecision_t>{};
     const auto a2 = a.size() > 2 * k ? a.subspan(2 * k) : std::span<const uint_multiprecision_t>{};
 
     const auto b0 = b.first(std::min(k, b.size()));
-    const auto b1 = b.size() > k     ? b.subspan(k, std::min(k, b.size() - k))
-                                     : std::span<const uint_multiprecision_t>{};
+    const auto b1 = b.size() > k ? b.subspan(k, std::min(k, b.size() - k)) : std::span<const uint_multiprecision_t>{};
     const auto b2 = b.size() > 2 * k ? b.subspan(2 * k) : std::span<const uint_multiprecision_t>{};
 
     // Carve scratch:
@@ -527,8 +524,8 @@ constexpr void multiply_toom_cook_3(const std::span<uint_multiprecision_t> resul
         }
         const std::size_t new_size = std::max(size, addend.size());
         BEMAN_BIG_INT_DEBUG_ASSERT(tmp.size() > new_size);
-        const bool carry = add_unsigned_spans(
-            tmp.first(new_size), std::span<const uint_multiprecision_t>{tmp.data(), size}, addend);
+        const bool carry =
+            add_unsigned_spans(tmp.first(new_size), std::span<const uint_multiprecision_t>{tmp.data(), size}, addend);
         if (carry) {
             tmp[new_size] = 1;
             return new_size + 1;
@@ -593,16 +590,18 @@ constexpr void multiply_toom_cook_3(const std::span<uint_multiprecision_t> resul
     if (tmpa_size == 0 || tmpb_size == 0) {
         // One of the evaluations is zero, so vm1 = 0.
     } else {
-        multiply_toom_cook_3(vm1, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
-                             std::span<const uint_multiprecision_t>{tmpb.data(), tmpb_size}, scratch);
+        multiply_toom_cook_3(vm1,
+                             std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                             std::span<const uint_multiprecision_t>{tmpb.data(), tmpb_size},
+                             scratch);
     }
 
     // ---- Evaluate at x = 2: tmpa = 4*a2 + 2*a1 + a0 (Horner: ((a2*2)+a1)*2+a0); tmpb similarly ----
     std::ranges::copy(a2, tmpa.begin());
     tmpa_size = a2.size();
-    tmpa_size = double_in_place(tmpa, tmpa_size); // 2*a2
+    tmpa_size = double_in_place(tmpa, tmpa_size);  // 2*a2
     tmpa_size = add_into_tmp(tmpa, tmpa_size, a1); // 2*a2 + a1
-    tmpa_size = double_in_place(tmpa, tmpa_size); // 4*a2 + 2*a1
+    tmpa_size = double_in_place(tmpa, tmpa_size);  // 4*a2 + 2*a1
     tmpa_size = add_into_tmp(tmpa, tmpa_size, a0); // 4*a2 + 2*a1 + a0
 
     std::ranges::copy(b2, tmpb.begin());
@@ -682,8 +681,7 @@ constexpr void multiply_toom_cook_3(const std::span<uint_multiprecision_t> resul
     // c0 already at result[0..2k); c4 already at result[4k..). Add the three middle
     // coefficients with carry chains spanning to result.size() so carries can
     // propagate into the c4 region.
-    const auto add_shifted = [&](const std::size_t                            shift,
-                                 const std::span<const uint_multiprecision_t> src) {
+    const auto add_shifted = [&](const std::size_t shift, const std::span<const uint_multiprecision_t> src) {
         const auto dest  = result.subspan(shift);
         bool       carry = false;
         for (std::size_t i = 0; i < dest.size(); ++i) {

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -489,12 +489,16 @@ constexpr void multiply_toom_cook_3(const std::span<uint_multiprecision_t> resul
 
     // Split each operand into three pieces. Empty pieces represent zero.
     const auto a0 = a.first(std::min(k, a.size()));
-    const auto a1 = a.size() > k ? a.subspan(k, std::min(k, a.size() - k)) : std::span<const uint_multiprecision_t>{};
-    const auto a2 = a.size() > 2 * k ? a.subspan(2 * k) : std::span<const uint_multiprecision_t>{};
+    const auto a1 = a.size() > k ? a.subspan(k, std::min(k, a.size() - k))
+                                 : std::span<const uint_multiprecision_t>{};
+    const auto a2 = a.size() > 2 * k ? a.subspan(2 * k)
+                                     : std::span<const uint_multiprecision_t>{};
 
     const auto b0 = b.first(std::min(k, b.size()));
-    const auto b1 = b.size() > k ? b.subspan(k, std::min(k, b.size() - k)) : std::span<const uint_multiprecision_t>{};
-    const auto b2 = b.size() > 2 * k ? b.subspan(2 * k) : std::span<const uint_multiprecision_t>{};
+    const auto b1 = b.size() > k ? b.subspan(k, std::min(k, b.size() - k))
+                                 : std::span<const uint_multiprecision_t>{};
+    const auto b2 = b.size() > 2 * k ? b.subspan(2 * k)
+                                     : std::span<const uint_multiprecision_t>{};
 
     // Carve scratch:
     //   tmpa, tmpb: k+2 limbs each
@@ -521,7 +525,7 @@ constexpr void multiply_toom_cook_3(const std::span<uint_multiprecision_t> resul
     }
 
     // ---- Helper: in-place tmp[0..size) += addend; returns new size (may grow by 1) ----
-    const auto add_into_tmp = [](const std::span<uint_multiprecision_t>       tmp,
+    constexpr auto add_into_tmp = [](const std::span<uint_multiprecision_t>       tmp,
                                  const std::size_t                            size,
                                  const std::span<const uint_multiprecision_t> addend) -> std::size_t {
         if (addend.empty()) {
@@ -538,20 +542,39 @@ constexpr void multiply_toom_cook_3(const std::span<uint_multiprecision_t> resul
         return new_size;
     };
 
-    // ---- Helper: in-place tmp[0..size) *= 2; returns new size (may grow by 1) ----
-    const auto double_in_place = [](const std::span<uint_multiprecision_t> tmp,
-                                    const std::size_t                      size) -> std::size_t {
+    // ---- Helper: in-place tmp[0..size) <<= 1; returns new size (may grow by 1) ----
+    constexpr auto shift_left_one = [](const std::span<uint_multiprecision_t> tmp,
+                                   std::size_t                            size) -> std::size_t {
         if (size == 0) {
             return 0;
         }
         BEMAN_BIG_INT_DEBUG_ASSERT(tmp.size() > size);
-        const auto view  = std::span<const uint_multiprecision_t>{tmp.data(), size};
-        const bool carry = add_unsigned_spans(tmp.first(size), view, view);
-        if (carry) {
-            tmp[size] = 1;
-            return size + 1;
+        constexpr std::size_t limb_bits = width_v<uint_multiprecision_t>;
+        uint_multiprecision_t prev      = 0;
+        for (std::size_t i = 0; i < size; ++i) {
+            const auto limb = tmp[i];
+            tmp[i]          = funnel_shl(wide<uint_multiprecision_t>{.low_bits = prev, .high_bits = limb}, 1u);
+            prev            = limb;
+        }
+        if (const auto carry = prev >> (limb_bits - 1)) {
+            tmp[size++] = carry;
         }
         return size;
+    };
+
+    // ---- Helper: in-place tmp >>= 1; returns the dropped low bit (caller asserts == 0 for exact div) ----
+    constexpr auto shift_right_one = [](const std::span<uint_multiprecision_t> tmp) -> uint_multiprecision_t {
+        if (tmp.empty()) {
+            return 0;
+        }
+        const uint_multiprecision_t rem  = tmp[0] & uint_multiprecision_t{1};
+        uint_multiprecision_t       high = 0;
+        for (std::size_t i = tmp.size(); i-- > 0;) {
+            const auto limb = tmp[i];
+            tmp[i]          = funnel_shr(wide<uint_multiprecision_t>{.low_bits = limb, .high_bits = high}, 1u);
+            high            = limb;
+        }
+        return rem;
     };
 
     // ---- Evaluate at x = 1: tmpa = a0 + a1 + a2; tmpb = b0 + b1 + b2 ----
@@ -601,19 +624,19 @@ constexpr void multiply_toom_cook_3(const std::span<uint_multiprecision_t> resul
                              scratch);
     }
 
-    // ---- Evaluate at x = 2: tmpa = 4*a2 + 2*a1 + a0 (Horner: ((a2*2)+a1)*2+a0); tmpb similarly ----
+    // ---- Evaluate at x = 2: tmpa = 4*a2 + 2*a1 + a0 (Horner: ((a2<<1)+a1)<<1+a0); tmpb similarly ----
     std::ranges::copy(a2, tmpa.begin());
     tmpa_size = a2.size();
-    tmpa_size = double_in_place(tmpa, tmpa_size);  // 2*a2
+    tmpa_size = shift_left_one(tmpa, tmpa_size);   // 2*a2
     tmpa_size = add_into_tmp(tmpa, tmpa_size, a1); // 2*a2 + a1
-    tmpa_size = double_in_place(tmpa, tmpa_size);  // 4*a2 + 2*a1
+    tmpa_size = shift_left_one(tmpa, tmpa_size);   // 4*a2 + 2*a1
     tmpa_size = add_into_tmp(tmpa, tmpa_size, a0); // 4*a2 + 2*a1 + a0
 
     std::ranges::copy(b2, tmpb.begin());
     tmpb_size = b2.size();
-    tmpb_size = double_in_place(tmpb, tmpb_size);
+    tmpb_size = shift_left_one(tmpb, tmpb_size);
     tmpb_size = add_into_tmp(tmpb, tmpb_size, b1);
-    tmpb_size = double_in_place(tmpb, tmpb_size);
+    tmpb_size = shift_left_one(tmpb, tmpb_size);
     tmpb_size = add_into_tmp(tmpb, tmpb_size, b0);
 
     // v2 = p(2) * q(2)
@@ -657,7 +680,7 @@ constexpr void multiply_toom_cook_3(const std::span<uint_multiprecision_t> resul
         subtract_unsigned_spans(vm1, v1_view, vm1_view);
     }
     {
-        [[maybe_unused]] const auto rem = divide_unsigned_short(vm1, vm1_view, uint_multiprecision_t{2});
+        [[maybe_unused]] const auto rem = shift_right_one(vm1);
         BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
     }
 
@@ -667,7 +690,7 @@ constexpr void multiply_toom_cook_3(const std::span<uint_multiprecision_t> resul
     // Step 4: v2 <- (v2 - v1) / 2.
     subtract_unsigned_spans(v2, v2_view, v1_view);
     {
-        [[maybe_unused]] const auto rem = divide_unsigned_short(v2, v2_view, uint_multiprecision_t{2});
+        [[maybe_unused]] const auto rem = shift_right_one(v2);
         BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
     }
 

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -432,6 +432,277 @@ constexpr void multiply_karatsuba(const std::span<uint_multiprecision_t> result,
     scratch.deallocate(total_scratch);
 }
 
+// Minimum number of limbs for Toom-Cook 3 to be worthwhile
+// TODO(mborland) : We need to test where this should actually be
+inline constexpr std::size_t toom_cook_3_cutoff = 120;
+
+// Heuristic estimate of scratch space needed for Toom-Cook 3 multiplication.
+// Includes space for karatsuba fallback plan
+constexpr std::size_t toom_cook_3_storage_size(const std::size_t s) noexcept { return 8 * s; }
+
+// ---------------------------------------------------------------------------
+// Recursive Toom-Cook 3-Way multiplication (Bodrato variant).
+// Reference: Knuth TAOCP section 4.3.3
+// Reference: Bodrato, "Towards Optimal Toom-Cook Multiplication" (2006)
+//
+// Splits each operand into three pieces of size k = ceil(max(an,bn)/3):
+//   a = a2*B^(2k) + a1*B^k + a0,   b = b2*B^(2k) + b1*B^k + b0  (B = 2^limb_bits)
+//
+// Evaluates the product polynomial r(x) = p(x)*q(x) at five points
+// {0, 1, -1, 2, infinity}, then interpolates the five coefficients c0-c4 of
+// r(x) via Bodrato's seven-step in-place sequence (one /3, two /2).
+// Result = c0 + c1*B^k + c2*B^(2k) + c3*B^(3k) + c4*B^(4k).
+//
+// `result` must be pre-zeroed and have space for a.size() + b.size() limbs.
+// `result` must NOT alias `a` or `b`.
+// `scratch` provides pre-allocated workspace for temporaries.
+// ---------------------------------------------------------------------------
+template <class Allocator>
+constexpr void multiply_toom_cook_3(const std::span<uint_multiprecision_t> result,
+                                    std::span<const uint_multiprecision_t> a,
+                                    std::span<const uint_multiprecision_t> b,
+                                    scratch_allocator<Allocator>&          scratch) noexcept {
+    BEMAN_BIG_INT_DEBUG_ASSERT(!a.empty());
+    BEMAN_BIG_INT_DEBUG_ASSERT(!b.empty());
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.size() >= trimmed_size(a) + trimmed_size(b));
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != a.data());
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != b.data());
+
+    a = a.first(trimmed_size(a));
+    b = b.first(trimmed_size(b));
+
+    // Partition at k = ceil(max(an, bn) / 3).
+    const std::size_t min_size = std::min(a.size(), b.size());
+    const std::size_t k        = (std::max(a.size(), b.size()) + 2) / 3;
+
+    // Fall through to Karatsuba (and on through to schoolbook) when the smaller
+    // operand is below the performance cutoff or below the algorithm's 2*k
+    // invariant (Toom-Cook 3 needs both a2 and b2 non-empty).
+    if (min_size < toom_cook_3_cutoff || min_size <= 2 * k) {
+        multiply_karatsuba(result, a, b, scratch);
+        return;
+    }
+
+    // Split each operand into three pieces. Empty pieces represent zero.
+    const auto a0 = a.first(std::min(k, a.size()));
+    const auto a1 = a.size() > k     ? a.subspan(k, std::min(k, a.size() - k))
+                                     : std::span<const uint_multiprecision_t>{};
+    const auto a2 = a.size() > 2 * k ? a.subspan(2 * k) : std::span<const uint_multiprecision_t>{};
+
+    const auto b0 = b.first(std::min(k, b.size()));
+    const auto b1 = b.size() > k     ? b.subspan(k, std::min(k, b.size() - k))
+                                     : std::span<const uint_multiprecision_t>{};
+    const auto b2 = b.size() > 2 * k ? b.subspan(2 * k) : std::span<const uint_multiprecision_t>{};
+
+    // Carve scratch:
+    //   tmpa, tmpb: k+2 limbs each
+    //   v1, vm1, v2: 2k+2 limbs each, hold three product values that survive through interpolation
+    //   v0 = a0*b0 and vinf = a2*b2 live directly in result.
+    const std::size_t tmp_cap       = k + 2;
+    const std::size_t prod_cap      = 2 * k + 2;
+    const std::size_t total_scratch = 2 * tmp_cap + 3 * prod_cap;
+
+    auto block = scratch.allocate(total_scratch);
+    auto tmpa  = block.first(tmp_cap);
+    auto tmpb  = block.subspan(tmp_cap, tmp_cap);
+    auto v1    = block.subspan(2 * tmp_cap, prod_cap);
+    auto vm1   = block.subspan(2 * tmp_cap + prod_cap, prod_cap);
+    auto v2    = block.subspan(2 * tmp_cap + 2 * prod_cap, prod_cap);
+
+    // ---- v0 = a0*b0, written into result[0..2k) ----
+    // result is pre-zeroed by the caller convention, so result.first(2k) is too.
+    multiply_toom_cook_3(result.first(a0.size() + b0.size()), a0, b0, scratch);
+
+    // ---- vinf = a2*b2, written into result[4k..) ----
+    if (!a2.empty() && !b2.empty()) {
+        multiply_toom_cook_3(result.subspan(4 * k, a2.size() + b2.size()), a2, b2, scratch);
+    }
+
+    // ---- Helper: in-place tmp[0..size) += addend; returns new size (may grow by 1) ----
+    const auto add_into_tmp = [](const std::span<uint_multiprecision_t>       tmp,
+                                 const std::size_t                            size,
+                                 const std::span<const uint_multiprecision_t> addend) -> std::size_t {
+        if (addend.empty()) {
+            return size;
+        }
+        const std::size_t new_size = std::max(size, addend.size());
+        BEMAN_BIG_INT_DEBUG_ASSERT(tmp.size() > new_size);
+        const bool carry = add_unsigned_spans(
+            tmp.first(new_size), std::span<const uint_multiprecision_t>{tmp.data(), size}, addend);
+        if (carry) {
+            tmp[new_size] = 1;
+            return new_size + 1;
+        }
+        return new_size;
+    };
+
+    // ---- Helper: in-place tmp[0..size) *= 2; returns new size (may grow by 1) ----
+    const auto double_in_place = [](const std::span<uint_multiprecision_t> tmp,
+                                    const std::size_t                      size) -> std::size_t {
+        if (size == 0) {
+            return 0;
+        }
+        BEMAN_BIG_INT_DEBUG_ASSERT(tmp.size() > size);
+        const auto view  = std::span<const uint_multiprecision_t>{tmp.data(), size};
+        const bool carry = add_unsigned_spans(tmp.first(size), view, view);
+        if (carry) {
+            tmp[size] = 1;
+            return size + 1;
+        }
+        return size;
+    };
+
+    // ---- Evaluate at x = 1: tmpa = a0 + a1 + a2; tmpb = b0 + b1 + b2 ----
+    std::ranges::copy(a0, tmpa.begin());
+    std::size_t tmpa_size = a0.size();
+    tmpa_size             = add_into_tmp(tmpa, tmpa_size, a1);
+    tmpa_size             = add_into_tmp(tmpa, tmpa_size, a2);
+
+    std::ranges::copy(b0, tmpb.begin());
+    std::size_t tmpb_size = b0.size();
+    tmpb_size             = add_into_tmp(tmpb, tmpb_size, b1);
+    tmpb_size             = add_into_tmp(tmpb, tmpb_size, b2);
+
+    // v1 = tmpa * tmpb
+    std::ranges::fill(v1, uint_multiprecision_t{0});
+    multiply_toom_cook_3(v1, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                         std::span<const uint_multiprecision_t>{tmpb.data(), tmpb_size}, scratch);
+
+    // ---- Evaluate at x = -1: tmpa = (a0 + a2) - a1 (signed); tmpb similarly ----
+    std::ranges::copy(a0, tmpa.begin());
+    tmpa_size               = a0.size();
+    tmpa_size               = add_into_tmp(tmpa, tmpa_size, a2);
+    const auto sub_a        = subtract_unsigned_spans_signed(
+        tmpa, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size}, a1);
+    tmpa_size               = sub_a.size;
+    const bool sign_a       = sub_a.negative;
+
+    std::ranges::copy(b0, tmpb.begin());
+    tmpb_size               = b0.size();
+    tmpb_size               = add_into_tmp(tmpb, tmpb_size, b2);
+    const auto sub_b        = subtract_unsigned_spans_signed(
+        tmpb, std::span<const uint_multiprecision_t>{tmpb.data(), tmpb_size}, b1);
+    tmpb_size               = sub_b.size;
+    const bool sign_b       = sub_b.negative;
+
+    // Sign of vm1 = sign of (p(-1)*q(-1)). Magnitude = |p(-1)| * |q(-1)|.
+    const bool sign_vm1 = sign_a ^ sign_b;
+
+    // vm1 = |p(-1)| * |q(-1)|
+    std::ranges::fill(vm1, uint_multiprecision_t{0});
+    if (tmpa_size == 0 || tmpb_size == 0) {
+        // One of the evaluations is zero, so vm1 = 0.
+    } else {
+        multiply_toom_cook_3(vm1, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                             std::span<const uint_multiprecision_t>{tmpb.data(), tmpb_size}, scratch);
+    }
+
+    // ---- Evaluate at x = 2: tmpa = 4*a2 + 2*a1 + a0 (Horner: ((a2*2)+a1)*2+a0); tmpb similarly ----
+    std::ranges::copy(a2, tmpa.begin());
+    tmpa_size = a2.size();
+    tmpa_size = double_in_place(tmpa, tmpa_size); // 2*a2
+    tmpa_size = add_into_tmp(tmpa, tmpa_size, a1); // 2*a2 + a1
+    tmpa_size = double_in_place(tmpa, tmpa_size); // 4*a2 + 2*a1
+    tmpa_size = add_into_tmp(tmpa, tmpa_size, a0); // 4*a2 + 2*a1 + a0
+
+    std::ranges::copy(b2, tmpb.begin());
+    tmpb_size = b2.size();
+    tmpb_size = double_in_place(tmpb, tmpb_size);
+    tmpb_size = add_into_tmp(tmpb, tmpb_size, b1);
+    tmpb_size = double_in_place(tmpb, tmpb_size);
+    tmpb_size = add_into_tmp(tmpb, tmpb_size, b0);
+
+    // v2 = p(2) * q(2)
+    std::ranges::fill(v2, uint_multiprecision_t{0});
+    multiply_toom_cook_3(v2, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                         std::span<const uint_multiprecision_t>{tmpb.data(), tmpb_size}, scratch);
+
+    // ---- Bodrato interpolation (in-place; full 2k+2 buffers throughout) ----
+    // After this sequence: v0=c0 (in result), vm1=c1, v1=c2, v2=c3, vinf=c4 (in result).
+    //
+    // Clip vinf_view to its semantic size of 2k limbs: c4 = a2*b2 with a2.size() <= k
+    // and b2.size() <= k yields a product of at most 2k limbs. The result span may
+    // extend past 4k+2k when called recursively from a parent whose prod_cap buffer
+    // is larger than the actual product (slack = caller-pre-zeroed). Subtracting
+    // those slack zeros is correct, but the size assertion in subtract_unsigned_spans
+    // would fail without clipping.
+    const auto v0_view   = std::span<const uint_multiprecision_t>{result.data(), 2 * k};
+    const auto vinf_size = std::min(result.size() - 4 * k, 2 * k);
+    const auto vinf_view = std::span<const uint_multiprecision_t>{result.data() + 4 * k, vinf_size};
+    const auto v1_view   = std::span<const uint_multiprecision_t>{v1};
+    const auto vm1_view  = std::span<const uint_multiprecision_t>{vm1};
+    const auto v2_view   = std::span<const uint_multiprecision_t>{v2};
+
+    // Step 1: v2 <- (v2 - vm1) / 3 (sign-aware: add if vm1 was negative).
+    if (sign_vm1) {
+        [[maybe_unused]] const bool carry_out = add_unsigned_spans(v2, v2_view, vm1_view);
+        BEMAN_BIG_INT_DEBUG_ASSERT(!carry_out);
+    } else {
+        subtract_unsigned_spans(v2, v2_view, vm1_view);
+    }
+    {
+        [[maybe_unused]] const auto rem = divide_unsigned_short(v2, v2_view, uint_multiprecision_t{3});
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Step 2: vm1 <- (v1 - vm1) / 2 (sign-aware). After this, vm1 is non-negative.
+    if (sign_vm1) {
+        [[maybe_unused]] const bool carry_out = add_unsigned_spans(vm1, v1_view, vm1_view);
+        BEMAN_BIG_INT_DEBUG_ASSERT(!carry_out);
+    } else {
+        subtract_unsigned_spans(vm1, v1_view, vm1_view);
+    }
+    {
+        [[maybe_unused]] const auto rem = divide_unsigned_short(vm1, vm1_view, uint_multiprecision_t{2});
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Step 3: v1 <- v1 - v0 (sizes: v1 is 2k+2, v0_view is 2k; v1 >= v0 numerically).
+    subtract_unsigned_spans(v1, v1_view, v0_view);
+
+    // Step 4: v2 <- (v2 - v1) / 2.
+    subtract_unsigned_spans(v2, v2_view, v1_view);
+    {
+        [[maybe_unused]] const auto rem = divide_unsigned_short(v2, v2_view, uint_multiprecision_t{2});
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Step 5: v1 <- v1 - vm1 - vinf.
+    subtract_unsigned_spans(v1, v1_view, vm1_view);
+    subtract_unsigned_spans(v1, v1_view, vinf_view);
+
+    // Step 6: v2 <- v2 - 2*vinf (subtract twice, no doubling helper needed).
+    subtract_unsigned_spans(v2, v2_view, vinf_view);
+    subtract_unsigned_spans(v2, v2_view, vinf_view);
+
+    // Step 7: vm1 <- vm1 - v2.
+    subtract_unsigned_spans(vm1, vm1_view, v2_view);
+
+    // ---- Recompose: result += vm1*B^k + v1*B^(2k) + v2*B^(3k) ----
+    // c0 already at result[0..2k); c4 already at result[4k..). Add the three middle
+    // coefficients with carry chains spanning to result.size() so carries can
+    // propagate into the c4 region.
+    const auto add_shifted = [&](const std::size_t                            shift,
+                                 const std::span<const uint_multiprecision_t> src) {
+        const auto dest  = result.subspan(shift);
+        bool       carry = false;
+        for (std::size_t i = 0; i < dest.size(); ++i) {
+            const auto si            = i < src.size() ? src[i] : uint_multiprecision_t{0};
+            const auto [r_value, c1] = carrying_add(dest[i], si, carry);
+            dest[i]                  = r_value;
+            carry                    = c1;
+        }
+        BEMAN_BIG_INT_DEBUG_ASSERT(!carry);
+    };
+
+    add_shifted(k, vm1_view);
+    add_shifted(2 * k, v1_view);
+    add_shifted(3 * k, v2_view);
+
+    // Move bump pointer back so the next sibling recursive call reuses the same region.
+    scratch.deallocate(total_scratch);
+}
+
 // ---------------------------------------------------------------------------
 // Top-level multiplication dispatcher.
 // `result` must be pre-zeroed and have space for a.size() + b.size() limbs.

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -544,14 +544,14 @@ constexpr void multiply_toom_cook_3(const std::span<uint_multiprecision_t> resul
             return 0;
         }
         BEMAN_BIG_INT_DEBUG_ASSERT(tmp.size() > size);
-        constexpr std::size_t limb_bits = width_v<uint_multiprecision_t>;
+        constexpr std::size_t local_limb_bits = width_v<uint_multiprecision_t>;
         uint_multiprecision_t prev      = 0;
         for (std::size_t i = 0; i < size; ++i) {
             const auto limb = tmp[i];
             tmp[i]          = funnel_shl(wide<uint_multiprecision_t>{.low_bits = prev, .high_bits = limb}, 1u);
             prev            = limb;
         }
-        if (const auto carry = prev >> (limb_bits - 1)) {
+        if (const auto carry = prev >> (local_limb_bits - 1)) {
             tmp[size++] = carry;
         }
         return size;

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -15,7 +15,7 @@
 namespace beman::big_int::detail {
 
 // Minimum number of limbs for Karatsuba to be worthwhile
-// Directly from Boost
+// Directly from Boost, and reconfirmed as correct
 inline constexpr std::size_t karatsuba_cutoff = 40;
 
 // Heuristic estimate of scratch space needed for Karatsuba multiplication
@@ -432,9 +432,9 @@ constexpr void multiply_karatsuba(const std::span<uint_multiprecision_t> result,
     scratch.deallocate(total_scratch);
 }
 
-// Minimum number of limbs for Toom-Cook 3 to be worthwhile
-// TODO(mborland) : We need to test where this should actually be
-inline constexpr std::size_t toom_cook_3_cutoff = 120;
+// Minimum number of limbs for Toom-Cook 3 to be worthwhile.
+// Toom-Cook 3 first beats Karatsuba around 800 limbs on Apple Silicon.
+inline constexpr std::size_t toom_cook_3_cutoff = 800;
 
 // Heuristic estimate of scratch space needed for Toom-Cook 3 multiplication.
 // Includes space for karatsuba fallback plan

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -545,7 +545,7 @@ constexpr void multiply_toom_cook_3(const std::span<uint_multiprecision_t> resul
         }
         BEMAN_BIG_INT_DEBUG_ASSERT(tmp.size() > size);
         constexpr std::size_t local_limb_bits = width_v<uint_multiprecision_t>;
-        uint_multiprecision_t prev      = 0;
+        uint_multiprecision_t prev            = 0;
         for (std::size_t i = 0; i < size; ++i) {
             const auto limb = tmp[i];
             tmp[i]          = funnel_shl(wide<uint_multiprecision_t>{.low_bits = prev, .high_bits = limb}, 1u);

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -8,6 +8,7 @@
 #include <beman/big_int/detail/wide_ops.hpp>
 
 #include <algorithm>
+#include <compare>
 #include <memory>
 #include <span>
 
@@ -104,6 +105,27 @@ constexpr bool is_span_zero(const std::span<const uint_multiprecision_t> s) noex
 }
 
 // ---------------------------------------------------------------------------
+// Three-way compare of two little-endian unsigned spans.
+// Operands need not be trimmed: trailing zero limbs on either side are
+// treated as insignificant.
+// ---------------------------------------------------------------------------
+[[nodiscard]] constexpr std::strong_ordering
+compare_unsigned_spans(const std::span<const uint_multiprecision_t> a,
+                       const std::span<const uint_multiprecision_t> b) noexcept {
+    const std::size_t na = a.size();
+    const std::size_t nb = b.size();
+    const std::size_t n  = std::max(na, nb);
+    for (std::size_t i = n; i-- > 0;) {
+        const auto ai = i < na ? a[i] : uint_multiprecision_t{0};
+        const auto bi = i < nb ? b[i] : uint_multiprecision_t{0};
+        if (ai != bi) {
+            return ai < bi ? std::strong_ordering::less : std::strong_ordering::greater;
+        }
+    }
+    return std::strong_ordering::equal;
+}
+
+// ---------------------------------------------------------------------------
 // Unsigned span addition: result = a + b
 // `result.size()` must be >= max(a.size(), b.size()).
 // `result` may alias `a`. Returns true if there is a carry out.
@@ -145,6 +167,74 @@ constexpr std::size_t subtract_unsigned_spans(const std::span<uint_multiprecisio
 
     BEMAN_BIG_INT_DEBUG_ASSERT(!borrow);
     return trimmed_size(std::span<const uint_multiprecision_t>{result.data(), a.size()});
+}
+
+// ---------------------------------------------------------------------------
+// Signed span subtraction: writes |a - b| into result, returns its size and
+// whether the result is negative (i.e. b > a, so result holds b - a).
+// `result` may alias `a` or `b`. Used by Toom-Cook 3 to evaluate at x = -1.
+// ---------------------------------------------------------------------------
+struct signed_sub_result {
+    std::size_t size;
+    bool        negative;
+};
+
+constexpr signed_sub_result
+subtract_unsigned_spans_signed(const std::span<uint_multiprecision_t>       result,
+                               const std::span<const uint_multiprecision_t> a,
+                               const std::span<const uint_multiprecision_t> b) noexcept {
+    // Trim before comparing so the size relationship matches the value relationship,
+    // satisfying subtract_unsigned_spans's a.size() >= b.size() invariant.
+    const std::size_t a_trim = a.empty() ? 0 : trimmed_size(a);
+    const std::size_t b_trim = b.empty() ? 0 : trimmed_size(b);
+    const auto        a_view = a.first(a_trim);
+    const auto        b_view = b.first(b_trim);
+
+    if (compare_unsigned_spans(a_view, b_view) >= 0) {
+        BEMAN_BIG_INT_DEBUG_ASSERT(result.size() >= a_trim);
+        if (a_trim == 0) {
+            return {0, false};
+        }
+        return {subtract_unsigned_spans(result.first(a_trim), a_view, b_view), false};
+    }
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.size() >= b_trim);
+    return {subtract_unsigned_spans(result.first(b_trim), b_view, a_view), true};
+}
+
+// ---------------------------------------------------------------------------
+// Single-limb short division.
+// `quotient[i]` := floor(([remainder, dividend[i]] as two limbs) / divisor)
+// scanning from the top limb down.
+// Returns the scalar remainder.
+// `quotient` and `dividend` may be the same range (i.e. alias each other),
+// but `quotient` may not be a strict subrange of `dividend`.
+//
+// Preconditions:
+//   - divisor != 0
+//   - quotient.size() >= dividend.size()
+//   - dividend.size() >= 1
+//   - quotient may alias dividend (we read dividend[i] before writing
+//     quotient[i]; subsequent iterations touch strictly lower indices).
+// ---------------------------------------------------------------------------
+[[nodiscard]] constexpr uint_multiprecision_t
+divide_unsigned_short(const std::span<uint_multiprecision_t>       quotient,
+                      const std::span<const uint_multiprecision_t> dividend,
+                      const uint_multiprecision_t                  divisor) noexcept {
+    BEMAN_BIG_INT_DEBUG_ASSERT(divisor != 0);
+    BEMAN_BIG_INT_DEBUG_ASSERT(quotient.size() >= dividend.size());
+    BEMAN_BIG_INT_DEBUG_ASSERT(!dividend.empty());
+
+    uint_multiprecision_t remainder = 0;
+    for (std::size_t i = dividend.size(); i-- > 0;) {
+        // narrowing_div requires x.high_bits < y; the previous remainder was
+        // taken mod divisor, so this invariant holds (and 0 < divisor on the
+        // first iteration).
+        const wide<uint_multiprecision_t> num{.low_bits = dividend[i], .high_bits = remainder};
+        const auto [q, r] = narrowing_div(num, divisor);
+        quotient[i]       = q;
+        remainder         = r;
+    }
+    return remainder;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/beman/big_int/addition_bench.test.cpp
+++ b/tests/beman/big_int/addition_bench.test.cpp
@@ -7,6 +7,7 @@
 #include <span>
 
 #include "benchmark_testing.hpp"
+#include "testing.hpp"
 
 namespace local {
 template <typename BigIntType>
@@ -52,8 +53,8 @@ bool run_benchmarks() {
     const auto big_int_bytes = std::as_bytes(big_int_fibonacci.representation());
     const auto cpp_int_bytes = std::as_bytes(cpp_int_rep);
 
-    const auto big_int_sig = beman::big_int::benchmark_testing::significant_byte_len(big_int_bytes);
-    const auto cpp_int_sig = beman::big_int::benchmark_testing::significant_byte_len(cpp_int_bytes);
+    const auto big_int_sig = beman::big_int::significant_byte_len(big_int_bytes);
+    const auto cpp_int_sig = beman::big_int::significant_byte_len(cpp_int_bytes);
 
     const bool result_length_is_ok{big_int_sig == cpp_int_sig};
 

--- a/tests/beman/big_int/benchmark_testing.hpp
+++ b/tests/beman/big_int/benchmark_testing.hpp
@@ -6,7 +6,6 @@
 
 #include <cstdint>
 #include <ctime>
-#include <span>
 
 #include <beman/big_int/detail/config.hpp>
 
@@ -52,15 +51,6 @@ struct stopwatch {
         return elapsed_ns;
     }
 };
-
-// Returns the number of bytes before the trailing run of zero bytes.
-[[nodiscard]] inline auto significant_byte_len(const std::span<const std::byte> bytes) noexcept -> std::size_t {
-    std::size_t n = bytes.size();
-    while (n > 0 && bytes[n - 1] == std::byte{0}) {
-        --n;
-    }
-    return n;
-}
 
 } // namespace beman::big_int::benchmark_testing
 

--- a/tests/beman/big_int/karatsuba_mersenne.test.cpp
+++ b/tests/beman/big_int/karatsuba_mersenne.test.cpp
@@ -12,38 +12,6 @@
 
 namespace local {
 
-template <class IntegralType>
-constexpr auto pow(const IntegralType& b, unsigned p) -> IntegralType {
-    using local_integer_type = IntegralType;
-
-    // Calculate (b ^ p).
-
-    local_integer_type result{1};
-
-    local_integer_type y{b};
-
-    while (p != 0U) {
-        if ((p & 1U) != 0U) {
-            result *= y;
-        }
-
-        y = y *= y;
-
-        p >>= 1U;
-    }
-
-    return result;
-}
-
-// Returns the number of bytes before the trailing run of zero bytes.
-[[nodiscard]] inline auto significant_byte_len(const std::span<const std::byte> bytes) noexcept -> std::size_t {
-    std::size_t n = bytes.size();
-    while (n > 0 && bytes[n - 1] == std::byte{0}) {
-        --n;
-    }
-    return n;
-}
-
 auto run_one_mersenne(const unsigned p2) -> void {
     using cpp_int_type =
         boost::multiprecision::number<boost::multiprecision::cpp_int_backend<>, boost::multiprecision::et_off>;
@@ -57,18 +25,18 @@ auto run_one_mersenne(const unsigned p2) -> void {
     // N[%]
 
     const cpp_int_type cpp_int_two{2};
-    const cpp_int_type cpp_int_mersenne{cpp_int_type{local::pow(cpp_int_two, p2)} - 1};
+    const cpp_int_type cpp_int_mersenne{cpp_int_type{beman::big_int::pow(cpp_int_two, p2)} - 1};
 
     const big_int_type big_int_two{2};
-    const big_int_type big_int_mersenne{big_int_type{local::pow(big_int_two, p2)} - 1};
+    const big_int_type big_int_mersenne{big_int_type{beman::big_int::pow(big_int_two, p2)} - 1};
 
     const std::span<const ::boost::multiprecision::limb_type> cpp_int_rep{cpp_int_mersenne.backend().limbs(),
                                                                           cpp_int_mersenne.backend().size()};
     const auto big_int_bytes = std::as_bytes(big_int_mersenne.representation());
     const auto cpp_int_bytes = std::as_bytes(cpp_int_rep);
 
-    const auto big_int_sig = local::significant_byte_len(big_int_bytes);
-    const auto cpp_int_sig = local::significant_byte_len(cpp_int_bytes);
+    const auto big_int_sig = beman::big_int::significant_byte_len(big_int_bytes);
+    const auto cpp_int_sig = beman::big_int::significant_byte_len(cpp_int_bytes);
 
     const bool result_length_is_ok{big_int_sig == cpp_int_sig};
 

--- a/tests/beman/big_int/multiplication_bench.test.cpp
+++ b/tests/beman/big_int/multiplication_bench.test.cpp
@@ -4,33 +4,7 @@
 #include <beman/big_int/big_int.hpp>
 #include "benchmark_testing.hpp"
 #include "boost_mp_testing.hpp"
-
-namespace local {
-
-template <class IntegralType>
-[[nodiscard]] constexpr auto pow(const IntegralType& b, unsigned p) -> IntegralType {
-    using local_integer_type = IntegralType;
-
-    // Calculate (b ^ p).
-
-    local_integer_type result{1};
-
-    local_integer_type y{b};
-
-    while (p != 0U) {
-        if ((p & 1U) != 0U) {
-            result *= y;
-        }
-
-        y *= y;
-
-        p >>= 1U;
-    }
-
-    return result;
-}
-
-} // namespace local
+#include "testing.hpp"
 
 bool run_benchmarks(const unsigned p2) {
     using cpp_int_type =
@@ -42,13 +16,13 @@ bool run_benchmarks(const unsigned p2) {
     local_stopwatch_type my_stopwatch{};
 
     const cpp_int_type cpp_int_two{2};
-    const cpp_int_type cpp_int_mersenne{cpp_int_type{local::pow(cpp_int_two, p2)} - 1};
+    const cpp_int_type cpp_int_mersenne{cpp_int_type{beman::big_int::pow(cpp_int_two, p2)} - 1};
     std::cout << "stopwatch big_int: " << local_stopwatch_type::elapsed_time<double>(my_stopwatch) << std::endl;
 
     my_stopwatch.reset();
 
     const big_int_type big_int_two{2};
-    const big_int_type big_int_mersenne{big_int_type{local::pow(big_int_two, p2)} - 1};
+    const big_int_type big_int_mersenne{big_int_type{beman::big_int::pow(big_int_two, p2)} - 1};
     std::cout << "stopwatch cpp_int: " << local_stopwatch_type::elapsed_time<double>(my_stopwatch) << std::endl;
 
     const std::span<const ::boost::multiprecision::limb_type> cpp_int_rep{cpp_int_mersenne.backend().limbs(),
@@ -56,8 +30,8 @@ bool run_benchmarks(const unsigned p2) {
     const auto big_int_bytes = std::as_bytes(big_int_mersenne.representation());
     const auto cpp_int_bytes = std::as_bytes(cpp_int_rep);
 
-    const auto big_int_sig = beman::big_int::benchmark_testing::significant_byte_len(big_int_bytes);
-    const auto cpp_int_sig = beman::big_int::benchmark_testing::significant_byte_len(cpp_int_bytes);
+    const auto big_int_sig = beman::big_int::significant_byte_len(big_int_bytes);
+    const auto cpp_int_sig = beman::big_int::significant_byte_len(cpp_int_bytes);
 
     const bool result_length_is_ok{big_int_sig == cpp_int_sig};
 

--- a/tests/beman/big_int/multiplication_stress_bench.test.cpp
+++ b/tests/beman/big_int/multiplication_stress_bench.test.cpp
@@ -73,7 +73,7 @@ double measure_algorithm(const std::size_t limbs, const unsigned trials, const s
     std::vector<uint_t> result(2 * limbs, uint_t{0});
 
     std_allocator    alloc;
-    scratch_for_test scratch(std::max(scratch_size, std::size_t{1}), alloc);
+    scratch_for_test scratch(std::max<std::size_t>(scratch_size, 1), alloc);
 
     const auto a_view = std::span<const uint_t>{a};
     const auto b_view = std::span<const uint_t>{b};
@@ -143,25 +143,22 @@ struct algorithm_runner {
 };
 
 constexpr algorithm_runner algorithms[] = {
-    {"schoolbook", std::size_t{2}, std::size_t{200}, run_long_at},
-    {"karatsuba", std::size_t{4}, std::size_t{2000}, run_karatsuba_at},
-    {"toom-cook-3", std::size_t{800}, std::size_t{5000}, run_toom_cook_3_at},
+    {"schoolbook", 2, 200, run_long_at},
+    {"karatsuba", 4, 2000, run_karatsuba_at},
+    {"toom-cook-3", 800, 5000, run_toom_cook_3_at},
     // Future additions, e.g.:
-    // {"toom-cook-4", std::size_t{2000},  std::size_t{10000}, run_toom_cook_4_at},
-    // {"toom-cook-5", std::size_t{5000},  std::size_t{20000}, run_toom_cook_5_at},
+    // {"toom-cook-4", 2000, 10000, run_toom_cook_4_at},
+    // {"toom-cook-5", 5000, 20000, run_toom_cook_5_at},
 };
 
 // Limb counts to sample. Dense coverage at the low end for the
 // schoolbook -> Karatsuba crossover, dense in the middle for the
 // Karatsuba -> Toom-Cook 3 crossover, then a coarser tail.
 constexpr std::size_t sweep_limbs[] = {
-    std::size_t{2},    std::size_t{4},    std::size_t{6},    std::size_t{8},    std::size_t{10},   std::size_t{12},
-    std::size_t{14},   std::size_t{16},   std::size_t{20},   std::size_t{24},   std::size_t{28},   std::size_t{32},
-    std::size_t{36},   std::size_t{40},   std::size_t{48},   std::size_t{56},   std::size_t{64},   std::size_t{72},
-    std::size_t{80},   std::size_t{96},   std::size_t{112},  std::size_t{128},  std::size_t{144},  std::size_t{160},
-    std::size_t{192},  std::size_t{224},  std::size_t{256},  std::size_t{320},  std::size_t{400},  std::size_t{500},
-    std::size_t{640},  std::size_t{800},  std::size_t{1000}, std::size_t{1280}, std::size_t{1600}, std::size_t{2000},
-    std::size_t{2500}, std::size_t{3200}, std::size_t{4000}, std::size_t{5000},
+    2,    4,    6,    8,    10,   12,   14,   16,   20,   24,
+    28,   32,   36,   40,   48,   56,   64,   72,   80,   96,
+    112,  128,  144,  160,  192,  224,  256,  320,  400,  500,
+    640,  800,  1000, 1280, 1600, 2000, 2500, 3200, 4000, 5000,
 };
 
 // Aim for ~0.2-1 second per data point. Trial counts taper as the cost per

--- a/tests/beman/big_int/multiplication_stress_bench.test.cpp
+++ b/tests/beman/big_int/multiplication_stress_bench.test.cpp
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: BSL-1.0
+//
+// Stress benchmark for tuning the Karatsuba and Toom-Cook 3 cutoffs.
+// Sweeps each algorithm (schoolbook, Karatsuba, Toom-Cook 3, ...) over a
+// range of limb counts and prints average time per multiplication.
+//
+// Disabled by default. To run:
+//   cmake --preset appleclang-release -DBEMAN_BIG_INT_RUN_BENCHMARKS=ON
+//   cmake --build build/appleclang-release
+//   ./build/appleclang-release/tests/beman/big_int/beman.big_int.tests.multiplication_stress_bench
+//
+// Output is CSV on stdout (algorithm,limbs,trials,ns_per_mul). Pipe to a file
+// or to a plotting script to find crossover points.
+//
+// To add a new algorithm (Toom-Cook 4, 5, ...):
+//   1. Add a `run_toom_cook_4_at` function that calls the new
+//      `detail::multiply_toom_cook_4` and returns ns per multiplication.
+//   2. Append an entry to the `algorithms[]` table below with sensible
+//      min/max limb counts.
+//   3. Extend `sweep_limbs[]` if the new algorithm is interesting at limb
+//      counts not already covered.
+
+#include <beman/big_int/big_int.hpp>
+#include <beman/big_int/detail/mul_impl.hpp>
+
+#include <gtest/gtest.h>
+
+#include "benchmark_testing.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <random>
+#include <span>
+#include <string_view>
+#include <vector>
+
+namespace local {
+
+using uint_t           = ::beman::big_int::uint_multiprecision_t;
+using stopwatch        = ::beman::big_int::benchmark_testing::stopwatch;
+using std_allocator    = std::allocator<uint_t>;
+using scratch_for_test = ::beman::big_int::detail::scratch_allocator<std_allocator>;
+
+// Fill a span with random limbs and force the top limb non-zero so the
+// operand actually has `dest.size()` significant limbs (no accidental trim).
+inline void fill_random(const std::span<uint_t> dest, std::mt19937_64& rng) {
+    std::uniform_int_distribution<uint_t> dist;
+    for (auto& x : dest) {
+        x = dist(rng);
+    }
+    if (!dest.empty() && dest.back() == 0) {
+        dest.back() = 1;
+    }
+}
+
+// Run `algo(result, a, b, scratch)` for `trials` iterations after one warmup
+// and return the average wall time in nanoseconds. `scratch_size` is the
+// total limbs to pre-allocate for the algorithm's scratch (0 -> no scratch
+// needed, but we still construct a minimal allocator to keep the lambda
+// signature uniform).
+template <class Algo>
+double measure_algorithm(const std::size_t limbs,
+                         const unsigned    trials,
+                         const std::size_t scratch_size,
+                         Algo              algo) {
+    std::mt19937_64           rng{0xC0FFEEULL};
+    std::vector<uint_t>       a(limbs);
+    std::vector<uint_t>       b(limbs);
+    fill_random(a, rng);
+    fill_random(b, rng);
+
+    std::vector<uint_t> result(2 * limbs, uint_t{0});
+
+    std_allocator    alloc;
+    scratch_for_test scratch(std::max(scratch_size, std::size_t{1}), alloc);
+
+    const auto a_view = std::span<const uint_t>{a};
+    const auto b_view = std::span<const uint_t>{b};
+    const auto r_view = std::span<uint_t>{result};
+
+    // Warm caches / branch predictors with one untimed run.
+    std::ranges::fill(result, uint_t{0});
+    algo(r_view, a_view, b_view, scratch);
+
+    const stopwatch sw{};
+    for (unsigned i = 0; i < trials; ++i) {
+        std::ranges::fill(result, uint_t{0});
+        algo(r_view, a_view, b_view, scratch);
+    }
+    const double seconds = stopwatch::elapsed_time<double>(sw);
+    return (seconds * 1.0e9) / static_cast<double>(trials);
+}
+
+// Per-algorithm runners. Each invokes the algorithm directly so we measure
+// it in isolation (no dispatcher overhead, no cutoff fallback above the
+// algorithm's own internal threshold).
+
+double run_long_at(const std::size_t limbs, const unsigned trials) {
+    return measure_algorithm(limbs,
+                             trials,
+                             /*scratch_size=*/0,
+                             [](const std::span<uint_t>       r,
+                                const std::span<const uint_t> a,
+                                const std::span<const uint_t> b,
+                                scratch_for_test&) {
+                                 ::beman::big_int::detail::multiply_long(r.first(a.size() + b.size()), a, b);
+                             });
+}
+
+double run_karatsuba_at(const std::size_t limbs, const unsigned trials) {
+    return measure_algorithm(
+        limbs,
+        trials,
+        ::beman::big_int::detail::karatsuba_storage_size(limbs),
+        [](const std::span<uint_t>       r,
+           const std::span<const uint_t> a,
+           const std::span<const uint_t> b,
+           scratch_for_test&             s) {
+            ::beman::big_int::detail::multiply_karatsuba(r.first(a.size() + b.size()), a, b, s);
+        });
+}
+
+double run_toom_cook_3_at(const std::size_t limbs, const unsigned trials) {
+    return measure_algorithm(
+        limbs,
+        trials,
+        ::beman::big_int::detail::toom_cook_3_storage_size(limbs),
+        [](const std::span<uint_t>       r,
+           const std::span<const uint_t> a,
+           const std::span<const uint_t> b,
+           scratch_for_test&             s) {
+            ::beman::big_int::detail::multiply_toom_cook_3(r.first(a.size() + b.size()), a, b, s);
+        });
+}
+
+// Registry of algorithms to sweep. Each entry constrains the sweep to a
+// reasonable range: too small and the algorithm's own internal cutoff just
+// falls back to the previous tier; too large and a single multiplication
+// dominates the whole run.
+struct algorithm_runner {
+    std::string_view name;
+    std::size_t      min_limbs;
+    std::size_t      max_limbs;
+    double (*run)(std::size_t limbs, unsigned trials);
+};
+
+constexpr algorithm_runner algorithms[] = {
+    {"schoolbook",  std::size_t{4},   std::size_t{200},  run_long_at},
+    {"karatsuba",   std::size_t{20},  std::size_t{2000}, run_karatsuba_at},
+    {"toom-cook-3", std::size_t{80},  std::size_t{5000}, run_toom_cook_3_at},
+    // Future additions, e.g.:
+    // {"toom-cook-4", std::size_t{200},  std::size_t{10000}, run_toom_cook_4_at},
+    // {"toom-cook-5", std::size_t{500},  std::size_t{20000}, run_toom_cook_5_at},
+};
+
+// Limb counts to sample. Dense coverage around the existing cutoffs
+// (Karatsuba: 40, Toom-Cook 3: 120) so the crossover is clearly visible,
+// then a coarser tail to inform higher-order cutoffs.
+constexpr std::size_t sweep_limbs[] = {
+    std::size_t{4},    std::size_t{8},    std::size_t{16},   std::size_t{24},   std::size_t{32},
+    std::size_t{40},   std::size_t{48},   std::size_t{56},   std::size_t{64},   std::size_t{72},
+    std::size_t{80},   std::size_t{96},   std::size_t{112},  std::size_t{128},  std::size_t{144},
+    std::size_t{160},  std::size_t{192},  std::size_t{224},  std::size_t{256},  std::size_t{320},
+    std::size_t{400},  std::size_t{500},  std::size_t{640},  std::size_t{800},  std::size_t{1000},
+    std::size_t{1280}, std::size_t{1600}, std::size_t{2000}, std::size_t{2500}, std::size_t{3200},
+    std::size_t{4000}, std::size_t{5000},
+};
+
+// Aim for ~0.2-1 second per data point. Trial counts taper as the cost per
+// multiplication grows. Adjust if a machine is much faster/slower than the
+// development baseline.
+[[nodiscard]] constexpr unsigned choose_trials(const std::size_t limbs) noexcept {
+    if (limbs <= 16) {
+        return 50000U;
+    }
+    if (limbs <= 32) {
+        return 20000U;
+    }
+    if (limbs <= 64) {
+        return 5000U;
+    }
+    if (limbs <= 128) {
+        return 1000U;
+    }
+    if (limbs <= 256) {
+        return 300U;
+    }
+    if (limbs <= 512) {
+        return 100U;
+    }
+    if (limbs <= 1024) {
+        return 30U;
+    }
+    if (limbs <= 2000) {
+        return 10U;
+    }
+    return 3U;
+}
+
+void run_sweep() {
+    std::cout << "algorithm,limbs,trials,ns_per_mul\n";
+    for (const auto& algo : algorithms) {
+        for (const std::size_t limbs : sweep_limbs) {
+            if (limbs < algo.min_limbs || limbs > algo.max_limbs) {
+                continue;
+            }
+            const unsigned trials = choose_trials(limbs);
+            const double   ns     = algo.run(limbs, trials);
+            std::cout << algo.name << ',' << limbs << ',' << trials << ',' << std::fixed
+                      << std::setprecision(1) << ns << '\n';
+        }
+        std::cout.flush();
+    }
+}
+
+} // namespace local
+
+TEST(Multiplication, MultiplicationStressBench) {
+#ifdef BEMAN_BIG_INT_RUN_BENCHMARKS
+    local::run_sweep();
+    SUCCEED();
+#else
+    GTEST_SKIP() << "Stress benchmarks not run (define BEMAN_BIG_INT_RUN_BENCHMARKS to enable)";
+#endif
+}

--- a/tests/beman/big_int/multiplication_stress_bench.test.cpp
+++ b/tests/beman/big_int/multiplication_stress_bench.test.cpp
@@ -155,10 +155,8 @@ constexpr algorithm_runner algorithms[] = {
 // schoolbook -> Karatsuba crossover, dense in the middle for the
 // Karatsuba -> Toom-Cook 3 crossover, then a coarser tail.
 constexpr std::size_t sweep_limbs[] = {
-    2,    4,    6,    8,    10,   12,   14,   16,   20,   24,
-    28,   32,   36,   40,   48,   56,   64,   72,   80,   96,
-    112,  128,  144,  160,  192,  224,  256,  320,  400,  500,
-    640,  800,  1000, 1280, 1600, 2000, 2500, 3200, 4000, 5000,
+    2,   4,   6,   8,   10,  12,  14,  16,  20,  24,  28,  32,  36,   40,   48,   56,   64,   72,   80,   96,
+    112, 128, 144, 160, 192, 224, 256, 320, 400, 500, 640, 800, 1000, 1280, 1600, 2000, 2500, 3200, 4000, 5000,
 };
 
 // Aim for ~0.2-1 second per data point. Trial counts taper as the cost per

--- a/tests/beman/big_int/multiplication_stress_bench.test.cpp
+++ b/tests/beman/big_int/multiplication_stress_bench.test.cpp
@@ -149,45 +149,49 @@ struct algorithm_runner {
 };
 
 constexpr algorithm_runner algorithms[] = {
-    {"schoolbook",  std::size_t{4},   std::size_t{200},  run_long_at},
-    {"karatsuba",   std::size_t{20},  std::size_t{2000}, run_karatsuba_at},
-    {"toom-cook-3", std::size_t{80},  std::size_t{5000}, run_toom_cook_3_at},
+    {"schoolbook",  std::size_t{2},   std::size_t{200},  run_long_at},
+    {"karatsuba",   std::size_t{4},   std::size_t{2000}, run_karatsuba_at},
+    {"toom-cook-3", std::size_t{800}, std::size_t{5000}, run_toom_cook_3_at},
     // Future additions, e.g.:
-    // {"toom-cook-4", std::size_t{200},  std::size_t{10000}, run_toom_cook_4_at},
-    // {"toom-cook-5", std::size_t{500},  std::size_t{20000}, run_toom_cook_5_at},
+    // {"toom-cook-4", std::size_t{2000},  std::size_t{10000}, run_toom_cook_4_at},
+    // {"toom-cook-5", std::size_t{5000},  std::size_t{20000}, run_toom_cook_5_at},
 };
 
-// Limb counts to sample. Dense coverage around the existing cutoffs
-// (Karatsuba: 40, Toom-Cook 3: 120) so the crossover is clearly visible,
-// then a coarser tail to inform higher-order cutoffs.
+// Limb counts to sample. Dense coverage at the low end for the
+// schoolbook -> Karatsuba crossover, dense in the middle for the
+// Karatsuba -> Toom-Cook 3 crossover, then a coarser tail.
 constexpr std::size_t sweep_limbs[] = {
-    std::size_t{4},    std::size_t{8},    std::size_t{16},   std::size_t{24},   std::size_t{32},
-    std::size_t{40},   std::size_t{48},   std::size_t{56},   std::size_t{64},   std::size_t{72},
-    std::size_t{80},   std::size_t{96},   std::size_t{112},  std::size_t{128},  std::size_t{144},
-    std::size_t{160},  std::size_t{192},  std::size_t{224},  std::size_t{256},  std::size_t{320},
-    std::size_t{400},  std::size_t{500},  std::size_t{640},  std::size_t{800},  std::size_t{1000},
-    std::size_t{1280}, std::size_t{1600}, std::size_t{2000}, std::size_t{2500}, std::size_t{3200},
-    std::size_t{4000}, std::size_t{5000},
+    std::size_t{2},    std::size_t{4},    std::size_t{6},    std::size_t{8},    std::size_t{10},
+    std::size_t{12},   std::size_t{14},   std::size_t{16},   std::size_t{20},   std::size_t{24},
+    std::size_t{28},   std::size_t{32},   std::size_t{36},   std::size_t{40},   std::size_t{48},
+    std::size_t{56},   std::size_t{64},   std::size_t{72},   std::size_t{80},   std::size_t{96},
+    std::size_t{112},  std::size_t{128},  std::size_t{144},  std::size_t{160},  std::size_t{192},
+    std::size_t{224},  std::size_t{256},  std::size_t{320},  std::size_t{400},  std::size_t{500},
+    std::size_t{640},  std::size_t{800},  std::size_t{1000}, std::size_t{1280}, std::size_t{1600},
+    std::size_t{2000}, std::size_t{2500}, std::size_t{3200}, std::size_t{4000}, std::size_t{5000},
 };
 
 // Aim for ~0.2-1 second per data point. Trial counts taper as the cost per
 // multiplication grows. Adjust if a machine is much faster/slower than the
 // development baseline.
 [[nodiscard]] constexpr unsigned choose_trials(const std::size_t limbs) noexcept {
+    if (limbs <= 8) {
+        return 200000U;
+    }
     if (limbs <= 16) {
-        return 50000U;
+        return 100000U;
     }
     if (limbs <= 32) {
-        return 20000U;
+        return 30000U;
     }
     if (limbs <= 64) {
-        return 5000U;
+        return 10000U;
     }
     if (limbs <= 128) {
-        return 1000U;
+        return 2000U;
     }
     if (limbs <= 256) {
-        return 300U;
+        return 500U;
     }
     if (limbs <= 512) {
         return 100U;

--- a/tests/beman/big_int/multiplication_stress_bench.test.cpp
+++ b/tests/beman/big_int/multiplication_stress_bench.test.cpp
@@ -63,13 +63,10 @@ inline void fill_random(const std::span<uint_t> dest, std::mt19937_64& rng) {
 // needed, but we still construct a minimal allocator to keep the lambda
 // signature uniform).
 template <class Algo>
-double measure_algorithm(const std::size_t limbs,
-                         const unsigned    trials,
-                         const std::size_t scratch_size,
-                         Algo              algo) {
-    std::mt19937_64           rng{0xC0FFEEULL};
-    std::vector<uint_t>       a(limbs);
-    std::vector<uint_t>       b(limbs);
+double measure_algorithm(const std::size_t limbs, const unsigned trials, const std::size_t scratch_size, Algo algo) {
+    std::mt19937_64     rng{0xC0FFEEULL};
+    std::vector<uint_t> a(limbs);
+    std::vector<uint_t> b(limbs);
     fill_random(a, rng);
     fill_random(b, rng);
 
@@ -100,41 +97,38 @@ double measure_algorithm(const std::size_t limbs,
 // algorithm's own internal threshold).
 
 double run_long_at(const std::size_t limbs, const unsigned trials) {
-    return measure_algorithm(limbs,
-                             trials,
-                             /*scratch_size=*/0,
-                             [](const std::span<uint_t>       r,
-                                const std::span<const uint_t> a,
-                                const std::span<const uint_t> b,
-                                scratch_for_test&) {
-                                 ::beman::big_int::detail::multiply_long(r.first(a.size() + b.size()), a, b);
-                             });
+    return measure_algorithm(
+        limbs,
+        trials,
+        /*scratch_size=*/0,
+        [](const std::span<uint_t>       r,
+           const std::span<const uint_t> a,
+           const std::span<const uint_t> b,
+           scratch_for_test&) { ::beman::big_int::detail::multiply_long(r.first(a.size() + b.size()), a, b); });
 }
 
 double run_karatsuba_at(const std::size_t limbs, const unsigned trials) {
-    return measure_algorithm(
-        limbs,
-        trials,
-        ::beman::big_int::detail::karatsuba_storage_size(limbs),
-        [](const std::span<uint_t>       r,
-           const std::span<const uint_t> a,
-           const std::span<const uint_t> b,
-           scratch_for_test&             s) {
-            ::beman::big_int::detail::multiply_karatsuba(r.first(a.size() + b.size()), a, b, s);
-        });
+    return measure_algorithm(limbs,
+                             trials,
+                             ::beman::big_int::detail::karatsuba_storage_size(limbs),
+                             [](const std::span<uint_t>       r,
+                                const std::span<const uint_t> a,
+                                const std::span<const uint_t> b,
+                                scratch_for_test&             s) {
+                                 ::beman::big_int::detail::multiply_karatsuba(r.first(a.size() + b.size()), a, b, s);
+                             });
 }
 
 double run_toom_cook_3_at(const std::size_t limbs, const unsigned trials) {
-    return measure_algorithm(
-        limbs,
-        trials,
-        ::beman::big_int::detail::toom_cook_3_storage_size(limbs),
-        [](const std::span<uint_t>       r,
-           const std::span<const uint_t> a,
-           const std::span<const uint_t> b,
-           scratch_for_test&             s) {
-            ::beman::big_int::detail::multiply_toom_cook_3(r.first(a.size() + b.size()), a, b, s);
-        });
+    return measure_algorithm(limbs,
+                             trials,
+                             ::beman::big_int::detail::toom_cook_3_storage_size(limbs),
+                             [](const std::span<uint_t>       r,
+                                const std::span<const uint_t> a,
+                                const std::span<const uint_t> b,
+                                scratch_for_test&             s) {
+                                 ::beman::big_int::detail::multiply_toom_cook_3(r.first(a.size() + b.size()), a, b, s);
+                             });
 }
 
 // Registry of algorithms to sweep. Each entry constrains the sweep to a
@@ -149,8 +143,8 @@ struct algorithm_runner {
 };
 
 constexpr algorithm_runner algorithms[] = {
-    {"schoolbook",  std::size_t{2},   std::size_t{200},  run_long_at},
-    {"karatsuba",   std::size_t{4},   std::size_t{2000}, run_karatsuba_at},
+    {"schoolbook", std::size_t{2}, std::size_t{200}, run_long_at},
+    {"karatsuba", std::size_t{4}, std::size_t{2000}, run_karatsuba_at},
     {"toom-cook-3", std::size_t{800}, std::size_t{5000}, run_toom_cook_3_at},
     // Future additions, e.g.:
     // {"toom-cook-4", std::size_t{2000},  std::size_t{10000}, run_toom_cook_4_at},
@@ -161,14 +155,13 @@ constexpr algorithm_runner algorithms[] = {
 // schoolbook -> Karatsuba crossover, dense in the middle for the
 // Karatsuba -> Toom-Cook 3 crossover, then a coarser tail.
 constexpr std::size_t sweep_limbs[] = {
-    std::size_t{2},    std::size_t{4},    std::size_t{6},    std::size_t{8},    std::size_t{10},
-    std::size_t{12},   std::size_t{14},   std::size_t{16},   std::size_t{20},   std::size_t{24},
-    std::size_t{28},   std::size_t{32},   std::size_t{36},   std::size_t{40},   std::size_t{48},
-    std::size_t{56},   std::size_t{64},   std::size_t{72},   std::size_t{80},   std::size_t{96},
-    std::size_t{112},  std::size_t{128},  std::size_t{144},  std::size_t{160},  std::size_t{192},
-    std::size_t{224},  std::size_t{256},  std::size_t{320},  std::size_t{400},  std::size_t{500},
-    std::size_t{640},  std::size_t{800},  std::size_t{1000}, std::size_t{1280}, std::size_t{1600},
-    std::size_t{2000}, std::size_t{2500}, std::size_t{3200}, std::size_t{4000}, std::size_t{5000},
+    std::size_t{2},    std::size_t{4},    std::size_t{6},    std::size_t{8},    std::size_t{10},   std::size_t{12},
+    std::size_t{14},   std::size_t{16},   std::size_t{20},   std::size_t{24},   std::size_t{28},   std::size_t{32},
+    std::size_t{36},   std::size_t{40},   std::size_t{48},   std::size_t{56},   std::size_t{64},   std::size_t{72},
+    std::size_t{80},   std::size_t{96},   std::size_t{112},  std::size_t{128},  std::size_t{144},  std::size_t{160},
+    std::size_t{192},  std::size_t{224},  std::size_t{256},  std::size_t{320},  std::size_t{400},  std::size_t{500},
+    std::size_t{640},  std::size_t{800},  std::size_t{1000}, std::size_t{1280}, std::size_t{1600}, std::size_t{2000},
+    std::size_t{2500}, std::size_t{3200}, std::size_t{4000}, std::size_t{5000},
 };
 
 // Aim for ~0.2-1 second per data point. Trial counts taper as the cost per
@@ -214,8 +207,8 @@ void run_sweep() {
             }
             const unsigned trials = choose_trials(limbs);
             const double   ns     = algo.run(limbs, trials);
-            std::cout << algo.name << ',' << limbs << ',' << trials << ',' << std::fixed
-                      << std::setprecision(1) << ns << '\n';
+            std::cout << algo.name << ',' << limbs << ',' << trials << ',' << std::fixed << std::setprecision(1) << ns
+                      << '\n';
         }
         std::cout.flush();
     }

--- a/tests/beman/big_int/testing.hpp
+++ b/tests/beman/big_int/testing.hpp
@@ -1,7 +1,9 @@
 #ifndef BEMAN_BIG_INT_TEST_HPP
 #define BEMAN_BIG_INT_TEST_HPP
 
+#include <cstddef>
 #include <ostream>
+#include <span>
 
 #include <beman/big_int/big_int.hpp>
 
@@ -15,6 +17,34 @@ std::ostream& operator<<(std::ostream& out, const basic_big_int<b, A>& x) {
 template <class T>
 std::ostream& operator<<(std::ostream& out, const div_result<T>& x) {
     return out << "{.quotient = " << x.quotient << ", .remainder = " << x.remainder << '}';
+}
+
+// Square-and-multiply integer exponentiation. Used by Mersenne and benchmark
+// tests to compute b^p in big_int / cpp_int types without dragging in
+// boost::multiprecision::pow.
+template <class IntegralType>
+[[nodiscard]] constexpr IntegralType pow(const IntegralType& b, unsigned p) {
+    IntegralType result{1};
+    IntegralType y{b};
+    while (p != 0U) {
+        if ((p & 1U) != 0U) {
+            result *= y;
+        }
+        y *= y;
+        p >>= 1U;
+    }
+    return result;
+}
+
+// Returns the number of bytes before the trailing run of zero bytes.
+// Used to compare big_int representations against boost::multiprecision::cpp_int
+// limb arrays, where padding limbs may differ but the significant bytes match.
+[[nodiscard]] inline std::size_t significant_byte_len(const std::span<const std::byte> bytes) noexcept {
+    std::size_t n = bytes.size();
+    while (n > 0 && bytes[n - 1] == std::byte{0}) {
+        --n;
+    }
+    return n;
 }
 
 } // namespace beman::big_int

--- a/tests/beman/big_int/toom_cook_3.test.cpp
+++ b/tests/beman/big_int/toom_cook_3.test.cpp
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: BSL-1.0
+
+#include "boost_mp_testing.hpp"
+#include "testing.hpp"
+#include <gtest/gtest.h>
+#include <cstddef>
+
+namespace bmp = ::beman::big_int::boost_mp_testing;
+
+constexpr std::size_t limb_bits =
+    static_cast<std::size_t>(std::numeric_limits<::beman::big_int::uint_multiprecision_t>::digits);
+
+// Toom-Cook 3 cutoff is 120 limbs. Tests around the boundary verify both
+// that the dispatcher correctly enters Toom-3 above the cutoff and that
+// the algorithm produces correct results for varying input sizes.
+
+void check_balanced(const std::size_t limbs_a, const std::size_t limbs_b) {
+    const std::string a = bmp::random_big_int(limbs_a * limb_bits);
+    const std::string b = bmp::random_big_int(limbs_b * limb_bits);
+    EXPECT_TRUE(bmp::check_cpp_int_equal(std::multiplies<>{}, a, b));
+}
+
+TEST(Multiplication, ToomCook3AtCutoff) {
+    // Both operands exactly at the Toom-Cook 3 cutoff. Forces dispatch into
+    // Toom-3 with shallow recursion (k = 40, so all sub-products fall back
+    // to Karatsuba).
+    check_balanced(120, 120);
+}
+
+TEST(Multiplication, ToomCook3JustAboveCutoff) {
+    check_balanced(121, 121);
+    check_balanced(125, 125);
+}
+
+TEST(Multiplication, ToomCook3JustBelowCutoff) {
+    // Both 119 limbs: dispatcher uses Karatsuba, not Toom-3. Sanity check
+    // that the cutoff gate works as expected.
+    check_balanced(119, 119);
+}
+
+TEST(Multiplication, ToomCook3DeepRecursion) {
+    // Large enough to drive multiple Toom-3 recursion levels.
+    check_balanced(400, 400);
+    check_balanced(1100, 1100);
+}
+
+TEST(Multiplication, ToomCook3AsymmetricBalanced) {
+    // Asymmetric but within the 3*min > 2*max gate, so Toom-3 is still used.
+    // For min = 121, the gate requires 3*121 > 2*max, i.e., max < 181.5.
+    check_balanced(121, 180);
+    check_balanced(150, 200);
+    check_balanced(200, 250);
+}
+
+TEST(Multiplication, ToomCook3AsymmetricFallback) {
+    // Asymmetric beyond the gate: Toom-3 falls back to Karatsuba.
+    // These exercise the fallback path with both operands above the
+    // Toom-3 cutoff but with min <= 2*k.
+    check_balanced(120, 500);
+    check_balanced(150, 600);
+}
+
+TEST(Multiplication, ToomCook3Squaring) {
+    // a * a (same operand) at sizes that exercise Toom-3.
+    const std::string a = bmp::random_big_int(150 * limb_bits);
+    EXPECT_TRUE(bmp::check_cpp_int_equal(std::multiplies<>{}, a, a));
+
+    const std::string b = bmp::random_big_int(500 * limb_bits);
+    EXPECT_TRUE(bmp::check_cpp_int_equal(std::multiplies<>{}, b, b));
+}
+
+TEST(Multiplication, ToomCook3SignedOperands) {
+    // Negative operand handling is independent of the algorithm choice, but
+    // confirm the sign propagation works at Toom-3 sizes.
+    const std::string a = bmp::random_big_int(150 * limb_bits, /*negative=*/true);
+    const std::string b = bmp::random_big_int(150 * limb_bits, /*negative=*/false);
+    EXPECT_TRUE(bmp::check_cpp_int_equal(std::multiplies<>{}, a, b));
+
+    const std::string c = bmp::random_big_int(150 * limb_bits, /*negative=*/true);
+    const std::string d = bmp::random_big_int(150 * limb_bits, /*negative=*/true);
+    EXPECT_TRUE(bmp::check_cpp_int_equal(std::multiplies<>{}, c, d));
+}

--- a/tests/beman/big_int/toom_cook_3.test.cpp
+++ b/tests/beman/big_int/toom_cook_3.test.cpp
@@ -60,8 +60,8 @@ TEST(Multiplication, ToomCook3AsymmetricFallback) {
     // Asymmetric beyond the gate: Toom-3 falls back to Karatsuba even though
     // both operands clear the cutoff. min <= 2*k violates the invariant that
     // both a2 and b2 are non-empty.
-    check_balanced(800, 1500);  // k=500, 2k=1000 >= 800 -> fallback
-    check_balanced(900, 2000);  // k=667, 2k=1334 >= 900 -> fallback
+    check_balanced(800, 1500); // k=500, 2k=1000 >= 800 -> fallback
+    check_balanced(900, 2000); // k=667, 2k=1334 >= 900 -> fallback
 }
 
 TEST(Multiplication, ToomCook3Squaring) {

--- a/tests/beman/big_int/toom_cook_3.test.cpp
+++ b/tests/beman/big_int/toom_cook_3.test.cpp
@@ -11,7 +11,7 @@ namespace bmp = ::beman::big_int::boost_mp_testing;
 constexpr std::size_t limb_bits =
     static_cast<std::size_t>(std::numeric_limits<::beman::big_int::uint_multiprecision_t>::digits);
 
-// Toom-Cook 3 cutoff is 120 limbs. Tests around the boundary verify both
+// Toom-Cook 3 cutoff is 800 limbs. Tests around the boundary verify both
 // that the dispatcher correctly enters Toom-3 above the cutoff and that
 // the algorithm produces correct results for varying input sizes.
 
@@ -23,61 +23,64 @@ void check_balanced(const std::size_t limbs_a, const std::size_t limbs_b) {
 
 TEST(Multiplication, ToomCook3AtCutoff) {
     // Both operands exactly at the Toom-Cook 3 cutoff. Forces dispatch into
-    // Toom-3 with shallow recursion (k = 40, so all sub-products fall back
+    // Toom-3 with shallow recursion (k = 267, so all sub-products fall back
     // to Karatsuba).
-    check_balanced(120, 120);
+    check_balanced(800, 800);
 }
 
 TEST(Multiplication, ToomCook3JustAboveCutoff) {
-    check_balanced(121, 121);
-    check_balanced(125, 125);
+    check_balanced(801, 801);
+    check_balanced(850, 850);
 }
 
 TEST(Multiplication, ToomCook3JustBelowCutoff) {
-    // Both 119 limbs: dispatcher uses Karatsuba, not Toom-3. Sanity check
+    // Both 799 limbs: dispatcher uses Karatsuba, not Toom-3. Sanity check
     // that the cutoff gate works as expected.
-    check_balanced(119, 119);
+    check_balanced(799, 799);
 }
 
 TEST(Multiplication, ToomCook3DeepRecursion) {
-    // Large enough to drive multiple Toom-3 recursion levels.
-    check_balanced(400, 400);
-    check_balanced(1100, 1100);
+    // Large enough to drive multiple Toom-3 recursion levels. At cutoff 800,
+    // the inner products of a 2500-limb call have ~835 limbs each (still
+    // above the cutoff), giving two Toom-3 levels before the cascade drops
+    // into Karatsuba.
+    check_balanced(2500, 2500);
+    check_balanced(5000, 5000);
 }
 
 TEST(Multiplication, ToomCook3AsymmetricBalanced) {
-    // Asymmetric but within the 3*min > 2*max gate, so Toom-3 is still used.
-    // For min = 121, the gate requires 3*121 > 2*max, i.e., max < 181.5.
-    check_balanced(121, 180);
-    check_balanced(150, 200);
-    check_balanced(200, 250);
+    // Asymmetric but within the algorithm's min > 2*k gate, so Toom-3 is
+    // still used. For each pair, k = ceil(max/3) and we ensure min > 2*k.
+    check_balanced(850, 1200);  // k=400, 2k=800 < 850
+    check_balanced(1000, 1400); // k=467, 2k=934 < 1000
+    check_balanced(1500, 2100); // k=700, 2k=1400 < 1500
 }
 
 TEST(Multiplication, ToomCook3AsymmetricFallback) {
-    // Asymmetric beyond the gate: Toom-3 falls back to Karatsuba.
-    // These exercise the fallback path with both operands above the
-    // Toom-3 cutoff but with min <= 2*k.
-    check_balanced(120, 500);
-    check_balanced(150, 600);
+    // Asymmetric beyond the gate: Toom-3 falls back to Karatsuba even though
+    // both operands clear the cutoff. min <= 2*k violates the invariant that
+    // both a2 and b2 are non-empty.
+    check_balanced(800, 1500);  // k=500, 2k=1000 >= 800 -> fallback
+    check_balanced(900, 2000);  // k=667, 2k=1334 >= 900 -> fallback
 }
 
 TEST(Multiplication, ToomCook3Squaring) {
     // a * a (same operand) at sizes that exercise Toom-3.
-    const std::string a = bmp::random_big_int(150 * limb_bits);
+    const std::string a = bmp::random_big_int(1000 * limb_bits);
     EXPECT_TRUE(bmp::check_cpp_int_equal(std::multiplies<>{}, a, a));
 
-    const std::string b = bmp::random_big_int(500 * limb_bits);
+    const std::string b = bmp::random_big_int(2000 * limb_bits);
     EXPECT_TRUE(bmp::check_cpp_int_equal(std::multiplies<>{}, b, b));
 }
 
 TEST(Multiplication, ToomCook3SignedOperands) {
     // Negative operand handling is independent of the algorithm choice, but
     // confirm the sign propagation works at Toom-3 sizes.
-    const std::string a = bmp::random_big_int(150 * limb_bits, /*negative=*/true);
-    const std::string b = bmp::random_big_int(150 * limb_bits, /*negative=*/false);
+    const std::string a = bmp::random_big_int(1000 * limb_bits, /*negative=*/true);
+    const std::string b = bmp::random_big_int(1000 * limb_bits, /*negative=*/false);
     EXPECT_TRUE(bmp::check_cpp_int_equal(std::multiplies<>{}, a, b));
 
-    const std::string c = bmp::random_big_int(150 * limb_bits, /*negative=*/true);
-    const std::string d = bmp::random_big_int(150 * limb_bits, /*negative=*/true);
+    const std::string c = bmp::random_big_int(1000 * limb_bits, /*negative=*/true);
+    const std::string d = bmp::random_big_int(1000 * limb_bits, /*negative=*/true);
     EXPECT_TRUE(bmp::check_cpp_int_equal(std::multiplies<>{}, c, d));
 }

--- a/tests/beman/big_int/toom_cook_3_exercise.test.cpp
+++ b/tests/beman/big_int/toom_cook_3_exercise.test.cpp
@@ -16,9 +16,11 @@ using random_engine_length_type =
 
 random_engine_length_type generator_limb_length{static_cast<typename random_engine_length_type::result_type>(53)};
 
-// Toom-Cook 3 cutoff is 120 limbs. Sizes 130..400 exercise the algorithm
-// at depths 0..2 and force most calls to actually take the Toom-3 path.
-std::uniform_int_distribution distribution_limb_length{std::size_t{UINT16_C(130)}, std::size_t{UINT16_C(400)}};
+// Toom-Cook 3 cutoff is 800 limbs. Sizes 810..1500 exercise the algorithm:
+// balanced pairs enter Toom-3 directly, asymmetric pairs may fall back to
+// Karatsuba (min <= 2*k), so both paths get coverage.
+std::uniform_int_distribution distribution_limb_length{std::size_t{UINT16_C(810)},
+                                                       std::size_t{UINT16_C(1500)}};
 
 } // namespace detail
 
@@ -38,7 +40,9 @@ auto test_one_multiplication() -> void {
 } // namespace local
 
 TEST(Multiplication, ToomCook3Exercise01) {
-    constexpr unsigned trials{128U};
+    // Trial count reduced from 128 because each multiplication now operates
+    // on much larger (810-1500 limb) operands to clear the raised cutoff.
+    constexpr unsigned trials{32U};
 
     for (unsigned index{0U}; index < trials; ++index) {
         static_cast<void>(index);

--- a/tests/beman/big_int/toom_cook_3_exercise.test.cpp
+++ b/tests/beman/big_int/toom_cook_3_exercise.test.cpp
@@ -19,8 +19,7 @@ random_engine_length_type generator_limb_length{static_cast<typename random_engi
 // Toom-Cook 3 cutoff is 800 limbs. Sizes 810..1500 exercise the algorithm:
 // balanced pairs enter Toom-3 directly, asymmetric pairs may fall back to
 // Karatsuba (min <= 2*k), so both paths get coverage.
-std::uniform_int_distribution distribution_limb_length{std::size_t{UINT16_C(810)},
-                                                       std::size_t{UINT16_C(1500)}};
+std::uniform_int_distribution distribution_limb_length{std::size_t{UINT16_C(810)}, std::size_t{UINT16_C(1500)}};
 
 } // namespace detail
 

--- a/tests/beman/big_int/toom_cook_3_exercise.test.cpp
+++ b/tests/beman/big_int/toom_cook_3_exercise.test.cpp
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: BSL-1.0
+
+#include "boost_mp_testing.hpp"
+#include "testing.hpp"
+#include <gtest/gtest.h>
+
+namespace bmp = ::beman::big_int::boost_mp_testing;
+
+namespace local {
+
+namespace detail {
+
+using random_engine_length_type =
+    ::std::linear_congruential_engine<::std::uint32_t, UINT32_C(48271), UINT32_C(0), UINT32_C(2147483647)>;
+
+random_engine_length_type generator_limb_length{static_cast<typename random_engine_length_type::result_type>(53)};
+
+// Toom-Cook 3 cutoff is 120 limbs. Sizes 130..400 exercise the algorithm
+// at depths 0..2 and force most calls to actually take the Toom-3 path.
+std::uniform_int_distribution distribution_limb_length{std::size_t{UINT16_C(130)}, std::size_t{UINT16_C(400)}};
+
+} // namespace detail
+
+auto test_one_multiplication() -> void {
+    constexpr std::size_t limb_bits{
+        static_cast<std::size_t>(std::numeric_limits<::beman::big_int::uint_multiprecision_t>::digits)};
+
+    const std::size_t len_a_in_bits{detail::distribution_limb_length(detail::generator_limb_length) * limb_bits};
+    const std::size_t len_b_in_bits{detail::distribution_limb_length(detail::generator_limb_length) * limb_bits};
+
+    const std::string str_a{bmp::random_big_int(len_a_in_bits)};
+    const std::string str_b{bmp::random_big_int(len_b_in_bits)};
+
+    EXPECT_TRUE(bmp::check_cpp_int_equal(std::multiplies<>{}, str_a, str_b));
+}
+
+} // namespace local
+
+TEST(Multiplication, ToomCook3Exercise01) {
+    constexpr unsigned trials{128U};
+
+    for (unsigned index{0U}; index < trials; ++index) {
+        static_cast<void>(index);
+
+        local::test_one_multiplication();
+    }
+}

--- a/tests/beman/big_int/toom_cook_3_mersenne.test.cpp
+++ b/tests/beman/big_int/toom_cook_3_mersenne.test.cpp
@@ -60,11 +60,13 @@ auto run_one_mersenne(const unsigned p2) -> void {
 }
 
 // Mersenne primes large enough to drive multiple Toom-Cook 3 recursion levels.
-// At 64-bit limbs, p2/64 limbs are needed; at toom_cook_3_cutoff = 120 limbs
-// (~7680 bits), Toom-3 recursion engages and recurses while sub-products
-// remain above the cutoff.
-constexpr std::array<unsigned, std::size_t{4}> my_mersenne_powers_of_two{
-    13466917U, 20996011U, 24036583U, 30402457U};
+// At 64-bit limbs, p2/64 limbs are needed; at toom_cook_3_cutoff = 800 limbs
+// (~51200 bits), Toom-3 still recurses several levels for these exponents
+// (e.g. 13466917 bits = ~210k limbs, recurses ~5-6 levels before falling
+// through to Karatsuba). Dropped the two largest exponents from the
+// karatsuba-era list to keep test wall time under control now that each
+// Toom-3 step does more work below the higher cutoff.
+constexpr std::array<unsigned, std::size_t{2}> my_mersenne_powers_of_two{13466917U, 20996011U};
 
 } // namespace local
 
@@ -76,12 +78,4 @@ TEST(Multiplication, ToomCook3Mersenne00) {
 
 TEST(Multiplication, ToomCook3Mersenne01) {
     local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{1}]);
-}
-
-TEST(Multiplication, ToomCook3Mersenne02) {
-    local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{2}]);
-}
-
-TEST(Multiplication, ToomCook3Mersenne03) {
-    local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{3}]);
 }

--- a/tests/beman/big_int/toom_cook_3_mersenne.test.cpp
+++ b/tests/beman/big_int/toom_cook_3_mersenne.test.cpp
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: BSL-1.0
+
+#include "testing.hpp"
+#include <boost/multiprecision/cpp_int.hpp>
+#include <beman/big_int/big_int.hpp>
+#include <gtest/gtest.h>
+#include <array>
+#include <span>
+
+namespace local {
+
+auto run_one_mersenne(const unsigned p2) -> void {
+    using cpp_int_type =
+        boost::multiprecision::number<boost::multiprecision::cpp_int_backend<>, boost::multiprecision::et_off>;
+    using big_int_type = beman::big_int::big_int;
+
+    // Mersenne value (2^p2 - 1) computed via square-and-multiply pow().
+    // The exponents below produce limb counts well above the Toom-Cook 3
+    // cutoff (120) at multiple recursion depths.
+
+    const cpp_int_type cpp_int_two{2};
+    const cpp_int_type cpp_int_mersenne{cpp_int_type{beman::big_int::pow(cpp_int_two, p2)} - 1};
+
+    const big_int_type big_int_two{2};
+    const big_int_type big_int_mersenne{big_int_type{beman::big_int::pow(big_int_two, p2)} - 1};
+
+    const std::span<const ::boost::multiprecision::limb_type> cpp_int_rep{cpp_int_mersenne.backend().limbs(),
+                                                                          cpp_int_mersenne.backend().size()};
+    const auto big_int_bytes = std::as_bytes(big_int_mersenne.representation());
+    const auto cpp_int_bytes = std::as_bytes(cpp_int_rep);
+
+    const auto big_int_sig = beman::big_int::significant_byte_len(big_int_bytes);
+    const auto cpp_int_sig = beman::big_int::significant_byte_len(cpp_int_bytes);
+
+    const bool result_length_is_ok{big_int_sig == cpp_int_sig};
+
+    EXPECT_TRUE(result_length_is_ok);
+
+    bool result_is_ok{result_length_is_ok};
+
+    bool result_bytes_same_is_ok{false};
+
+    if (result_is_ok) {
+        for (std::size_t i = 0; i < big_int_sig; ++i) {
+            if (big_int_bytes[i] != cpp_int_bytes[i]) {
+                result_bytes_same_is_ok = false;
+                break;
+            } else {
+                result_bytes_same_is_ok = true;
+            }
+        }
+    }
+
+    EXPECT_TRUE(result_bytes_same_is_ok);
+
+    result_is_ok = (result_bytes_same_is_ok && result_is_ok);
+
+    EXPECT_TRUE(result_is_ok);
+}
+
+// Mersenne primes large enough to drive multiple Toom-Cook 3 recursion levels.
+// At 64-bit limbs, p2/64 limbs are needed; at toom_cook_3_cutoff = 120 limbs
+// (~7680 bits), Toom-3 recursion engages and recurses while sub-products
+// remain above the cutoff.
+constexpr std::array<unsigned, std::size_t{4}> my_mersenne_powers_of_two{
+    13466917U, 20996011U, 24036583U, 30402457U};
+
+} // namespace local
+
+// See also https://oeis.org/A057429 sequences of Mersenne primes.
+
+TEST(Multiplication, ToomCook3Mersenne00) {
+    local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{0}]);
+}
+
+TEST(Multiplication, ToomCook3Mersenne01) {
+    local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{1}]);
+}
+
+TEST(Multiplication, ToomCook3Mersenne02) {
+    local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{2}]);
+}
+
+TEST(Multiplication, ToomCook3Mersenne03) {
+    local::run_one_mersenne(local::my_mersenne_powers_of_two[std::size_t{3}]);
+}


### PR DESCRIPTION
Adds Toom-Cook 3 multiplication algorithm. Using a stress testing file for tuning I found that the Schoolbook / Karatsuba is dead on at 40 from boost, and that the Karatsuba / Toom-Cook 3 crossover point is 800 limbs. 

CC: @ckormanyos 

Closes: #207 