### PR TITLE
Implement support for `std::hash`

### DIFF
--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -3984,7 +3984,6 @@ struct std::hash<beman::big_int::basic_big_int<b, A>> {
     std::size_t operator()(const beman::big_int::basic_big_int<b, A>& x) const noexcept {
         return beman::big_int::detail::siphash(x.representation());
     }
-
 };
 
 // A convenience macro rather than calling a stateless lambda

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -17,6 +17,7 @@
 #include <ranges>
 #include <span>
 #include <string>
+#include <utility>
 
 #if __has_include(<stdfloat>)
     #include <stdfloat>
@@ -28,6 +29,7 @@
 #include <beman/big_int/detail/floats.hpp>
 #include <beman/big_int/detail/mul_impl.hpp>
 #include <beman/big_int/detail/wide_ops.hpp>
+#include <beman/big_int/detail/siphash.hpp>
 
 BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
 BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Warray-bounds") // This causes way too many problems.
@@ -3975,7 +3977,15 @@ BEMAN_BIG_INT_DIAGNOSTIC_POP()
 } // namespace literals
 } // namespace beman::big_int
 
-BEMAN_BIG_INT_DIAGNOSTIC_POP()
+// [big.int.hash], hash support
+template <std::size_t b, class A>
+struct std::hash<beman::big_int::basic_big_int<b, A>> {
+
+    std::size_t operator()(const beman::big_int::basic_big_int<b, A>& x) const noexcept {
+        return beman::big_int::detail::siphash(x.representation());
+    }
+
+};
 
 // A convenience macro rather than calling a stateless lambda
 #define BEMAN_BIG_INT_COPY_TO_RUNTIME(...) \

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -275,6 +275,8 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     template <size_t b, class A>
     friend constexpr std::to_chars_result to_chars(char*, char*, const basic_big_int<b, A>&, int);
 
+    friend struct ::std::hash<basic_big_int>;
+
   private:
     using alloc_traits = std::allocator_traits<Allocator>;
     using alloc_result = detail::allocation_result<pointer>;
@@ -3982,7 +3984,7 @@ template <std::size_t b, class A>
 struct std::hash<beman::big_int::basic_big_int<b, A>> {
 
     std::size_t operator()(const beman::big_int::basic_big_int<b, A>& x) const noexcept {
-        return beman::big_int::detail::siphash(x.representation());
+        return beman::big_int::detail::siphash(x.representation(), x.is_negative());
     }
 };
 

--- a/include/beman/big_int/detail/siphash.hpp
+++ b/include/beman/big_int/detail/siphash.hpp
@@ -83,7 +83,7 @@ constexpr std::size_t siphash(const std::span<const uint_multiprecision_t> limbs
         for (std::size_t i = 0; i < pairs; ++i) {
             auto m = static_cast<std::uint64_t>(limbs[i * 2]) |
                      (static_cast<std::uint64_t>(limbs[i * 2 + 1]) << 32);
-            s = compress(s, m);
+            s      = compress(s, m);
         }
         // Odd trailing uint_multiprecision_t folds into the final block
     }
@@ -110,7 +110,7 @@ constexpr std::size_t siphash(const std::span<const uint_multiprecision_t> limbs
     if constexpr (sizeof(std::size_t) == sizeof(std::uint64_t)) {
         return h;
     } else {
-        return static_cast<std::size_t>(h ^ (h >> 32U));
+        return h ^ (h >> 32U);
     }
 }
 

--- a/include/beman/big_int/detail/siphash.hpp
+++ b/include/beman/big_int/detail/siphash.hpp
@@ -34,7 +34,8 @@ constexpr void sipround(std::uint64_t& v0, std::uint64_t& v1, std::uint64_t& v2,
     v2 = std::rotl(v2, 32);
 }
 
