### PR TITLE
Implement Toom-Cook 4

### DIFF
--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -259,6 +259,91 @@ constexpr void multiply_karatsuba(const std::span<uint_multiprecision_t> result,
     scratch.deallocate(total_scratch);
 }
 
+// ---------------------------------------------------------------------------
+// Helpers shared by the Toom-Cook variants. All operate on little-endian
+// multi-precision spans of uint_multiprecision_t limbs.
+// ---------------------------------------------------------------------------
+
+// In-place tmp[0..size) += addend; returns new size (may grow by 1).
+constexpr std::size_t add_into_tmp(const std::span<uint_multiprecision_t>       tmp,
+                                   const std::size_t                            size,
+                                   const std::span<const uint_multiprecision_t> addend) noexcept {
+    if (addend.empty()) {
+        return size;
+    }
+
+    const std::size_t new_size = std::max(size, addend.size());
+    BEMAN_BIG_INT_DEBUG_ASSERT(tmp.size() > new_size);
+
+    const bool carry =
+        add_unsigned_spans(tmp.first(new_size), std::span<const uint_multiprecision_t>{tmp.data(), size}, addend);
+
+    if (carry) {
+        tmp[new_size] = 1;
+        return new_size + 1;
+    }
+
+    return new_size;
+}
+
+// In-place tmp[0..size) <<= 1; returns new size (may grow by 1).
+// Pass size == tmp.size() to shift the full span; the carry-branch assertion
+// then enforces that the shift did not overflow.
+constexpr std::size_t shift_left_one(const std::span<uint_multiprecision_t> tmp, std::size_t size) noexcept {
+    if (size == 0) {
+        return 0;
+    }
+
+    BEMAN_BIG_INT_DEBUG_ASSERT(size <= tmp.size());
+    constexpr std::size_t local_limb_bits = width_v<uint_multiprecision_t>;
+    uint_multiprecision_t prev            = 0;
+    for (std::size_t i = 0; i < size; ++i) {
+        const auto limb = tmp[i];
+        tmp[i]          = funnel_shl(wide<uint_multiprecision_t>{.low_bits = prev, .high_bits = limb}, 1u);
+        prev            = limb;
+    }
+
+    if (const auto carry = prev >> (local_limb_bits - 1)) {
+        BEMAN_BIG_INT_DEBUG_ASSERT(size < tmp.size());
+        tmp[size++] = carry;
+    }
+
+    return size;
+}
+
+// In-place tmp >>= 1; returns the dropped low bit (caller asserts == 0 for exact div).
+constexpr uint_multiprecision_t shift_right_one(const std::span<uint_multiprecision_t> tmp) noexcept {
+    if (tmp.empty()) {
+        return 0;
+    }
+
+    const uint_multiprecision_t rem  = tmp[0] & uint_multiprecision_t{1};
+    uint_multiprecision_t       high = 0;
+    for (std::size_t i = tmp.size(); i-- > 0;) {
+        const auto limb = tmp[i];
+        tmp[i]          = funnel_shr(wide<uint_multiprecision_t>{.low_bits = limb, .high_bits = high}, 1u);
+        high            = limb;
+    }
+
+    return rem;
+}
+
+// In-place result[shift..) += src; asserts no carry out of the result span.
+constexpr void add_shifted(const std::span<uint_multiprecision_t>       result,
+                           const std::size_t                            shift,
+                           const std::span<const uint_multiprecision_t> src) noexcept {
+    const auto dest  = result.subspan(shift);
+    bool       carry = false;
+    for (std::size_t i = 0; i < dest.size(); ++i) {
+        const auto si            = i < src.size() ? src[i] : uint_multiprecision_t{0};
+        const auto [r_value, c1] = carrying_add(dest[i], si, carry);
+        dest[i]                  = r_value;
+        carry                    = c1;
+    }
+
+    BEMAN_BIG_INT_DEBUG_ASSERT(!carry);
+}
+
 // Minimum number of limbs for Toom-Cook 3 to be worthwhile.
 // Toom-Cook 3 first beats Karatsuba around 800 limbs on Apple Silicon.
 inline constexpr std::size_t toom_cook_3_cutoff = 800;