-constexpr void compress(std::uint64_t& v0, std::uint64_t& v1, std::uint64_t& v2, std::uint64_t& v3, const std::uint64_t m) {
+constexpr void
+compress(std::uint64_t& v0, std::uint64_t& v1, std::uint64_t& v2, std::uint64_t& v3, const std::uint64_t m) {
     v3 ^= m;
 
     sipround(v0, v1, v2, v3);
@@ -47,12 +48,11 @@ constexpr void compress(std::uint64_t& v0, std::uint64_t& v1, std::uint64_t& v2,
 
 constexpr std::size_t siphash(const std::span<const uint_multiprecision_t> limbs) {
 
-    using impl::sipround;
     using impl::compress;
+    using impl::sipround;
 
     constexpr auto k0 = 0x0706050403020100ULL;
     constexpr auto k1 = 0x0f0e0d0c0b0a0908ULL;
-    
     auto v0 = 0x736f6d6570736575ULL ^ k0;
     auto v1 = 0x646f72616e646f6dULL ^ k1;
     auto v2 = 0x6c7967656e657261ULL ^ k0;

--- a/include/beman/big_int/detail/siphash.hpp
+++ b/include/beman/big_int/detail/siphash.hpp
@@ -64,26 +64,27 @@ constexpr std::size_t siphash(const std::span<const uint_multiprecision_t> limbs
     }
 
     const auto byte_len = limbs.size() * sizeof(uint_multiprecision_t);
-
-    if constexpr (std::same_as<uint_multiprecision_t, uint64_t>) {
+    
+    if constexpr (sizeof(uint_multiprecision_t) == sizeof(std::uint64_t)) {
         for (const auto m : limbs) {
-            compress(v0, v1, v2, v3, m);
+            compress(v0, v1, v2, v3, static_cast<std::uint64_t>(m));
         }
     } else {
         // Pack pairs of uint32_t into uint64_t words
         const auto pairs = limbs.size() / 2;
         for (std::size_t i = 0; i < pairs; ++i) {
-            auto m = limbs[i * 2] | (static_cast<uint64_t>(limbs[i * 2 + 1]) << 32);
+            auto m = static_cast<std::uint64_t>(limbs[i * 2]) |
+                     (static_cast<std::uint64_t>(limbs[i * 2 + 1]) << 32);
             compress(v0, v1, v2, v3, m);
         }
         // Odd trailing uint_multiprecision_t folds into the final block
     }
 
     // Final block: length in high byte + possible trailing uint32_t
-    auto b = static_cast<uint64_t>(byte_len) << 56;
-    if constexpr (std::same_as<uint_multiprecision_t, uint32_t>) {
+    auto b = static_cast<std::uint64_t>(byte_len) << 56;
+    if constexpr (sizeof(uint_multiprecision_t) == sizeof(std::uint32_t)) {
         if (limbs.size() & 1) {
-            b |= limbs.back();
+            b |= static_cast<std::uint64_t>(limbs.back());
         }
     }
 

--- a/include/beman/big_int/detail/siphash.hpp
+++ b/include/beman/big_int/detail/siphash.hpp
@@ -46,7 +46,7 @@ compress(std::uint64_t& v0, std::uint64_t& v1, std::uint64_t& v2, std::uint64_t&
 
 } // namespace impl
 
-constexpr std::size_t siphash(const std::span<const uint_multiprecision_t> limbs) {
+constexpr std::size_t siphash(const std::span<const uint_multiprecision_t> limbs, const bool sign) {
 
     using impl::compress;
     using impl::sipround;
@@ -58,6 +58,11 @@ constexpr std::size_t siphash(const std::span<const uint_multiprecision_t> limbs
     std::uint64_t v1 = 0x646f72616e646f6dULL ^ k1;
     std::uint64_t v2 = 0x6c7967656e657261ULL ^ k0;
     std::uint64_t v3 = 0x7465646279746573ULL ^ k1;
+
+    // Fold the sign into the initial state so it propagates through every round
+    if (sign) {
+        v3 ^= std::numeric_limits<std::uint64_t>::max();
+    }
 
     const auto byte_len = limbs.size() * sizeof(uint_multiprecision_t);
 

--- a/include/beman/big_int/detail/siphash.hpp
+++ b/include/beman/big_int/detail/siphash.hpp
@@ -53,10 +53,10 @@ constexpr std::size_t siphash(const std::span<const uint_multiprecision_t> limbs
 
     constexpr auto k0 = 0x0706050403020100ULL;
     constexpr auto k1 = 0x0f0e0d0c0b0a0908ULL;
-    auto v0 = 0x736f6d6570736575ULL ^ k0;
-    auto v1 = 0x646f72616e646f6dULL ^ k1;
-    auto v2 = 0x6c7967656e657261ULL ^ k0;
-    auto v3 = 0x7465646279746573ULL ^ k1;
+    auto           v0 = 0x736f6d6570736575ULL ^ k0;
+    auto           v1 = 0x646f72616e646f6dULL ^ k1;
+    auto           v2 = 0x6c7967656e657261ULL ^ k0;
+    auto           v3 = 0x7465646279746573ULL ^ k1;
 
     const auto byte_len = limbs.size() * sizeof(uint_multiprecision_t);
 

--- a/include/beman/big_int/detail/siphash.hpp
+++ b/include/beman/big_int/detail/siphash.hpp
@@ -51,12 +51,13 @@ constexpr std::size_t siphash(const std::span<const uint_multiprecision_t> limbs
     using impl::compress;
     using impl::sipround;
 
-    constexpr auto k0 = 0x0706050403020100ULL;
-    constexpr auto k1 = 0x0f0e0d0c0b0a0908ULL;
-    auto           v0 = 0x736f6d6570736575ULL ^ k0;
-    auto           v1 = 0x646f72616e646f6dULL ^ k1;
-    auto           v2 = 0x6c7967656e657261ULL ^ k0;
-    auto           v3 = 0x7465646279746573ULL ^ k1;
+    constexpr std::uint64_t k0 = 0x0706050403020100ULL;
+    constexpr std::uint64_t k1 = 0x0f0e0d0c0b0a0908ULL;
+    
+    std::uint64_t v0 = 0x736f6d6570736575ULL ^ k0;
+    std::uint64_t v1 = 0x646f72616e646f6dULL ^ k1;
+    std::uint64_t v2 = 0x6c7967656e657261ULL ^ k0;
+    std::uint64_t v3 = 0x7465646279746573ULL ^ k1;
 
     const auto byte_len = limbs.size() * sizeof(uint_multiprecision_t);
 

--- a/include/beman/big_int/detail/siphash.hpp
+++ b/include/beman/big_int/detail/siphash.hpp
@@ -53,7 +53,6 @@ constexpr std::size_t siphash(const std::span<const uint_multiprecision_t> limbs
 
     constexpr std::uint64_t k0 = 0x0706050403020100ULL;
     constexpr std::uint64_t k1 = 0x0f0e0d0c0b0a0908ULL;
-    
     std::uint64_t v0 = 0x736f6d6570736575ULL ^ k0;
     std::uint64_t v1 = 0x646f72616e646f6dULL ^ k1;
     std::uint64_t v2 = 0x6c7967656e657261ULL ^ k0;

--- a/include/beman/big_int/detail/siphash.hpp
+++ b/include/beman/big_int/detail/siphash.hpp
@@ -12,36 +12,42 @@
 
 namespace beman::big_int::detail {
 
+struct state_holder {
+    std::uint64_t v0;
+    std::uint64_t v1;
+    std::uint64_t v2;
+    std::uint64_t v3;
+};
+
 namespace impl {
 
-constexpr void sipround(std::uint64_t& v0, std::uint64_t& v1, std::uint64_t& v2, std::uint64_t& v3) {
-    v0 += v1;
-    v1 = std::rotl(v1, 13);
-    v1 ^= v0;
-    v0 = std::rotl(v0, 32);
+constexpr state_holder sipround(state_holder s) {
+    s.v0 += s.v1;
+    s.v1 = std::rotl(s.v1, 13);
+    s.v1 ^= s.v0;
+    s.v0 = std::rotl(s.v0, 32);
 
-    v2 += v3;
-    v3 = std::rotl(v3, 16);
-    v3 ^= v2;
+    s.v2 += s.v3;
+    s.v3 = std::rotl(s.v3, 16);
+    s.v3 ^= s.v2;
 
-    v0 += v3;
-    v3 = std::rotl(v3, 21);
-    v3 ^= v0;
+    s.v0 += s.v3;
+    s.v3 = std::rotl(s.v3, 21);
+    s.v3 ^= s.v0;
 
-    v2 += v1;
-    v1 = std::rotl(v1, 17);
-    v1 ^= v2;
-    v2 = std::rotl(v2, 32);
+    s.v2 += s.v1;
+    s.v1 = std::rotl(s.v1, 17);
+    s.v1 ^= s.v2;
+    s.v2 = std::rotl(s.v2, 32);
+    return s;
 }
 
-constexpr void
-compress(std::uint64_t& v0, std::uint64_t& v1, std::uint64_t& v2, std::uint64_t& v3, const std::uint64_t m) {
-    v3 ^= m;
-
-    sipround(v0, v1, v2, v3);
-    sipround(v0, v1, v2, v3);
-
-    v0 ^= m;
+constexpr state_holder compress(state_holder s, const std::uint64_t m) {
+    s.v3 ^= m;
+    s = sipround(s);
+    s = sipround(s);
+    s.v0 ^= m;
+    return s;
 }
 
 } // namespace impl
@@ -53,21 +59,23 @@ constexpr std::size_t siphash(const std::span<const uint_multiprecision_t> limbs
 
     constexpr std::uint64_t k0 = 0x0706050403020100ULL;
     constexpr std::uint64_t k1 = 0x0f0e0d0c0b0a0908ULL;
-    std::uint64_t           v0 = 0x736f6d6570736575ULL ^ k0;
-    std::uint64_t           v1 = 0x646f72616e646f6dULL ^ k1;
-    std::uint64_t           v2 = 0x6c7967656e657261ULL ^ k0;
-    std::uint64_t           v3 = 0x7465646279746573ULL ^ k1;
+    state_holder            s{
+        0x736f6d6570736575ULL ^ k0,
+        0x646f72616e646f6dULL ^ k1,
+        0x6c7967656e657261ULL ^ k0,
+        0x7465646279746573ULL ^ k1,
+    };
 
     // Fold the sign into the initial state so it propagates through every round
     if (sign) {
-        v3 ^= std::numeric_limits<std::uint64_t>::max();
+        s.v3 ^= std::numeric_limits<std::uint64_t>::max();
     }
 
     const auto byte_len = limbs.size() * sizeof(uint_multiprecision_t);
-    
+
     if constexpr (sizeof(uint_multiprecision_t) == sizeof(std::uint64_t)) {
         for (const auto m : limbs) {
-            compress(v0, v1, v2, v3, static_cast<std::uint64_t>(m));
+            s = compress(s, static_cast<std::uint64_t>(m));
         }
     } else {
         // Pack pairs of uint32_t into uint64_t words
@@ -75,7 +83,7 @@ constexpr std::size_t siphash(const std::span<const uint_multiprecision_t> limbs
         for (std::size_t i = 0; i < pairs; ++i) {
             auto m = static_cast<std::uint64_t>(limbs[i * 2]) |
                      (static_cast<std::uint64_t>(limbs[i * 2 + 1]) << 32);
-            compress(v0, v1, v2, v3, m);
+            s = compress(s, m);
         }
         // Odd trailing uint_multiprecision_t folds into the final block
     }
@@ -88,16 +96,16 @@ constexpr std::size_t siphash(const std::span<const uint_multiprecision_t> limbs
         }
     }
 
-    compress(v0, v1, v2, v3, b);
+    s = compress(s, b);
 
-    v2 ^= 0xFFULL;
+    s.v2 ^= 0xFFULL;
 
-    sipround(v0, v1, v2, v3);
-    sipround(v0, v1, v2, v3);
-    sipround(v0, v1, v2, v3);
-    sipround(v0, v1, v2, v3);
+    s = sipround(s);
+    s = sipround(s);
+    s = sipround(s);
+    s = sipround(s);
 
-    const auto h = v0 ^ v1 ^ v2 ^ v3;
+    const auto h = s.v0 ^ s.v1 ^ s.v2 ^ s.v3;
 
     if constexpr (sizeof(std::size_t) == sizeof(std::uint64_t)) {
         return h;

--- a/include/beman/big_int/detail/siphash.hpp
+++ b/include/beman/big_int/detail/siphash.hpp
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: BSL-1.0
+
+#ifndef BEMAN_BIG_INT_SIPHASH_HPP
+#define BEMAN_BIG_INT_SIPHASH_HPP
+
+#include <beman/big_int/detail/config.hpp>
+#include <cstdint>
+#include <cstddef>
+#include <bit>
+#include <span>
+
+namespace beman::big_int::detail {
+
+constexpr void sipround(std::uint64_t& v0, std::uint64_t& v1, std::uint64_t& v2, std::uint64_t& v3) {
+    v0 += v1;
+    v1 = std::rotl(v1, 13);
+    v1 ^= v0;
+    v0 = std::rotl(v0, 32);
+
+    v2 += v3;
+    v3 = std::rotl(v3, 16);
+    v3 ^= v2;
+
+    v0 += v3;
+    v3 = std::rotl(v3, 21);
+    v3 ^= v0;
+
+    v2 += v1;
+    v1 = std::rotl(v1, 17);
+    v1 ^= v2;
+    v2 = std::rotl(v2, 32);
+}
+
+constexpr void compress(std::uint64_t& v0, std::uint64_t& v1, std::uint64_t& v2, std::uint64_t& v3, const std::uint64_t m) {
+    v3 ^= m;
+
+    sipround(v0, v1, v2, v3);
+    sipround(v0, v1, v2, v3);
+
+    v0 ^= m;
+}
+
+constexpr std::uint64_t siphash(const std::span<const uint_multiprecision_t> limbs) {
+
+    constexpr auto k0 = 0x0706050403020100ULL;
+    constexpr auto k1 = 0x0f0e0d0c0b0a0908ULL;
+    
+    auto v0 = 0x736f6d6570736575ULL ^ k0;
+    auto v1 = 0x646f72616e646f6dULL ^ k1;
+    auto v2 = 0x6c7967656e657261ULL ^ k0;
+    auto v3 = 0x7465646279746573ULL ^ k1;
+
+    const auto byte_len = limbs.size() * sizeof(uint_multiprecision_t);
+
+    if constexpr (std::same_as<uint_multiprecision_t, uint64_t>) {
+        for (const auto m : limbs) {
+            compress(v0, v1, v2, v3, m);
+        }
+    } else {
+        // Pack pairs of uint32_t into uint64_t words
+        const auto pairs = limbs.size() / 2;
+        for (std::size_t i = 0; i < pairs; ++i) {
+            auto m = limbs[i * 2] | (static_cast<uint64_t>(limbs[i * 2 + 1]) << 32);
+            compress(v0, v1, v2, v3, m);
+        }
+        // Odd trailing uint_multiprecision_t folds into the final block
+    }
+
+    // Final block: length in high byte + possible trailing uint32_t
+    auto b = static_cast<uint64_t>(byte_len) << 56;
+    if constexpr (std::same_as<uint_multiprecision_t, uint32_t>) {
+        if (limbs.size() & 1) {
+            b |= limbs.back();
+        }
+    }
+
+    compress(v0, v1, v2, v3, b);
+
+    v2 ^= 0xFFULL;
+
+    sipround(v0, v1, v2, v3);
+    sipround(v0, v1, v2, v3);
+    sipround(v0, v1, v2, v3);
+    sipround(v0, v1, v2, v3);
+
+    return v0 ^ v1 ^ v2 ^ v3;
+}
+
+} // namespace beman::big_int::detail
+
+#endif // BEMAN_BIG_INT_SIPHASH_HPP

--- a/include/beman/big_int/detail/siphash.hpp
+++ b/include/beman/big_int/detail/siphash.hpp
@@ -12,6 +12,8 @@
 
 namespace beman::big_int::detail {
 
+namespace impl {
+
 constexpr void sipround(std::uint64_t& v0, std::uint64_t& v1, std::uint64_t& v2, std::uint64_t& v3) {
     v0 += v1;
     v1 = std::rotl(v1, 13);
@@ -41,7 +43,12 @@ constexpr void compress(std::uint64_t& v0, std::uint64_t& v1, std::uint64_t& v2,
     v0 ^= m;
 }
 
-constexpr std::uint64_t siphash(const std::span<const uint_multiprecision_t> limbs) {
+} // namespace impl
+
+constexpr std::size_t siphash(const std::span<const uint_multiprecision_t> limbs) {
+
+    using impl::sipround;
+    using impl::compress;
 
     constexpr auto k0 = 0x0706050403020100ULL;
     constexpr auto k1 = 0x0f0e0d0c0b0a0908ULL;
@@ -84,7 +91,13 @@ constexpr std::uint64_t siphash(const std::span<const uint_multiprecision_t> lim
     sipround(v0, v1, v2, v3);
     sipround(v0, v1, v2, v3);
 
-    return v0 ^ v1 ^ v2 ^ v3;
+    const auto h = v0 ^ v1 ^ v2 ^ v3;
+
+    if constexpr (sizeof(std::size_t) == sizeof(std::uint64_t)) {
+        return h;
+    } else {
+        return static_cast<std::size_t>(h ^ (h >> 32U));
+    }
 }
 
 } // namespace beman::big_int::detail

--- a/include/beman/big_int/detail/siphash.hpp
+++ b/include/beman/big_int/detail/siphash.hpp
@@ -53,10 +53,10 @@ constexpr std::size_t siphash(const std::span<const uint_multiprecision_t> limbs
 
     constexpr std::uint64_t k0 = 0x0706050403020100ULL;
     constexpr std::uint64_t k1 = 0x0f0e0d0c0b0a0908ULL;
-    std::uint64_t v0 = 0x736f6d6570736575ULL ^ k0;
-    std::uint64_t v1 = 0x646f72616e646f6dULL ^ k1;
-    std::uint64_t v2 = 0x6c7967656e657261ULL ^ k0;
-    std::uint64_t v3 = 0x7465646279746573ULL ^ k1;
+    std::uint64_t           v0 = 0x736f6d6570736575ULL ^ k0;
+    std::uint64_t           v1 = 0x646f72616e646f6dULL ^ k1;
+    std::uint64_t           v2 = 0x6c7967656e657261ULL ^ k0;
+    std::uint64_t           v3 = 0x7465646279746573ULL ^ k1;
 
     // Fold the sign into the initial state so it propagates through every round
     if (sign) {

--- a/include/beman/big_int/detail/siphash.hpp
+++ b/include/beman/big_int/detail/siphash.hpp
@@ -81,8 +81,7 @@ constexpr std::size_t siphash(const std::span<const uint_multiprecision_t> limbs
         // Pack pairs of uint32_t into uint64_t words
         const auto pairs = limbs.size() / 2;
         for (std::size_t i = 0; i < pairs; ++i) {
-            auto m = static_cast<std::uint64_t>(limbs[i * 2]) |
-                     (static_cast<std::uint64_t>(limbs[i * 2 + 1]) << 32);
+            auto m = static_cast<std::uint64_t>(limbs[i * 2]) | (static_cast<std::uint64_t>(limbs[i * 2 + 1]) << 32);
             s      = compress(s, m);
         }
         // Odd trailing uint_multiprecision_t folds into the final block

--- a/tests/beman/big_int/hash.test.cpp
+++ b/tests/beman/big_int/hash.test.cpp
@@ -40,8 +40,7 @@ static_assert(std::is_nothrow_invocable_r_v<std::size_t, std::hash<big_int>, con
 static_assert(std::is_default_constructible_v<std::hash<basic_big_int<32>>>);
 static_assert(std::is_default_constructible_v<std::hash<basic_big_int<256>>>);
 static_assert(std::is_default_constructible_v<std::hash<basic_big_int<1024>>>);
-static_assert(
-    std::is_nothrow_invocable_r_v<std::size_t, std::hash<basic_big_int<256>>, const basic_big_int<256>&>);
+static_assert(std::is_nothrow_invocable_r_v<std::size_t, std::hash<basic_big_int<256>>, const basic_big_int<256>&>);
 
 // ----- Determinism: hashing the same value twice yields the same hash -----
 
@@ -91,7 +90,7 @@ TEST(Hash, EqualValuesFromCopy) {
 
 TEST(Hash, EqualValuesAfterMove) {
     const std::hash<big_int> h{};
-    big_int                  a = 0xDEAD'BEEF'CAFE'BABE'1234'5678'90AB'CDEF_n;
+    big_int                  a        = 0xDEAD'BEEF'CAFE'BABE'1234'5678'90AB'CDEF_n;
     const std::size_t        expected = h(a);
     const big_int            b{std::move(a)};
     EXPECT_EQ(h(b), expected);
@@ -113,7 +112,7 @@ TEST(Hash, EqualValuesAfterArithmetic) {
 
 TEST(Hash, EqualMultiLimbAfterArithmetic) {
     const std::hash<big_int> h{};
-    const big_int            big = 1_n << 200;
+    const big_int            big        = 1_n << 200;
     const big_int            also_big_a = big + big_int{0};
     const big_int            also_big_b = (big_int{1} << 199) * big_int{2};
     ASSERT_EQ(big, also_big_a);
@@ -169,9 +168,9 @@ TEST(Hash, DistinctValuesFromOneToTwoFiftySix) {
 TEST(Hash, DistinctMultiLimbValues) {
     const std::hash<big_int> h{};
     const big_int            base = big_int{1} << 200;
-    const big_int            a = base + big_int{1};
-    const big_int            b = base + big_int{2};
-    const big_int            c = (big_int{1} << 201) + big_int{1};
+    const big_int            a    = base + big_int{1};
+    const big_int            b    = base + big_int{2};
+    const big_int            c    = (big_int{1} << 201) + big_int{1};
     EXPECT_NE(h(a), h(b));
     EXPECT_NE(h(a), h(c));
     EXPECT_NE(h(b), h(c));
@@ -280,9 +279,9 @@ TEST(Hash, UnorderedMapBigIntKey) {
     std::unordered_map<big_int, int> m;
     const big_int                    k1 = 10'000'000'000'000'000'000'000_n;
     const big_int                    k2 = 20'000'000'000'000'000'000'000_n;
-    m[k1] = 1;
-    m[k2] = 2;
-    m[k1] = 11; // overwrite
+    m[k1]                               = 1;
+    m[k2]                               = 2;
+    m[k1]                               = 11; // overwrite
     EXPECT_EQ(m.size(), 2U);
     EXPECT_EQ(m.at(k1), 11);
     EXPECT_EQ(m.at(k2), 2);

--- a/tests/beman/big_int/hash.test.cpp
+++ b/tests/beman/big_int/hash.test.cpp
@@ -305,9 +305,9 @@ TEST(Hash, SignDistinguishesAcrossInplaceBits) {
 
 TEST(Hash, NegatingTwiceRestoresHash) {
     const std::hash<big_int> h{};
-    const big_int            x = (big_int{1} << 100) + big_int{7};
+    const big_int            x        = (big_int{1} << 100) + big_int{7};
     const std::size_t        original = h(x);
-    const big_int            negated = -x;
+    const big_int            negated  = -x;
     EXPECT_NE(original, h(negated));
     EXPECT_EQ(original, h(-negated));
 }

--- a/tests/beman/big_int/hash.test.cpp
+++ b/tests/beman/big_int/hash.test.cpp
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: BSL-1.0
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <beman/big_int/big_int.hpp>
+
+#include "testing.hpp"
+
+namespace {
+
+using beman::big_int::basic_big_int;
+using beman::big_int::big_int;
+using namespace beman::big_int::literals;
+
+// ----- Type-level checks for the std::hash specialization -----
+
+static_assert(std::is_default_constructible_v<std::hash<big_int>>);
+static_assert(std::is_copy_constructible_v<std::hash<big_int>>);
+static_assert(std::is_copy_assignable_v<std::hash<big_int>>);
+static_assert(std::is_move_constructible_v<std::hash<big_int>>);
+static_assert(std::is_move_assignable_v<std::hash<big_int>>);
+static_assert(std::is_destructible_v<std::hash<big_int>>);
+static_assert(std::is_swappable_v<std::hash<big_int>>);
+
+static_assert(std::is_invocable_r_v<std::size_t, std::hash<big_int>, const big_int&>);
+static_assert(std::is_nothrow_invocable_r_v<std::size_t, std::hash<big_int>, const big_int&>);
+
+// The specialization must work for any inplace_bits / allocator parameterization,
+// not just the convenience alias.
+static_assert(std::is_default_constructible_v<std::hash<basic_big_int<32>>>);
+static_assert(std::is_default_constructible_v<std::hash<basic_big_int<256>>>);
+static_assert(std::is_default_constructible_v<std::hash<basic_big_int<1024>>>);
+static_assert(
+    std::is_nothrow_invocable_r_v<std::size_t, std::hash<basic_big_int<256>>, const basic_big_int<256>&>);
+
+// ----- Determinism: hashing the same value twice yields the same hash -----
+
+TEST(Hash, DeterminismSmall) {
+    const std::hash<big_int> h{};
+    const big_int            x{42};
+    EXPECT_EQ(h(x), h(x));
+}
+
+TEST(Hash, DeterminismZero) {
+    const std::hash<big_int> h{};
+    const big_int            x{};
+    EXPECT_EQ(h(x), h(x));
+}
+
+TEST(Hash, DeterminismMultiLimb) {
+    const std::hash<big_int> h{};
+    const big_int            x = 12345678901234567890123456789012345678901234567890_n;
+    EXPECT_EQ(h(x), h(x));
+}
+
+TEST(Hash, DeterminismAcrossInstances) {
+    // A freshly-constructed std::hash instance must agree with another instance.
+    const std::hash<big_int> h1{};
+    const std::hash<big_int> h2{};
+    const big_int            x = 0xCAFE'BABE'DEAD'BEEF_n;
+    EXPECT_EQ(h1(x), h2(x));
+}
+
+// ----- Equal values produce equal hashes (the only contract requirement) -----
+
+TEST(Hash, EqualValuesHashEqually) {
+    const std::hash<big_int> h{};
+    const big_int            a{12345};
+    const big_int            b{12345};
+    ASSERT_EQ(a, b);
+    EXPECT_EQ(h(a), h(b));
+}
+
+TEST(Hash, EqualValuesFromCopy) {
+    const std::hash<big_int> h{};
+    const big_int            a = 1'000'000'000'000'000'000_n;
+    const big_int            b{a};
+    ASSERT_EQ(a, b);
+    EXPECT_EQ(h(a), h(b));
+}
+
+TEST(Hash, EqualValuesAfterMove) {
+    const std::hash<big_int> h{};
+    big_int                  a = 0xDEAD'BEEF'CAFE'BABE'1234'5678'90AB'CDEF_n;
+    const std::size_t        expected = h(a);
+    const big_int            b{std::move(a)};
+    EXPECT_EQ(h(b), expected);
+}
+
+TEST(Hash, EqualValuesAfterArithmetic) {
+    const std::hash<big_int> h{};
+    const big_int            a{1000};
+    const big_int            b = big_int{700} + big_int{300};
+    const big_int            c = big_int{2000} - big_int{1000};
+    const big_int            d = big_int{500} * big_int{2};
+    ASSERT_EQ(a, b);
+    ASSERT_EQ(a, c);
+    ASSERT_EQ(a, d);
+    EXPECT_EQ(h(a), h(b));
+    EXPECT_EQ(h(a), h(c));
+    EXPECT_EQ(h(a), h(d));
+}
+
+TEST(Hash, EqualMultiLimbAfterArithmetic) {
+    const std::hash<big_int> h{};
+    const big_int            big = 1_n << 200;
+    const big_int            also_big_a = big + big_int{0};
+    const big_int            also_big_b = (big_int{1} << 199) * big_int{2};
+    ASSERT_EQ(big, also_big_a);
+    ASSERT_EQ(big, also_big_b);
+    EXPECT_EQ(h(big), h(also_big_a));
+    EXPECT_EQ(h(big), h(also_big_b));
+}
+
+// ----- Zero is well-defined -----
+
+TEST(Hash, ZeroIsConsistent) {
+    const std::hash<big_int> h{};
+    const big_int            z_default{};
+    const big_int            z_from_int{0};
+    const big_int            z_from_uint{0U};
+    const big_int            z_from_subtraction = big_int{7} - big_int{7};
+
+    ASSERT_TRUE(z_default == 0);
+    ASSERT_EQ(z_default, z_from_int);
+    ASSERT_EQ(z_default, z_from_uint);
+    ASSERT_EQ(z_default, z_from_subtraction);
+    EXPECT_EQ(h(z_default), h(z_from_int));
+    EXPECT_EQ(h(z_default), h(z_from_uint));
+    EXPECT_EQ(h(z_default), h(z_from_subtraction));
+}
+
+// ----- Different values produce different hashes (statistical / collision tests) -----
+
+TEST(Hash, DistinctSmallValues) {
+    const std::hash<big_int>        h{};
+    std::unordered_set<std::size_t> hashes;
+    for (int i = 0; i < 8; ++i) {
+        hashes.insert(h(big_int{i}));
+    }
+    // For a good keyed hash and only 8 distinct inputs, the chance of any
+    // collision is astronomically small. Require all eight to be distinct.
+    EXPECT_EQ(hashes.size(), 8U);
+}
+
+TEST(Hash, DistinctValuesFromOneToTwoFiftySix) {
+    const std::hash<big_int>        h{};
+    std::unordered_set<std::size_t> hashes;
+    constexpr int                   N = 256;
+    for (int i = 0; i < N; ++i) {
+        hashes.insert(h(big_int{i}));
+    }
+    // We allow a small slack so this is not flaky on 32-bit `size_t` platforms,
+    // where the hash is folded down to 32 bits and the birthday bound predicts
+    // a non-zero (but still small) collision probability over 256 inputs.
+    EXPECT_GE(hashes.size(), static_cast<std::size_t>(N - 4));
+}
+
+TEST(Hash, DistinctMultiLimbValues) {
+    const std::hash<big_int> h{};
+    const big_int            base = big_int{1} << 200;
+    const big_int            a = base + big_int{1};
+    const big_int            b = base + big_int{2};
+    const big_int            c = (big_int{1} << 201) + big_int{1};
+    EXPECT_NE(h(a), h(b));
+    EXPECT_NE(h(a), h(c));
+    EXPECT_NE(h(b), h(c));
+}
+
+TEST(Hash, DistinctPowersOfTwo) {
+    const std::hash<big_int> h{};
+    const big_int            a = big_int{1} << 100;
+    const big_int            b = big_int{1} << 200;
+    const big_int            c = big_int{1} << 300;
+    EXPECT_NE(h(a), h(b));
+    EXPECT_NE(h(b), h(c));
+    EXPECT_NE(h(a), h(c));
+}
+
+TEST(Hash, SingleVsMultiLimbDistinct) {
+    // Make sure a value that fits in one limb and a multi-limb value differ.
+    const std::hash<big_int> h{};
+    const big_int            small{1};
+    const big_int            wide = big_int{1} << 128;
+    EXPECT_NE(h(small), h(wide));
+}
+
+// ----- Stability across different inplace_bits parameterizations -----
+
+TEST(Hash, CrossInplaceBitsForSmallValue) {
+    // The hash is computed over `representation()`, which is a span of
+    // `uint_multiprecision_t` limbs and is independent of `inplace_bits`.
+    // The hash must therefore agree across all parameterizations.
+    const basic_big_int<32>   a{42};
+    const basic_big_int<64>   b{42};
+    const basic_big_int<256>  c{42};
+    const basic_big_int<1024> d{42};
+
+    const auto ha = std::hash<basic_big_int<32>>{}(a);
+    const auto hb = std::hash<basic_big_int<64>>{}(b);
+    const auto hc = std::hash<basic_big_int<256>>{}(c);
+    const auto hd = std::hash<basic_big_int<1024>>{}(d);
+
+    EXPECT_EQ(ha, hb);
+    EXPECT_EQ(ha, hc);
+    EXPECT_EQ(ha, hd);
+}
+
+TEST(Hash, CrossInplaceBitsForMultiLimb) {
+    const basic_big_int<64>   a = 1'000'000'000'000'000'000'000'000'000_n;
+    const basic_big_int<2048> b{a};
+
+    EXPECT_EQ(std::hash<basic_big_int<64>>{}(a), std::hash<basic_big_int<2048>>{}(b));
+}
+
+TEST(Hash, CrossInplaceBitsForZero) {
+    const basic_big_int<32>   a{};
+    const basic_big_int<2048> b{};
+
+    EXPECT_EQ(std::hash<basic_big_int<32>>{}(a), std::hash<basic_big_int<2048>>{}(b));
+}
+
+// ----- Usability in standard unordered associative containers -----
+
+TEST(Hash, UnorderedSetSmallKeys) {
+    std::unordered_set<big_int> s;
+    s.insert(big_int{1});
+    s.insert(big_int{2});
+    s.insert(big_int{3});
+    s.insert(big_int{2}); // duplicate
+    s.insert(big_int{1}); // duplicate
+    EXPECT_EQ(s.size(), 3U);
+    EXPECT_TRUE(s.contains(big_int{1}));
+    EXPECT_TRUE(s.contains(big_int{2}));
+    EXPECT_TRUE(s.contains(big_int{3}));
+    EXPECT_FALSE(s.contains(big_int{0}));
+    EXPECT_FALSE(s.contains(big_int{4}));
+}
+
+TEST(Hash, UnorderedSetMultiLimbKeys) {
+    std::unordered_set<big_int> s;
+    const big_int               k1 = 100'000'000'000'000'000'000'000_n;
+    const big_int               k2 = 200'000'000'000'000'000'000'000_n;
+    const big_int               k3 = (big_int{1} << 256) + big_int{1};
+    s.insert(k1);
+    s.insert(k2);
+    s.insert(k3);
+    s.insert(k1); // duplicate
+    EXPECT_EQ(s.size(), 3U);
+    EXPECT_TRUE(s.contains(k1));
+    EXPECT_TRUE(s.contains(k2));
+    EXPECT_TRUE(s.contains(k3));
+    EXPECT_FALSE(s.contains(big_int{0}));
+}
+
+TEST(Hash, UnorderedSetWithBothSignsAreDistinctElements) {
+    // Container equality is not the same as hash equality. Even if the
+    // hash collides for +x and -x, the unordered_set must store both as
+    // distinct elements because their `operator==` is false.
+    std::unordered_set<big_int> s;
+    s.insert(big_int{5});
+    s.insert(big_int{-5});
+    s.insert(big_int{5}); // duplicate
+    EXPECT_EQ(s.size(), 2U);
+    EXPECT_TRUE(s.contains(big_int{5}));
+    EXPECT_TRUE(s.contains(big_int{-5}));
+}
+
+TEST(Hash, UnorderedMapBigIntKey) {
+    std::unordered_map<big_int, int> m;
+    const big_int                    k1 = 10'000'000'000'000'000'000'000_n;
+    const big_int                    k2 = 20'000'000'000'000'000'000'000_n;
+    m[k1] = 1;
+    m[k2] = 2;
+    m[k1] = 11; // overwrite
+    EXPECT_EQ(m.size(), 2U);
+    EXPECT_EQ(m.at(k1), 11);
+    EXPECT_EQ(m.at(k2), 2);
+    EXPECT_EQ(m.count(big_int{0}), 0U);
+}
+
+TEST(Hash, UnorderedMapManyEntries) {
+    std::unordered_map<big_int, int> m;
+    constexpr int                    N = 100;
+    for (int i = 0; i < N; ++i) {
+        m.emplace(big_int{i} * big_int{1'000'000'000'000'000'000} + big_int{i}, i);
+    }
+    EXPECT_EQ(m.size(), static_cast<std::size_t>(N));
+    for (int i = 0; i < N; ++i) {
+        const big_int k = big_int{i} * big_int{1'000'000'000'000'000'000} + big_int{i};
+        EXPECT_EQ(m.at(k), i);
+    }
+}
+
+// ----- Boundary values -----
+
+TEST(Hash, BoundaryUint64Values) {
+    const std::hash<big_int> h{};
+    const big_int            u64_max{std::numeric_limits<std::uint64_t>::max()};
+    const big_int            u64_max_minus_one{std::numeric_limits<std::uint64_t>::max() - 1U};
+    const big_int            u64_max_plus_one = big_int{std::numeric_limits<std::uint64_t>::max()} + big_int{1};
+
+    EXPECT_NE(h(u64_max), h(u64_max_minus_one));
+    EXPECT_NE(h(u64_max), h(u64_max_plus_one));
+    EXPECT_NE(h(u64_max_minus_one), h(u64_max_plus_one));
+}
+
+TEST(Hash, BoundarySignedInt64Min) {
+    const std::hash<big_int> h{};
+    const big_int            i64_min{std::numeric_limits<std::int64_t>::min()};
+    const big_int            i64_min_copy{i64_min};
+    EXPECT_EQ(h(i64_min), h(i64_min_copy));
+}
+
+} // namespace

--- a/tests/beman/big_int/hash.test.cpp
+++ b/tests/beman/big_int/hash.test.cpp
@@ -263,9 +263,7 @@ TEST(Hash, UnorderedSetMultiLimbKeys) {
 }
 
 TEST(Hash, UnorderedSetWithBothSignsAreDistinctElements) {
-    // Container equality is not the same as hash equality. Even if the
-    // hash collides for +x and -x, the unordered_set must store both as
-    // distinct elements because their `operator==` is false.
+    // Both the hash and operator== must distinguish +x from -x.
     std::unordered_set<big_int> s;
     s.insert(big_int{5});
     s.insert(big_int{-5});
@@ -273,6 +271,45 @@ TEST(Hash, UnorderedSetWithBothSignsAreDistinctElements) {
     EXPECT_EQ(s.size(), 2U);
     EXPECT_TRUE(s.contains(big_int{5}));
     EXPECT_TRUE(s.contains(big_int{-5}));
+}
+
+TEST(Hash, SignDistinguishesSmallValues) {
+    const std::hash<big_int> h{};
+    for (int i = 1; i <= 32; ++i) {
+        const big_int pos{i};
+        const big_int neg{-i};
+        EXPECT_NE(h(pos), h(neg)) << "collision at i=" << i;
+    }
+}
+
+TEST(Hash, SignDistinguishesMultiLimbValues) {
+    const std::hash<big_int> h{};
+    const big_int            magnitude = (big_int{1} << 200) + big_int{12345};
+    const big_int            negated   = -magnitude;
+    ASSERT_NE(magnitude, negated);
+    EXPECT_NE(h(magnitude), h(negated));
+}
+
+TEST(Hash, SignDistinguishesAcrossInplaceBits) {
+    // The sign-aware hash must agree across inplace_bits parameterizations,
+    // both for positive and for negative values.
+    const basic_big_int<64>  pos_64{42};
+    const basic_big_int<256> pos_256{42};
+    const basic_big_int<64>  neg_64  = -pos_64;
+    const basic_big_int<256> neg_256 = -pos_256;
+
+    EXPECT_EQ(std::hash<basic_big_int<64>>{}(pos_64), std::hash<basic_big_int<256>>{}(pos_256));
+    EXPECT_EQ(std::hash<basic_big_int<64>>{}(neg_64), std::hash<basic_big_int<256>>{}(neg_256));
+    EXPECT_NE(std::hash<basic_big_int<64>>{}(pos_64), std::hash<basic_big_int<64>>{}(neg_64));
+}
+
+TEST(Hash, NegatingTwiceRestoresHash) {
+    const std::hash<big_int> h{};
+    const big_int            x = (big_int{1} << 100) + big_int{7};
+    const std::size_t        original = h(x);
+    const big_int            negated = -x;
+    EXPECT_NE(original, h(negated));
+    EXPECT_EQ(original, h(-negated));
 }
 
 TEST(Hash, UnorderedMapBigIntKey) {


### PR DESCRIPTION
Applies Siphash 2-4 to the representation for the implementation. The removal of the `BEMAN_BIG_INT_DIAGNOSTIC_POP()` is due to the fact that there were two calls to POP at the bottom of the file. Now it's just one.

Closes: #215 