@@ -342,58 +427,6 @@ constexpr void multiply_toom_cook_3(const std::span<uint_multiprecision_t> resul
     if (!a2.empty() && !b2.empty()) {
         multiply_toom_cook_3(result.subspan(4 * k, a2.size() + b2.size()), a2, b2, scratch);
     }
-
-    // ---- Helper: in-place tmp[0..size) += addend; returns new size (may grow by 1) ----
-    constexpr auto add_into_tmp = [](const std::span<uint_multiprecision_t>       tmp,
-                                     const std::size_t                            size,
-                                     const std::span<const uint_multiprecision_t> addend) -> std::size_t {
-        if (addend.empty()) {
-            return size;
-        }
-        const std::size_t new_size = std::max(size, addend.size());
-        BEMAN_BIG_INT_DEBUG_ASSERT(tmp.size() > new_size);
-        const bool carry =
-            add_unsigned_spans(tmp.first(new_size), std::span<const uint_multiprecision_t>{tmp.data(), size}, addend);
-        if (carry) {
-            tmp[new_size] = 1;
-            return new_size + 1;
-        }
-        return new_size;
-    };
-
-    // ---- Helper: in-place tmp[0..size) <<= 1; returns new size (may grow by 1) ----
-    constexpr auto shift_left_one = [](const std::span<uint_multiprecision_t> tmp, std::size_t size) -> std::size_t {
-        if (size == 0) {
-            return 0;
-        }
-        BEMAN_BIG_INT_DEBUG_ASSERT(tmp.size() > size);
-        constexpr std::size_t local_limb_bits = width_v<uint_multiprecision_t>;
-        uint_multiprecision_t prev            = 0;
-        for (std::size_t i = 0; i < size; ++i) {
-            const auto limb = tmp[i];
-            tmp[i]          = funnel_shl(wide<uint_multiprecision_t>{.low_bits = prev, .high_bits = limb}, 1u);
-            prev            = limb;
-        }
-        if (const auto carry = prev >> (local_limb_bits - 1)) {
-            tmp[size++] = carry;
-        }
-        return size;
-    };
-
-    // ---- Helper: in-place tmp >>= 1; returns the dropped low bit (caller asserts == 0 for exact div) ----
-    constexpr auto shift_right_one = [](const std::span<uint_multiprecision_t> tmp) -> uint_multiprecision_t {
-        if (tmp.empty()) {
-            return 0;
-        }
-        const uint_multiprecision_t rem  = tmp[0] & uint_multiprecision_t{1};
-        uint_multiprecision_t       high = 0;
-        for (std::size_t i = tmp.size(); i-- > 0;) {
-            const auto limb = tmp[i];
-            tmp[i]          = funnel_shr(wide<uint_multiprecision_t>{.low_bits = limb, .high_bits = high}, 1u);
-            high            = limb;
-        }
-        return rem;
-    };
 
     // ---- Evaluate at x = 1: tmpa = a0 + a1 + a2; tmpb = b0 + b1 + b2 ----
     std::ranges::copy(a0, tmpa.begin());
@@ -531,23 +564,499 @@ constexpr void multiply_toom_cook_3(const std::span<uint_multiprecision_t> resul
     // c0 already at result[0..2k); c4 already at result[4k..). Add the three middle
     // coefficients with carry chains spanning to result.size() so carries can
     // propagate into the c4 region.
-    const auto add_shifted = [&](const std::size_t shift, const std::span<const uint_multiprecision_t> src) {
-        const auto dest  = result.subspan(shift);
-        bool       carry = false;
-        for (std::size_t i = 0; i < dest.size(); ++i) {
-            const auto si            = i < src.size() ? src[i] : uint_multiprecision_t{0};
-            const auto [r_value, c1] = carrying_add(dest[i], si, carry);
-            dest[i]                  = r_value;
-            carry                    = c1;
-        }
-        BEMAN_BIG_INT_DEBUG_ASSERT(!carry);
-    };
-
-    add_shifted(k, vm1_view);
-    add_shifted(2 * k, v1_view);
-    add_shifted(3 * k, v2_view);
+    add_shifted(result, k, vm1_view);
+    add_shifted(result, 2 * k, v1_view);
+    add_shifted(result, 3 * k, v2_view);
 
     // Move bump pointer back so the next sibling recursive call reuses the same region.
+    scratch.deallocate(total_scratch);
+}
+
+// Minimum number of limbs for Toom-Cook 4 to be worthwhile.
+// Empirically tuned on Apple Silicon via multiplication_stress_bench
+inline constexpr std::size_t toom_cook_4_cutoff = 4500;
+
+// Heuristic estimate of scratch space needed for Toom-Cook 4 multiplication.
+// One Toom-4 level uses 14k+16 limbs (~3.5*s where k = ceil(s/4)). The geometric
+// sum over self-recursion converges to 14/3*s ~= 4.67*s as the asymptotic worst
+// case; empirically (probed via scratch_allocator high-water marks on sizes
+// 4500-80000 limbs) the actual peak ranges 4.50-4.66*s. 6*s leaves ~25-30%
+// safety margin and matches the same generous-but-not-wasteful ratio the older
+// algorithms use.
+constexpr std::size_t toom_cook_4_storage_size(const std::size_t s) noexcept { return 6 * s; }
+
+// ---------------------------------------------------------------------------
+// Recursive Toom-Cook 4-Way multiplication (Bodrato variant).
+// Reference: Bodrato, "Towards Optimal Toom-Cook Multiplication" (2006).
+//
+// Splits each operand into four pieces of size k = ceil(max(an,bn)/4):
+//   a = a3*B^(3k) + a2*B^(2k) + a1*B^k + a0,  b = b3*B^(3k) + ... (B = 2^limb_bits)
+//
+// Evaluates the product polynomial r(x) = p(x)*q(x) at seven points
+// {0, 1, -1, 2, -2, 1/2 (scaled by 8), infinity}, then interpolates the seven
+// coefficients c0..c6 of r(x) using a Bodrato-style in-place sequence with
+// exact divisions by 2, 3, and 5.
+// Result = c0 + c1*B^k + c2*B^(2k) + c3*B^(3k) + c4*B^(4k) + c5*B^(5k) + c6*B^(6k).
+//
+// `result` must be pre-zeroed and have space for a.size() + b.size() limbs.
+// `result` must NOT alias `a` or `b`.
+// `scratch` provides pre-allocated workspace for temporaries.
+//
+// `cutoff_override` is a benchmark-only escape hatch: when non-zero it replaces
+// `toom_cook_4_cutoff` for this call only. Production callers should omit it so
+// the default cutoff applies. Recursive sub-product calls always use the default.
+// ---------------------------------------------------------------------------
+template <class Allocator>
+constexpr void multiply_toom_cook_4(const std::span<uint_multiprecision_t> result,
+                                    std::span<const uint_multiprecision_t> a,
+                                    std::span<const uint_multiprecision_t> b,
+                                    scratch_allocator<Allocator>&          scratch,
+                                    const std::size_t                      cutoff_override = 0) noexcept {
+    BEMAN_BIG_INT_DEBUG_ASSERT(!a.empty());
+    BEMAN_BIG_INT_DEBUG_ASSERT(!b.empty());
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.size() >= trimmed_size_span(a) + trimmed_size_span(b));
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != a.data());
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != b.data());
+
+    a = a.first(trimmed_size_span(a));
+    b = b.first(trimmed_size_span(b));
+
+    // Partition at k = ceil(max(an, bn) / 4).
+    const std::size_t min_size         = std::min(a.size(), b.size());
+    const std::size_t k                = (std::max(a.size(), b.size()) + 3) / 4;
+    const std::size_t effective_cutoff = cutoff_override == 0 ? toom_cook_4_cutoff : cutoff_override;
+
+    // Fall through to Toom-Cook 3 (and on through Karatsuba and schoolbook) when the
+    // smaller operand is below the performance cutoff or below the algorithm's 3*k
+    // invariant (Toom-Cook 4 needs both a3 and b3 non-empty).
+    if (min_size < effective_cutoff || min_size <= 3 * k) {
+        multiply_toom_cook_3(result, a, b, scratch);
+        return;
+    }
+
+    // Split each operand into four pieces.
+    const auto a0 = a.first(std::min(k, a.size()));
+    const auto a1 = a.size() > k ? a.subspan(k, std::min(k, a.size() - k)) : std::span<const uint_multiprecision_t>{};
+    const auto a2 =
+        a.size() > 2 * k ? a.subspan(2 * k, std::min(k, a.size() - 2 * k)) : std::span<const uint_multiprecision_t>{};
+    const auto a3 = a.size() > 3 * k ? a.subspan(3 * k) : std::span<const uint_multiprecision_t>{};
+
+    const auto b0 = b.first(std::min(k, b.size()));
+    const auto b1 = b.size() > k ? b.subspan(k, std::min(k, b.size() - k)) : std::span<const uint_multiprecision_t>{};
+    const auto b2 =
+        b.size() > 2 * k ? b.subspan(2 * k, std::min(k, b.size() - 2 * k)) : std::span<const uint_multiprecision_t>{};
+    const auto b3 = b.size() > 3 * k ? b.subspan(3 * k) : std::span<const uint_multiprecision_t>{};
+
+    // Carve scratch:
+    //   tmpa, tmpb: k+2 limbs each (evaluation buffers, hold p(x) and q(x) at each point)
+    //   v1, vm1, v2, vm2, vh: 2k+2 limbs each (five interpolation buffers)
+    //   tmp_double: 2k+2 limbs (used for in-place bit shifts to replace doubling with mul)
+    // c0 = a0*b0 lives in result[0..2k); c6 = a3*b3 lives in result[6k..).
+    const std::size_t tmp_cap       = k + 2;
+    const std::size_t prod_cap      = 2 * k + 2;
+    const std::size_t total_scratch = 2 * tmp_cap + 6 * prod_cap;
+
+    auto block      = scratch.allocate(total_scratch);
+    auto tmpa       = block.first(tmp_cap);
+    auto tmpb       = block.subspan(tmp_cap, tmp_cap);
+    auto v1         = block.subspan(2 * tmp_cap, prod_cap);
+    auto vm1        = block.subspan(2 * tmp_cap + prod_cap, prod_cap);
+    auto v2         = block.subspan(2 * tmp_cap + 2 * prod_cap, prod_cap);
+    auto vm2        = block.subspan(2 * tmp_cap + 3 * prod_cap, prod_cap);
+    auto vh         = block.subspan(2 * tmp_cap + 4 * prod_cap, prod_cap);
+    auto tmp_double = block.subspan(2 * tmp_cap + 5 * prod_cap, prod_cap);
+
+    // ---- c0 = a0*b0, written into result[0..2k) (caller pre-zeroed). ----
+    multiply_toom_cook_4(result.first(a0.size() + b0.size()), a0, b0, scratch);
+
+    // ---- c6 = a3*b3, written into result[6k..). ----
+    // The min > 3*k gate above guarantees both a3 and b3 are non-empty.
+    multiply_toom_cook_4(result.subspan(6 * k, a3.size() + b3.size()), a3, b3, scratch);
+
+    // ---- Evaluate at x = 1: tmpa = a0 + a1 + a2 + a3; tmpb similarly. ----
+    std::ranges::copy(a0, tmpa.begin());
+    std::size_t tmpa_size = a0.size();
+    tmpa_size             = add_into_tmp(tmpa, tmpa_size, a1);
+    tmpa_size             = add_into_tmp(tmpa, tmpa_size, a2);
+    tmpa_size             = add_into_tmp(tmpa, tmpa_size, a3);
+
+    std::ranges::copy(b0, tmpb.begin());
+    std::size_t tmpb_size = b0.size();
+    tmpb_size             = add_into_tmp(tmpb, tmpb_size, b1);
+    tmpb_size             = add_into_tmp(tmpb, tmpb_size, b2);
+    tmpb_size             = add_into_tmp(tmpb, tmpb_size, b3);
+
+    // v1 = tmpa * tmpb
+    std::ranges::fill(v1, uint_multiprecision_t{0});
+    multiply_toom_cook_4(v1,
+                         std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                         std::span<const uint_multiprecision_t>{tmpb.data(), tmpb_size},
+                         scratch);
+
+    // ---- Evaluate at x = -1: tmpa = (a0 + a2) - (a1 + a3) signed; tmpb similarly. ----
+    std::ranges::copy(a0, tmpa.begin());
+    tmpa_size = a0.size();
+    tmpa_size = add_into_tmp(tmpa, tmpa_size, a2);
+    // tmpb temporarily used to hold a1 + a3 before subtraction.
+    std::ranges::copy(a1, tmpb.begin());
+    std::size_t aux_size = a1.size();
+    aux_size             = add_into_tmp(tmpb, aux_size, a3);
+    const auto sub_a_m1  = subtract_unsigned_spans_signed(tmpa,
+                                                        std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                                                        std::span<const uint_multiprecision_t>{tmpb.data(), aux_size});
+    tmpa_size            = sub_a_m1.size;
+    const bool sign_a_m1 = sub_a_m1.negative;
+
+    std::ranges::copy(b0, tmpb.begin());
+    tmpb_size = b0.size();
+    tmpb_size = add_into_tmp(tmpb, tmpb_size, b2);
+    // tmpa now holds (a0 + a2) - (a1 + a3); reuse tail of vm1 as a scratch slot for (b1 + b3).
+    std::ranges::copy(b1, vm1.begin());
+    aux_size            = b1.size();
+    aux_size            = add_into_tmp(vm1, aux_size, b3);
+    const auto sub_b_m1 = subtract_unsigned_spans_signed(tmpb,
+                                                        std::span<const uint_multiprecision_t>{tmpb.data(), tmpb_size},
+                                                        std::span<const uint_multiprecision_t>{vm1.data(), aux_size});
+    tmpb_size            = sub_b_m1.size;
+    const bool sign_b_m1 = sub_b_m1.negative;
+    const bool sign_vm1  = sign_a_m1 ^ sign_b_m1;
+
+    std::ranges::fill(vm1, uint_multiprecision_t{0});
+    if (tmpa_size != 0 && tmpb_size != 0) {
+        multiply_toom_cook_4(vm1,
+                             std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                             std::span<const uint_multiprecision_t>{tmpb.data(), tmpb_size},
+                             scratch);
+    }
+
+    // ---- Evaluate at x = 2: tmpa = ((a3*2 + a2)*2 + a1)*2 + a0 (Horner); tmpb similarly. ----
+    std::ranges::copy(a3, tmpa.begin());
+    tmpa_size = a3.size();
+    tmpa_size = shift_left_one(tmpa, tmpa_size);
+    tmpa_size = add_into_tmp(tmpa, tmpa_size, a2);
+    tmpa_size = shift_left_one(tmpa, tmpa_size);
+    tmpa_size = add_into_tmp(tmpa, tmpa_size, a1);
+    tmpa_size = shift_left_one(tmpa, tmpa_size);
+    tmpa_size = add_into_tmp(tmpa, tmpa_size, a0);
+
+    std::ranges::copy(b3, tmpb.begin());
+    tmpb_size = b3.size();
+    tmpb_size = shift_left_one(tmpb, tmpb_size);
+    tmpb_size = add_into_tmp(tmpb, tmpb_size, b2);
+    tmpb_size = shift_left_one(tmpb, tmpb_size);
+    tmpb_size = add_into_tmp(tmpb, tmpb_size, b1);
+    tmpb_size = shift_left_one(tmpb, tmpb_size);
+    tmpb_size = add_into_tmp(tmpb, tmpb_size, b0);
+
+    std::ranges::fill(v2, uint_multiprecision_t{0});
+    multiply_toom_cook_4(v2,
+                         std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                         std::span<const uint_multiprecision_t>{tmpb.data(), tmpb_size},
+                         scratch);
+
+    // ---- Evaluate at x = -2: tmpa = (a0 + 4*a2) - (2*a1 + 8*a3) signed; tmpb similarly.
+    // Build positive = a0 + 4*a2 in tmpa, negative = 2*a1 + 8*a3 in tmpb, then signed-sub.
+    std::ranges::copy(a2, tmpa.begin());
+    tmpa_size = a2.size();
+    tmpa_size = shift_left_one(tmpa, tmpa_size); // 2*a2
+    tmpa_size = shift_left_one(tmpa, tmpa_size); // 4*a2
+    tmpa_size = add_into_tmp(tmpa, tmpa_size, a0);
+
+    std::ranges::copy(a3, tmpb.begin());
+    aux_size = a3.size();
+    aux_size = shift_left_one(tmpb, aux_size); // 2*a3
+    aux_size = shift_left_one(tmpb, aux_size); // 4*a3
+    aux_size = shift_left_one(tmpb, aux_size); // 8*a3
+    aux_size = add_into_tmp(tmpb, aux_size, a1);
+    // tmpb holds 8*a3 + a1; we still need 2*a1, which is (8*a3 + a1) + a1 = 8*a3 + 2*a1.
+    aux_size = add_into_tmp(tmpb, aux_size, a1);
+
+    const auto sub_a_m2  = subtract_unsigned_spans_signed(tmpa,
+                                                        std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                                                        std::span<const uint_multiprecision_t>{tmpb.data(), aux_size});
+    tmpa_size            = sub_a_m2.size;
+    const bool sign_a_m2 = sub_a_m2.negative;
+
+    std::ranges::copy(b2, tmpb.begin());
+    tmpb_size = b2.size();
+    tmpb_size = shift_left_one(tmpb, tmpb_size);
+    tmpb_size = shift_left_one(tmpb, tmpb_size);
+    tmpb_size = add_into_tmp(tmpb, tmpb_size, b0);
+
+    // Use vm2 as a scratch slot for 8*b3 + 2*b1.
+    std::ranges::copy(b3, vm2.begin());
+    aux_size = b3.size();
+    aux_size = shift_left_one(vm2, aux_size);
+    aux_size = shift_left_one(vm2, aux_size);
+    aux_size = shift_left_one(vm2, aux_size);
+    aux_size = add_into_tmp(vm2, aux_size, b1);
+    aux_size = add_into_tmp(vm2, aux_size, b1);
+
+    const auto sub_b_m2  = subtract_unsigned_spans_signed(tmpb,
+                                                        std::span<const uint_multiprecision_t>{tmpb.data(), tmpb_size},
+                                                        std::span<const uint_multiprecision_t>{vm2.data(), aux_size});
+    tmpb_size            = sub_b_m2.size;
+    const bool sign_b_m2 = sub_b_m2.negative;
+    const bool sign_vm2  = sign_a_m2 ^ sign_b_m2;
+
+    std::ranges::fill(vm2, uint_multiprecision_t{0});
+    if (tmpa_size != 0 && tmpb_size != 0) {
+        multiply_toom_cook_4(vm2,
+                             std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                             std::span<const uint_multiprecision_t>{tmpb.data(), tmpb_size},
+                             scratch);
+    }
+
+    // ---- Evaluate at x = 1/2 (scaled by 8): tmpa = ((a0*2 + a1)*2 + a2)*2 + a3 (Horner);
+    // this equals 8*a(1/2), so the resulting product is 64*c(1/2). ----
+    std::ranges::copy(a0, tmpa.begin());
+    tmpa_size = a0.size();
+    tmpa_size = shift_left_one(tmpa, tmpa_size);
+    tmpa_size = add_into_tmp(tmpa, tmpa_size, a1);
+    tmpa_size = shift_left_one(tmpa, tmpa_size);
+    tmpa_size = add_into_tmp(tmpa, tmpa_size, a2);
+    tmpa_size = shift_left_one(tmpa, tmpa_size);
+    tmpa_size = add_into_tmp(tmpa, tmpa_size, a3);
+
+    std::ranges::copy(b0, tmpb.begin());
+    tmpb_size = b0.size();
+    tmpb_size = shift_left_one(tmpb, tmpb_size);
+    tmpb_size = add_into_tmp(tmpb, tmpb_size, b1);
+    tmpb_size = shift_left_one(tmpb, tmpb_size);
+    tmpb_size = add_into_tmp(tmpb, tmpb_size, b2);
+    tmpb_size = shift_left_one(tmpb, tmpb_size);
+    tmpb_size = add_into_tmp(tmpb, tmpb_size, b3);
+
+    std::ranges::fill(vh, uint_multiprecision_t{0});
+    multiply_toom_cook_4(vh,
+                         std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                         std::span<const uint_multiprecision_t>{tmpb.data(), tmpb_size},
+                         scratch);
+
+    // ---- Bodrato-style interpolation (in-place; full 2k+2 buffers throughout) ----
+    // After this sequence the c-coefficients live as:
+    //   c0 in result[0..2k), c1 in vh, c2 in v1, c3 in vm1, c4 in v2, c5 in vm2, c6 in result[6k..).
+    //
+    // v0_view and vinf_view bound the c0 and c6 regions in result. Clip vinf_view because
+    // the result span may be larger than 8k when the caller's prod_cap exceeds the actual
+    // product (same trick as Toom-3 at line 642).
+    const auto v0_view   = std::span<const uint_multiprecision_t>{result.data(), 2 * k};
+    const auto vinf_size = std::min(result.size() - 6 * k, 2 * k);
+    const auto vinf_view = std::span<const uint_multiprecision_t>{result.data() + 6 * k, vinf_size};
+    const auto v1_view   = std::span<const uint_multiprecision_t>{v1};
+    const auto vm1_view  = std::span<const uint_multiprecision_t>{vm1};
+    const auto v2_view   = std::span<const uint_multiprecision_t>{v2};
+    const auto vm2_view  = std::span<const uint_multiprecision_t>{vm2};
+    const auto vh_view   = std::span<const uint_multiprecision_t>{vh};
+    const auto td_view   = std::span<const uint_multiprecision_t>{tmp_double};
+
+    // Phase 1: Symmetrize {v1, vm1} into {E1, D1} and {v2, vm2} into {E2, D2}.
+    //   E1 = (v1 + vm1)/2 = c0 + c2 + c4 + c6
+    //   D1 = (v1 - vm1)/2 = c1 + c3 + c5
+    //   E2 = (v2 + vm2)/2 = c0 + 4c2 + 16c4 + 64c6
+    //   D2 = (v2 - vm2)/4 = c1 + 4c3 + 16c5
+
+    // Step 1a: v1 <- (v1 + vm1) algebraic (sign-aware on sign_vm1).
+    if (sign_vm1) {
+        subtract_unsigned_spans(v1, v1_view, vm1_view);
+    } else {
+        [[maybe_unused]] const bool carry_out = add_unsigned_spans(v1, v1_view, vm1_view);
+        BEMAN_BIG_INT_DEBUG_ASSERT(!carry_out);
+    }
+    // Step 1b: v1 /= 2.
+    {
+        [[maybe_unused]] const auto rem = shift_right_one(v1);
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+    // After Step 1: v1 = E1 = c0 + c2 + c4 + c6.
+
+    // Step 2: vm1 <- v1 - vm1 algebraic = (v1_orig - vm1_orig)/2 = D1.
+    if (sign_vm1) {
+        [[maybe_unused]] const bool carry_out = add_unsigned_spans(vm1, v1_view, vm1_view);
+        BEMAN_BIG_INT_DEBUG_ASSERT(!carry_out);
+    } else {
+        subtract_unsigned_spans(vm1, v1_view, vm1_view);
+    }
+    // After Step 2: vm1 = D1 = c1 + c3 + c5. sign_vm1 is no longer needed.
+
+    // Step 3a: v2 <- (v2 + vm2) algebraic.
+    if (sign_vm2) {
+        subtract_unsigned_spans(v2, v2_view, vm2_view);
+    } else {
+        [[maybe_unused]] const bool carry_out = add_unsigned_spans(v2, v2_view, vm2_view);
+        BEMAN_BIG_INT_DEBUG_ASSERT(!carry_out);
+    }
+    // Step 3b: v2 /= 2.
+    {
+        [[maybe_unused]] const auto rem = shift_right_one(v2);
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+    // After Step 3: v2 = E2 = c0 + 4c2 + 16c4 + 64c6.
+
+    // Step 4a: vm2 <- v2 - vm2 algebraic = (v2_orig - vm2_orig)/2 = 2c1 + 8c3 + 32c5.
+    if (sign_vm2) {
+        [[maybe_unused]] const bool carry_out = add_unsigned_spans(vm2, v2_view, vm2_view);
+        BEMAN_BIG_INT_DEBUG_ASSERT(!carry_out);
+    } else {
+        subtract_unsigned_spans(vm2, v2_view, vm2_view);
+    }
+    // Step 4b: vm2 /= 2.
+    {
+        [[maybe_unused]] const auto rem = shift_right_one(vm2);
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+    // After Step 4: vm2 = D2 = c1 + 4c3 + 16c5. sign_vm2 is no longer needed.
+
+    // Phase 2: Solve even system for c2 (into v1) and c4 (into v2).
+
+    // Step 5: v2 -= v1.  v2 = (c0+4c2+16c4+64c6) - (c0+c2+c4+c6) = 3*(c2 + 5c4 + 21c6).
+    subtract_unsigned_spans(v2, v2_view, v1_view);
+    // Step 6: v2 /= 3.  v2 = c2 + 5c4 + 21c6.
+    {
+        [[maybe_unused]] const auto rem = divide_unsigned_short(v2, v2_view, uint_multiprecision_t{3});
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Step 7: v1 -= c0.  v1 = c2 + c4 + c6.
+    subtract_unsigned_spans(v1, v1_view, v0_view);
+    // Step 8: v1 -= c6.  v1 = c2 + c4.
+    subtract_unsigned_spans(v1, v1_view, vinf_view);
+
+    // Step 9: v2 -= v1.  v2 = 4c4 + 21c6.
+    subtract_unsigned_spans(v2, v2_view, v1_view);
+
+    // Step 10: subtract 21*c6 from v2 using tmp_double for the doublings.
+    //   v2 -= 1*c6, then v2 -= 4*c6, then v2 -= 16*c6.  Total subtracted = 21*c6.
+    subtract_unsigned_spans(v2, v2_view, vinf_view);
+    std::ranges::fill(tmp_double, uint_multiprecision_t{0});
+    std::ranges::copy(vinf_view, tmp_double.begin());
+    std::size_t td_size = vinf_view.size();
+    td_size             = shift_left_one(tmp_double, td_size); //  2*c6
+    td_size             = shift_left_one(tmp_double, td_size); //  4*c6
+    subtract_unsigned_spans(v2, v2_view, std::span<const uint_multiprecision_t>{tmp_double.data(), td_size});
+    td_size = shift_left_one(tmp_double, td_size); //  8*c6
+    td_size = shift_left_one(tmp_double, td_size); // 16*c6
+    subtract_unsigned_spans(v2, v2_view, std::span<const uint_multiprecision_t>{tmp_double.data(), td_size});
+    // After Step 10: v2 = 4c4.
+
+    // Step 11: v2 /= 4 (two halvings).  v2 = c4.
+    {
+        [[maybe_unused]] const auto rem = shift_right_one(v2);
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+    {
+        [[maybe_unused]] const auto rem = shift_right_one(v2);
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Step 12: v1 -= v2.  v1 = c2.
+    subtract_unsigned_spans(v1, v1_view, v2_view);
+
+    // Phase 3: Reduce vh to T_odd = (vh - 64c0 - 16c2 - 4c4 - c6) / 2 = 16c1 + 4c3 + c5.
+
+    // Step 13: vh -= 64*c0 (subtract 64*c0 via doubled-tmp_double).
+    std::ranges::fill(tmp_double, uint_multiprecision_t{0});
+    std::ranges::copy(v0_view, tmp_double.begin());
+    td_size = trimmed_size_span(v0_view);
+    for (int i = 0; i < 6; ++i) {
+        td_size = shift_left_one(tmp_double, td_size);
+    }
+    subtract_unsigned_spans(vh, vh_view, std::span<const uint_multiprecision_t>{tmp_double.data(), td_size});
+
+    // Step 14: vh -= 16*c2 (c2 lives in v1 now).
+    std::ranges::fill(tmp_double, uint_multiprecision_t{0});
+    std::ranges::copy(v1_view, tmp_double.begin());
+    td_size = trimmed_size_span(v1_view);
+    for (int i = 0; i < 4; ++i) {
+        td_size = shift_left_one(tmp_double, td_size);
+    }
+    subtract_unsigned_spans(vh, vh_view, std::span<const uint_multiprecision_t>{tmp_double.data(), td_size});
+
+    // Step 15: vh -= 4*c4 (c4 lives in v2 now).
+    std::ranges::fill(tmp_double, uint_multiprecision_t{0});
+    std::ranges::copy(v2_view, tmp_double.begin());
+    td_size = trimmed_size_span(v2_view);
+    td_size = shift_left_one(tmp_double, td_size);
+    td_size = shift_left_one(tmp_double, td_size);
+    subtract_unsigned_spans(vh, vh_view, std::span<const uint_multiprecision_t>{tmp_double.data(), td_size});
+
+    // Step 16: vh -= c6.
+    subtract_unsigned_spans(vh, vh_view, vinf_view);
+
+    // Step 17: vh /= 2.  vh = 16c1 + 4c3 + c5 = T_odd.
+    {
+        [[maybe_unused]] const auto rem = shift_right_one(vh);
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Phase 4: Solve odd system using vm1 = D1, vm2 = D2, vh = T_odd.
+    //   vm2 -= D1:  3c3 + 15c5
+    //   vh  -= D1: 15c1 +  3c3
+    //   then divide both by 3.
+
+    // Step 18: vm2 -= vm1.  vm2 = 3*(c3 + 5c5).
+    subtract_unsigned_spans(vm2, vm2_view, vm1_view);
+    // Step 19: vh -= vm1.  vh = 3*(5c1 + c3).
+    subtract_unsigned_spans(vh, vh_view, vm1_view);
+    // Step 20: vm2 /= 3.  vm2 = alpha = c3 + 5c5.
+    {
+        [[maybe_unused]] const auto rem = divide_unsigned_short(vm2, vm2_view, uint_multiprecision_t{3});
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+    // Step 21: vh /= 3.  vh = beta = 5c1 + c3.
+    {
+        [[maybe_unused]] const auto rem = divide_unsigned_short(vh, vh_view, uint_multiprecision_t{3});
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Now vm1 = D1, vm2 = alpha, vh = beta. Recover c3 = (5*D1 - alpha - beta) / 3 into vm1.
+    // Step 22: tmp_double = D1; vm1 *= 4; vm1 += tmp_double  (-> 5*D1).
+    std::ranges::fill(tmp_double, uint_multiprecision_t{0});
+    std::ranges::copy(vm1_view, tmp_double.begin());
+    shift_left_one(vm1, vm1.size()); // 2*D1
+    shift_left_one(vm1, vm1.size()); // 4*D1
+    {
+        [[maybe_unused]] const bool carry = add_unsigned_spans(vm1, vm1_view, td_view); // 5*D1
+        BEMAN_BIG_INT_DEBUG_ASSERT(!carry);
+    }
+    // Step 23: vm1 -= alpha; vm1 -= beta.  vm1 = 3*c3.
+    subtract_unsigned_spans(vm1, vm1_view, vm2_view);
+    subtract_unsigned_spans(vm1, vm1_view, vh_view);
+    // Step 24: vm1 /= 3.  vm1 = c3.
+    {
+        [[maybe_unused]] const auto rem = divide_unsigned_short(vm1, vm1_view, uint_multiprecision_t{3});
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Step 25: vh -= c3 -> 5*c1; vh /= 5.  vh = c1.
+    subtract_unsigned_spans(vh, vh_view, vm1_view);
+    {
+        [[maybe_unused]] const auto rem = divide_unsigned_short(vh, vh_view, uint_multiprecision_t{5});
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Step 26: vm2 -= c3 -> 5*c5; vm2 /= 5.  vm2 = c5.
+    subtract_unsigned_spans(vm2, vm2_view, vm1_view);
+    {
+        [[maybe_unused]] const auto rem = divide_unsigned_short(vm2, vm2_view, uint_multiprecision_t{5});
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Phase 5: Recompose.
+    //   result += vh * B^k        (c1)
+    //   result += v1 * B^(2k)     (c2)
+    //   result += vm1 * B^(3k)    (c3)
+    //   result += v2 * B^(4k)     (c4)
+    //   result += vm2 * B^(5k)    (c5)
+    // c0 and c6 are already in result.
+    // Carries propagate up to result.size().
+    add_shifted(result, k, vh_view);
+    add_shifted(result, 2 * k, v1_view);
+    add_shifted(result, 3 * k, vm1_view);
+    add_shifted(result, 4 * k, v2_view);
+    add_shifted(result, 5 * k, vm2_view);
+
+    // Release scratch back to the bump pool for sibling reuse.
     scratch.deallocate(total_scratch);
 }
 
@@ -589,6 +1098,15 @@ constexpr std::size_t multiply_dispatch(const std::span<uint_multiprecision_t> r
     // Avoid these at compile time because the recursion depth could blow up consteval limits;
     // long multiplication works just fine in that case.
     if BEMAN_BIG_INT_IS_NOT_CONSTEVAL {
+        if (a.size() >= toom_cook_4_cutoff && b.size() >= toom_cook_4_cutoff) {
+            const std::size_t s            = std::max(a.size(), b.size());
+            const std::size_t storage_size = toom_cook_4_storage_size(s);
+            const std::size_t result_total = a.size() + b.size();
+
+            scratch_allocator<Allocator> scratch(storage_size, alloc);
+            multiply_toom_cook_4(result.first(result_total), a, b, scratch);
+            return trimmed_size_span(std::span<const uint_multiprecision_t>{result.data(), result_total});
+        }
         if (a.size() >= toom_cook_3_cutoff && b.size() >= toom_cook_3_cutoff) {
             const std::size_t s            = std::max(a.size(), b.size());
             const std::size_t storage_size = toom_cook_3_storage_size(s);

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -350,7 +350,7 @@ inline constexpr std::size_t toom_cook_3_cutoff = 800;
 
 // Heuristic estimate of scratch space needed for Toom-Cook 3 multiplication.
 // Includes space for karatsuba fallback plan
-constexpr std::size_t toom_cook_3_storage_size(const std::size_t s) noexcept { return 8 * s; }
+constexpr std::size_t toom_cook_3_storage_size(const std::size_t s) noexcept { return 6 * s; }
 
 // ---------------------------------------------------------------------------
 // Recursive Toom-Cook 3-Way multiplication (Bodrato variant).

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -129,18 +129,18 @@ constexpr void multiply_long(const std::span<uint_multiprecision_t>       result
 // `scratch` provides pre-allocated workspace for temporaries.
 // ---------------------------------------------------------------------------
 template <class Allocator>
-constexpr void multiply_karatsuba(const std::span<uint_multiprecision_t> result,
-                                  std::span<const uint_multiprecision_t> a,
-                                  std::span<const uint_multiprecision_t> b,
-                                  scratch_allocator<Allocator>&          scratch) noexcept {
-    BEMAN_BIG_INT_DEBUG_ASSERT(!a.empty());
-    BEMAN_BIG_INT_DEBUG_ASSERT(!b.empty());
-    BEMAN_BIG_INT_DEBUG_ASSERT(result.size() >= trimmed_size_span(a) + trimmed_size_span(b));
-    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != a.data());
-    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != b.data());
+constexpr void multiply_karatsuba(const std::span<uint_multiprecision_t>       result,
+                                  const std::span<const uint_multiprecision_t> a_untrimmed,
+                                  const std::span<const uint_multiprecision_t> b_untrimmed,
+                                  scratch_allocator<Allocator>&                scratch) noexcept {
+    BEMAN_BIG_INT_DEBUG_ASSERT(!a_untrimmed.empty());
+    BEMAN_BIG_INT_DEBUG_ASSERT(!b_untrimmed.empty());
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.size() >= trimmed_size_span(a_untrimmed) + trimmed_size_span(b_untrimmed));
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != a_untrimmed.data());
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != b_untrimmed.data());
 
-    a = a.first(trimmed_size_span(a));
-    b = b.first(trimmed_size_span(b));
+    const auto a = a_untrimmed.first(trimmed_size_span(a_untrimmed));
+    const auto b = b_untrimmed.first(trimmed_size_span(b_untrimmed));
 
     // First, check if we have enough limbs to justify karatsuba
     if (a.size() < karatsuba_cutoff || b.size() < karatsuba_cutoff) {
@@ -371,18 +371,18 @@ constexpr std::size_t toom_cook_3_storage_size(const std::size_t s) noexcept { r
 // `scratch` provides pre-allocated workspace for temporaries.
 // ---------------------------------------------------------------------------
 template <class Allocator>
-constexpr void multiply_toom_cook_3(const std::span<uint_multiprecision_t> result,
-                                    std::span<const uint_multiprecision_t> a,
-                                    std::span<const uint_multiprecision_t> b,
-                                    scratch_allocator<Allocator>&          scratch) noexcept {
-    BEMAN_BIG_INT_DEBUG_ASSERT(!a.empty());
-    BEMAN_BIG_INT_DEBUG_ASSERT(!b.empty());
-    BEMAN_BIG_INT_DEBUG_ASSERT(result.size() >= trimmed_size_span(a) + trimmed_size_span(b));
-    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != a.data());
-    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != b.data());
+constexpr void multiply_toom_cook_3(const std::span<uint_multiprecision_t>       result,
+                                    const std::span<const uint_multiprecision_t> a_untrimmed,
+                                    const std::span<const uint_multiprecision_t> b_untrimmed,
+                                    scratch_allocator<Allocator>&                scratch) noexcept {
+    BEMAN_BIG_INT_DEBUG_ASSERT(!a_untrimmed.empty());
+    BEMAN_BIG_INT_DEBUG_ASSERT(!b_untrimmed.empty());
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.size() >= trimmed_size_span(a_untrimmed) + trimmed_size_span(b_untrimmed));
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != a_untrimmed.data());
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != b_untrimmed.data());
 
-    a = a.first(trimmed_size_span(a));
-    b = b.first(trimmed_size_span(b));
+    const auto a = a_untrimmed.first(trimmed_size_span(a_untrimmed));
+    const auto b = b_untrimmed.first(trimmed_size_span(b_untrimmed));
 
     // Partition at k = ceil(max(an, bn) / 3).
     const std::size_t min_size = std::min(a.size(), b.size());
@@ -608,19 +608,19 @@ constexpr std::size_t toom_cook_4_storage_size(const std::size_t s) noexcept { r
 // the default cutoff applies. Recursive sub-product calls always use the default.
 // ---------------------------------------------------------------------------
 template <class Allocator>
-constexpr void multiply_toom_cook_4(const std::span<uint_multiprecision_t> result,
-                                    std::span<const uint_multiprecision_t> a,
-                                    std::span<const uint_multiprecision_t> b,
-                                    scratch_allocator<Allocator>&          scratch,
-                                    const std::size_t                      cutoff_override = 0) noexcept {
-    BEMAN_BIG_INT_DEBUG_ASSERT(!a.empty());
-    BEMAN_BIG_INT_DEBUG_ASSERT(!b.empty());
-    BEMAN_BIG_INT_DEBUG_ASSERT(result.size() >= trimmed_size_span(a) + trimmed_size_span(b));
-    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != a.data());
-    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != b.data());
+constexpr void multiply_toom_cook_4(const std::span<uint_multiprecision_t>       result,
+                                    const std::span<const uint_multiprecision_t> a_untrimmed,
+                                    const std::span<const uint_multiprecision_t> b_untrimmed,
+                                    scratch_allocator<Allocator>&                scratch,
+                                    const std::size_t                            cutoff_override = 0) noexcept {
+    BEMAN_BIG_INT_DEBUG_ASSERT(!a_untrimmed.empty());
+    BEMAN_BIG_INT_DEBUG_ASSERT(!b_untrimmed.empty());
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.size() >= trimmed_size_span(a_untrimmed) + trimmed_size_span(b_untrimmed));
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != a_untrimmed.data());
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != b_untrimmed.data());
 
-    a = a.first(trimmed_size_span(a));
-    b = b.first(trimmed_size_span(b));
+    const auto a = a_untrimmed.first(trimmed_size_span(a_untrimmed));
+    const auto b = b_untrimmed.first(trimmed_size_span(b_untrimmed));
 
     // Partition at k = ceil(max(an, bn) / 4).
     const std::size_t min_size         = std::min(a.size(), b.size());
@@ -1074,18 +1074,18 @@ constexpr void multiply_toom_cook_4(const std::span<uint_multiprecision_t> resul
 // Returns the number of significant result limbs (trimmed).
 // ---------------------------------------------------------------------------
 template <class Allocator>
-constexpr std::size_t multiply_dispatch(const std::span<uint_multiprecision_t> result,
-                                        std::span<const uint_multiprecision_t> a,
-                                        std::span<const uint_multiprecision_t> b,
-                                        Allocator&                             alloc) {
-    BEMAN_BIG_INT_DEBUG_ASSERT(!a.empty());
-    BEMAN_BIG_INT_DEBUG_ASSERT(!b.empty());
-    BEMAN_BIG_INT_DEBUG_ASSERT(result.size() >= a.size() + b.size());
-    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != a.data());
-    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != b.data());
+constexpr std::size_t multiply_dispatch(const std::span<uint_multiprecision_t>       result,
+                                        const std::span<const uint_multiprecision_t> a_untrimmed,
+                                        const std::span<const uint_multiprecision_t> b_untrimmed,
+                                        Allocator&                                   alloc) {
+    BEMAN_BIG_INT_DEBUG_ASSERT(!a_untrimmed.empty());
+    BEMAN_BIG_INT_DEBUG_ASSERT(!b_untrimmed.empty());
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.size() >= a_untrimmed.size() + b_untrimmed.size());
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != a_untrimmed.data());
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != b_untrimmed.data());
 
-    a = a.first(trimmed_size_span(a));
-    b = b.first(trimmed_size_span(b));
+    const auto a = a_untrimmed.first(trimmed_size_span(a_untrimmed));
+    const auto b = b_untrimmed.first(trimmed_size_span(b_untrimmed));
 
     // Trivial case, use single-limb shortcuts
     if (a.size() == 1 && b.size() == 1) {

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -701,9 +701,10 @@ constexpr void multiply_toom_cook_4(const std::span<uint_multiprecision_t> resul
     std::ranges::copy(a1, tmpb.begin());
     std::size_t aux_size = a1.size();
     aux_size             = add_into_tmp(tmpb, aux_size, a3);
-    const auto sub_a_m1  = subtract_unsigned_spans_signed(tmpa,
-                                                        std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
-                                                        std::span<const uint_multiprecision_t>{tmpb.data(), aux_size});
+    const auto sub_a_m1 =
+        subtract_unsigned_spans_signed(tmpa,
+                                       std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                                       std::span<const uint_multiprecision_t>{tmpb.data(), aux_size});
     tmpa_size            = sub_a_m1.size;
     const bool sign_a_m1 = sub_a_m1.negative;
 
@@ -712,11 +713,12 @@ constexpr void multiply_toom_cook_4(const std::span<uint_multiprecision_t> resul
     tmpb_size = add_into_tmp(tmpb, tmpb_size, b2);
     // tmpa now holds (a0 + a2) - (a1 + a3); reuse tail of vm1 as a scratch slot for (b1 + b3).
     std::ranges::copy(b1, vm1.begin());
-    aux_size            = b1.size();
-    aux_size            = add_into_tmp(vm1, aux_size, b3);
-    const auto sub_b_m1 = subtract_unsigned_spans_signed(tmpb,
-                                                        std::span<const uint_multiprecision_t>{tmpb.data(), tmpb_size},
-                                                        std::span<const uint_multiprecision_t>{vm1.data(), aux_size});
+    aux_size = b1.size();
+    aux_size = add_into_tmp(vm1, aux_size, b3);
+    const auto sub_b_m1 =
+        subtract_unsigned_spans_signed(tmpb,
+                                       std::span<const uint_multiprecision_t>{tmpb.data(), tmpb_size},
+                                       std::span<const uint_multiprecision_t>{vm1.data(), aux_size});
     tmpb_size            = sub_b_m1.size;
     const bool sign_b_m1 = sub_b_m1.negative;
     const bool sign_vm1  = sign_a_m1 ^ sign_b_m1;
@@ -771,9 +773,10 @@ constexpr void multiply_toom_cook_4(const std::span<uint_multiprecision_t> resul
     // tmpb holds 8*a3 + a1; we still need 2*a1, which is (8*a3 + a1) + a1 = 8*a3 + 2*a1.
     aux_size = add_into_tmp(tmpb, aux_size, a1);
 
-    const auto sub_a_m2  = subtract_unsigned_spans_signed(tmpa,
-                                                        std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
-                                                        std::span<const uint_multiprecision_t>{tmpb.data(), aux_size});
+    const auto sub_a_m2 =
+        subtract_unsigned_spans_signed(tmpa,
+                                       std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                                       std::span<const uint_multiprecision_t>{tmpb.data(), aux_size});
     tmpa_size            = sub_a_m2.size;
     const bool sign_a_m2 = sub_a_m2.negative;
 
@@ -792,9 +795,10 @@ constexpr void multiply_toom_cook_4(const std::span<uint_multiprecision_t> resul
     aux_size = add_into_tmp(vm2, aux_size, b1);
     aux_size = add_into_tmp(vm2, aux_size, b1);
 
-    const auto sub_b_m2  = subtract_unsigned_spans_signed(tmpb,
-                                                        std::span<const uint_multiprecision_t>{tmpb.data(), tmpb_size},
-                                                        std::span<const uint_multiprecision_t>{vm2.data(), aux_size});
+    const auto sub_b_m2 =
+        subtract_unsigned_spans_signed(tmpb,
+                                       std::span<const uint_multiprecision_t>{tmpb.data(), tmpb_size},
+                                       std::span<const uint_multiprecision_t>{vm2.data(), aux_size});
     tmpb_size            = sub_b_m2.size;
     const bool sign_b_m2 = sub_b_m2.negative;
     const bool sign_vm2  = sign_a_m2 ^ sign_b_m2;

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -265,7 +265,7 @@ constexpr void multiply_karatsuba(const std::span<uint_multiprecision_t> result,
 // ---------------------------------------------------------------------------
 
 // In-place tmp[0..size) += addend; returns new size (may grow by 1).
-constexpr std::size_t add_into_tmp(const std::span<uint_multiprecision_t>       tmp,
+[[nodiscard]] constexpr std::size_t add_into_tmp(const std::span<uint_multiprecision_t>       tmp,
                                    const std::size_t                            size,
                                    const std::span<const uint_multiprecision_t> addend) noexcept {
     if (addend.empty()) {
@@ -289,7 +289,8 @@ constexpr std::size_t add_into_tmp(const std::span<uint_multiprecision_t>       
 // In-place tmp[0..size) <<= 1; returns new size (may grow by 1).
 // Pass size == tmp.size() to shift the full span; the carry-branch assertion
 // then enforces that the shift did not overflow.
-constexpr std::size_t shift_left_one(const std::span<uint_multiprecision_t> tmp, std::size_t size) noexcept {
+[[nodiscard]] constexpr std::size_t shift_left_one(const std::span<uint_multiprecision_t> tmp,
+                                                   std::size_t                            size) noexcept {
     if (size == 0) {
         return 0;
     }
@@ -312,7 +313,7 @@ constexpr std::size_t shift_left_one(const std::span<uint_multiprecision_t> tmp,
 }
 
 // In-place tmp >>= 1; returns the dropped low bit (caller asserts == 0 for exact div).
-constexpr uint_multiprecision_t shift_right_one(const std::span<uint_multiprecision_t> tmp) noexcept {
+[[nodiscard]] constexpr uint_multiprecision_t shift_right_one(const std::span<uint_multiprecision_t> tmp) noexcept {
     if (tmp.empty()) {
         return 0;
     }
@@ -1017,8 +1018,10 @@ constexpr void multiply_toom_cook_4(const std::span<uint_multiprecision_t> resul
     // Step 22: tmp_double = D1; vm1 *= 4; vm1 += tmp_double  (-> 5*D1).
     std::ranges::fill(tmp_double, uint_multiprecision_t{0});
     std::ranges::copy(vm1_view, tmp_double.begin());
-    shift_left_one(vm1, vm1.size()); // 2*D1
-    shift_left_one(vm1, vm1.size()); // 4*D1
+    [[maybe_unused]] const auto sz_2D1 = shift_left_one(vm1, vm1.size()); // 2*D1
+    BEMAN_BIG_INT_DEBUG_ASSERT(sz_2D1 == vm1.size());
+    [[maybe_unused]] const auto sz_4D1 = shift_left_one(vm1, vm1.size()); // 4*D1
+    BEMAN_BIG_INT_DEBUG_ASSERT(sz_4D1 == vm1.size());
     {
         [[maybe_unused]] const bool carry = add_unsigned_spans(vm1, vm1_view, td_view); // 5*D1
         BEMAN_BIG_INT_DEBUG_ASSERT(!carry);

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -345,8 +345,8 @@ constexpr void add_shifted(const std::span<uint_multiprecision_t>       result,
 }
 
 // Minimum number of limbs for Toom-Cook 3 to be worthwhile.
-// Toom-Cook 3 first beats Karatsuba around 800 limbs on Apple Silicon.
-inline constexpr std::size_t toom_cook_3_cutoff = 800;
+// See multiplication_stress_bench for tuning
+inline constexpr std::size_t toom_cook_3_cutoff = 550;
 
 // Heuristic estimate of scratch space needed for Toom-Cook 3 multiplication.
 // Includes space for karatsuba fallback plan
@@ -574,7 +574,7 @@ constexpr void multiply_toom_cook_3(const std::span<uint_multiprecision_t> resul
 
 // Minimum number of limbs for Toom-Cook 4 to be worthwhile.
 // Empirically tuned on Apple Silicon via multiplication_stress_bench
-inline constexpr std::size_t toom_cook_4_cutoff = 4500;
+inline constexpr std::size_t toom_cook_4_cutoff = 1400;
 
 // Heuristic estimate of scratch space needed for Toom-Cook 4 multiplication.
 // One Toom-4 level uses 14k+16 limbs (~3.5*s where k = ceil(s/4)). The geometric

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -266,8 +266,8 @@ constexpr void multiply_karatsuba(const std::span<uint_multiprecision_t>       r
 
 // In-place tmp[0..size) += addend; returns new size (may grow by 1).
 [[nodiscard]] constexpr std::size_t add_into_tmp(const std::span<uint_multiprecision_t>       tmp,
-                                   const std::size_t                            size,
-                                   const std::span<const uint_multiprecision_t> addend) noexcept {
+                                                 const std::size_t                            size,
+                                                 const std::span<const uint_multiprecision_t> addend) noexcept {
     if (addend.empty()) {
         return size;
     }

--- a/tests/beman/big_int/multiplication_stress_bench.test.cpp
+++ b/tests/beman/big_int/multiplication_stress_bench.test.cpp
@@ -169,11 +169,10 @@ constexpr algorithm_runner algorithms[] = {
 // Limb counts to sample. Dense coverage at the low end for the
 // schoolbook -> Karatsuba crossover, dense in the middle for the
 // Karatsuba -> Toom-Cook 3 crossover, then a coarser tail.
-constexpr std::size_t sweep_limbs[] = {
-    2,   4,   6,   8,   10,  12,  14,  16,  20,  24,  28,  32,  36,   40,   48,   56,   64,   72,   80,   96,
-    112, 128, 144, 160, 192, 224, 256, 300, 400, 500, 550, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1600, 2000, 2500, 3200, 4000, 5000,
-    6000, 8000, 10000, 15000, 30000
-};
+constexpr std::size_t sweep_limbs[] = {2,    4,    6,    8,    10,   12,   14,   16,   20,   24,    28,    32,   36,
+                                       40,   48,   56,   64,   72,   80,   96,   112,  128,  144,   160,   192,  224,
+                                       256,  300,  400,  500,  550,  600,  700,  800,  900,  1000,  1100,  1200, 1300,
+                                       1400, 1600, 2000, 2500, 3200, 4000, 5000, 6000, 8000, 10000, 15000, 30000};
 
 // Aim for ~0.2-1 second per data point. Trial counts taper as the cost per
 // multiplication grows. Adjust if a machine is much faster/slower than the

--- a/tests/beman/big_int/multiplication_stress_bench.test.cpp
+++ b/tests/beman/big_int/multiplication_stress_bench.test.cpp
@@ -136,16 +136,16 @@ double run_toom_cook_4_at(const std::size_t limbs, const unsigned trials) {
     // 3*k correctness gate (small inputs still fall through). Recursive sub-products
     // use the default cutoff so they fall back to Toom-3 / Karatsuba / schoolbook
     // as they would in production.
-    return measure_algorithm(
-        limbs,
-        trials,
-        ::beman::big_int::detail::toom_cook_4_storage_size(limbs),
-        [](const std::span<uint_t>       r,
-           const std::span<const uint_t> a,
-           const std::span<const uint_t> b,
-           scratch_for_test&             s) {
-            ::beman::big_int::detail::multiply_toom_cook_4(r.first(a.size() + b.size()), a, b, s, std::size_t{1});
-        });
+    return measure_algorithm(limbs,
+                             trials,
+                             ::beman::big_int::detail::toom_cook_4_storage_size(limbs),
+                             [](const std::span<uint_t>       r,
+                                const std::span<const uint_t> a,
+                                const std::span<const uint_t> b,
+                                scratch_for_test&             s) {
+                                 ::beman::big_int::detail::multiply_toom_cook_4(
+                                     r.first(a.size() + b.size()), a, b, s, std::size_t{1});
+                             });
 }
 
 // Registry of algorithms to sweep. Each entry constrains the sweep to a

--- a/tests/beman/big_int/multiplication_stress_bench.test.cpp
+++ b/tests/beman/big_int/multiplication_stress_bench.test.cpp
@@ -131,6 +131,23 @@ double run_toom_cook_3_at(const std::size_t limbs, const unsigned trials) {
                              });
 }
 
+double run_toom_cook_4_at(const std::size_t limbs, const unsigned trials) {
+    // cutoff_override=1 forces Toom-4 to run at any input size that clears the
+    // 3*k correctness gate (small inputs still fall through). Recursive sub-products
+    // use the default cutoff so they fall back to Toom-3 / Karatsuba / schoolbook
+    // as they would in production.
+    return measure_algorithm(
+        limbs,
+        trials,
+        ::beman::big_int::detail::toom_cook_4_storage_size(limbs),
+        [](const std::span<uint_t>       r,
+           const std::span<const uint_t> a,
+           const std::span<const uint_t> b,
+           scratch_for_test&             s) {
+            ::beman::big_int::detail::multiply_toom_cook_4(r.first(a.size() + b.size()), a, b, s, std::size_t{1});
+        });
+}
+
 // Registry of algorithms to sweep. Each entry constrains the sweep to a
 // reasonable range: too small and the algorithm's own internal cutoff just
 // falls back to the previous tier; too large and a single multiplication
@@ -188,7 +205,13 @@ constexpr std::size_t sweep_limbs[] = {
         return 30U;
     }
     if (limbs <= 2000) {
+        return 15U;
+    }
+    if (limbs <= 5000) {
         return 10U;
+    }
+    if (limbs <= 7000) {
+        return 5U;
     }
     return 3U;
 }

--- a/tests/beman/big_int/multiplication_stress_bench.test.cpp
+++ b/tests/beman/big_int/multiplication_stress_bench.test.cpp
@@ -162,10 +162,8 @@ struct algorithm_runner {
 constexpr algorithm_runner algorithms[] = {
     {"schoolbook", 2, 200, run_long_at},
     {"karatsuba", 4, 2000, run_karatsuba_at},
-    {"toom-cook-3", 800, 5000, run_toom_cook_3_at},
-    // Future additions, e.g.:
-    // {"toom-cook-4", 2000, 10000, run_toom_cook_4_at},
-    // {"toom-cook-5", 5000, 20000, run_toom_cook_5_at},
+    {"toom-cook-3", 300, 10000, run_toom_cook_3_at},
+    {"toom-cook-4", 300, 30000, run_toom_cook_4_at},
 };
 
 // Limb counts to sample. Dense coverage at the low end for the
@@ -173,7 +171,8 @@ constexpr algorithm_runner algorithms[] = {
 // Karatsuba -> Toom-Cook 3 crossover, then a coarser tail.
 constexpr std::size_t sweep_limbs[] = {
     2,   4,   6,   8,   10,  12,  14,  16,  20,  24,  28,  32,  36,   40,   48,   56,   64,   72,   80,   96,
-    112, 128, 144, 160, 192, 224, 256, 320, 400, 500, 640, 800, 1000, 1280, 1600, 2000, 2500, 3200, 4000, 5000,
+    112, 128, 144, 160, 192, 224, 256, 300, 400, 500, 550, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1600, 2000, 2500, 3200, 4000, 5000,
+    6000, 8000, 10000, 15000, 30000
 };
 
 // Aim for ~0.2-1 second per data point. Trial counts taper as the cost per
@@ -198,19 +197,13 @@ constexpr std::size_t sweep_limbs[] = {
     if (limbs <= 256) {
         return 500U;
     }
-    if (limbs <= 512) {
+    if (limbs <= 3000) {
         return 100U;
     }
-    if (limbs <= 1024) {
+    if (limbs <= 20'000) {
         return 30U;
     }
-    if (limbs <= 2000) {
-        return 15U;
-    }
-    if (limbs <= 5000) {
-        return 10U;
-    }
-    if (limbs <= 7000) {
+    if (limbs <= 100'000) {
         return 5U;
     }
     return 3U;

--- a/tests/beman/big_int/toom_cook_4.test.cpp
+++ b/tests/beman/big_int/toom_cook_4.test.cpp
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: BSL-1.0
+
+#include "boost_mp_testing.hpp"
+#include "testing.hpp"
+#include <gtest/gtest.h>
+#include <cstddef>
+
+namespace bmp = ::beman::big_int::boost_mp_testing;
+
+constexpr std::size_t limb_bits =
+    static_cast<std::size_t>(std::numeric_limits<::beman::big_int::uint_multiprecision_t>::digits);
+
+// Toom-Cook 4 cutoff is 4500 limbs. Tests around the boundary verify both
+// that the dispatcher correctly enters Toom-4 above the cutoff and that
+// the algorithm produces correct results for varying input sizes.
+
+void check_balanced(const std::size_t limbs_a, const std::size_t limbs_b) {
+    const std::string a = bmp::random_big_int(limbs_a * limb_bits);
+    const std::string b = bmp::random_big_int(limbs_b * limb_bits);
+    EXPECT_TRUE(bmp::check_cpp_int_equal(std::multiplies<>{}, a, b));
+}
+
+TEST(Multiplication, ToomCook4AtCutoff) {
+    // Both operands exactly at the Toom-Cook 4 cutoff. Forces dispatch into
+    // Toom-4 with shallow recursion (k = 1125, so all sub-products fall back
+    // to Toom-3 / Karatsuba).
+    check_balanced(4500, 4500);
+}
+
+TEST(Multiplication, ToomCook4JustAboveCutoff) {
+    check_balanced(4501, 4501);
+    check_balanced(4600, 4600);
+}
+
+TEST(Multiplication, ToomCook4JustBelowCutoff) {
+    // Both 4499 limbs: dispatcher uses Toom-3, not Toom-4. Sanity check
+    // that the cutoff gate works as expected.
+    check_balanced(4499, 4499);
+}
+
+TEST(Multiplication, ToomCook4DeepRecursion) {
+    // Large enough to drive an extra Toom-4 recursion level.
+    // At cutoff 4500, a 20000-limb call splits into k=5000 sub-products,
+    // which clear the cutoff, so two Toom-4 levels run before the cascade
+    // drops into Toom-3.
+    check_balanced(20000, 20000);
+}
+
+TEST(Multiplication, ToomCook4AsymmetricBalanced) {
+    // Asymmetric but within the algorithm's min > 3*k gate, so Toom-4 is
+    // still used. For each pair, k = ceil(max/4) and we ensure min > 3*k.
+    check_balanced(4700, 5500);  // k=1375, 3k=4125 < 4700
+    check_balanced(5500, 6500);  // k=1625, 3k=4875 < 5500
+    check_balanced(8000, 10000); // k=2500, 3k=7500 < 8000
+}
+
+TEST(Multiplication, ToomCook4AsymmetricFallback) {
+    // Asymmetric beyond the gate: Toom-4 falls back to Toom-3 even though
+    // both operands clear the cutoff. min <= 3*k violates the invariant that
+    // both a3 and b3 are non-empty.
+    check_balanced(4500, 8000);  // k=2000, 3k=6000 >= 4500 -> fallback
+    check_balanced(5000, 12000); // k=3000, 3k=9000 >= 5000 -> fallback
+}
+
+TEST(Multiplication, ToomCook4Squaring) {
+    // a * a (same operand) at sizes that exercise Toom-4.
+    const std::string a = bmp::random_big_int(4700 * limb_bits);
+    EXPECT_TRUE(bmp::check_cpp_int_equal(std::multiplies<>{}, a, a));
+
+    const std::string b = bmp::random_big_int(6000 * limb_bits);
+    EXPECT_TRUE(bmp::check_cpp_int_equal(std::multiplies<>{}, b, b));
+}
+
+TEST(Multiplication, ToomCook4SignedOperands) {
+    // Negative operand handling is independent of the algorithm choice, but
+    // confirm the sign propagation works at Toom-4 sizes.
+    const std::string a = bmp::random_big_int(4700 * limb_bits, /*negative=*/true);
+    const std::string b = bmp::random_big_int(4700 * limb_bits, /*negative=*/false);
+    EXPECT_TRUE(bmp::check_cpp_int_equal(std::multiplies<>{}, a, b));
+
+    const std::string c = bmp::random_big_int(4700 * limb_bits, /*negative=*/true);
+    const std::string d = bmp::random_big_int(4700 * limb_bits, /*negative=*/true);
+    EXPECT_TRUE(bmp::check_cpp_int_equal(std::multiplies<>{}, c, d));
+}

--- a/tests/beman/big_int/toom_cook_4_exercise.test.cpp
+++ b/tests/beman/big_int/toom_cook_4_exercise.test.cpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: BSL-1.0
+
+#include "boost_mp_testing.hpp"
+#include "testing.hpp"
+#include <gtest/gtest.h>
+
+namespace bmp = ::beman::big_int::boost_mp_testing;
+
+namespace local {
+
+namespace detail {
+
+using random_engine_length_type =
+    ::std::linear_congruential_engine<::std::uint32_t, UINT32_C(48271), UINT32_C(0), UINT32_C(2147483647)>;
+
+random_engine_length_type generator_limb_length{static_cast<typename random_engine_length_type::result_type>(53)};
+
+// Toom-Cook 4 cutoff is 4500 limbs. Sizes 4600..6500 exercise the algorithm:
+// balanced pairs enter Toom-4 directly, asymmetric pairs may fall back to
+// Toom-3 (min <= 3*k), so both paths get coverage.
+std::uniform_int_distribution distribution_limb_length{std::size_t{UINT16_C(4600)}, std::size_t{UINT16_C(6500)}};
+
+} // namespace detail
+
+auto test_one_multiplication() -> void {
+    constexpr std::size_t limb_bits{
+        static_cast<std::size_t>(std::numeric_limits<::beman::big_int::uint_multiprecision_t>::digits)};
+
+    const std::size_t len_a_in_bits{detail::distribution_limb_length(detail::generator_limb_length) * limb_bits};
+    const std::size_t len_b_in_bits{detail::distribution_limb_length(detail::generator_limb_length) * limb_bits};
+
+    const std::string str_a{bmp::random_big_int(len_a_in_bits)};
+    const std::string str_b{bmp::random_big_int(len_b_in_bits)};
+
+    EXPECT_TRUE(bmp::check_cpp_int_equal(std::multiplies<>{}, str_a, str_b));
+}
+
+} // namespace local
+
+TEST(Multiplication, ToomCook4Exercise01) {
+    // Trial count kept small because each multiplication operates on
+    // large (2500-4000 limb) operands to clear the Toom-4 cutoff.
+    constexpr unsigned trials{16U};
+
+    for (unsigned index{0U}; index < trials; ++index) {
+        static_cast<void>(index);
+
+        local::test_one_multiplication();
+    }
+}


### PR DESCRIPTION
Similar to Toom-Cook 3 we follow Bodrato (http://marco.bodrato.it/papers/Bodrato2007-OptimalToomCookMultiplicationForBinaryFieldAndIntegers.pdf). Removes some of the lambdas from Toom-Cook 3 and converts them to shared usage free functions. Future work is tuning the memory allocations across the board. After some testing I have 6s here, but Toom-Cook 3 is currently using 8s. We can roll our own allocator with public test probes to figure this out.

Closes: #214 

CC: @ckormanyos 