### PR TITLE
Add shortcut for large power of two multiplications

### DIFF
--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -10,6 +10,7 @@
 #include <beman/big_int/detail/scratch_allocator.hpp>
 
 #include <algorithm>
+#include <bit>
 #include <compare>
 #include <memory>
 #include <span>
@@ -215,6 +216,30 @@ void multiply_toom_cook_6_5(const std::span<uint_multiprecision_t>       result,
                             const std::span<const uint_multiprecision_t> b_untrimmed,
                             scratch_allocator_base&                      scratch,
                             const std::size_t                            cutoff_override = 0) noexcept;
+
+// ---------------------------------------------------------------------------
+// result <- a * p2 where p2 is a trimmed power of two: a shifted copy of `a`
+// placed at limb offset p2.size() - 1, bit-shifted by countr_zero(p2.back()).
+// O(n) with no scratch, versus a full kernel dispatch (see GMP mpz_mul_2exp).
+// `result` must be pre-zeroed, have space for a.size() + p2.size() limbs, and
+// must NOT alias `a`. Returns the number of significant result limbs.
+// ---------------------------------------------------------------------------
+constexpr std::size_t multiply_power_of_two(const std::span<uint_multiprecision_t>       result,
+                                            const std::span<const uint_multiprecision_t> a,
+                                            const std::span<const uint_multiprecision_t> p2) noexcept {
+    BEMAN_BIG_INT_DEBUG_ASSERT(is_power_of_two_span(p2));
+    BEMAN_BIG_INT_DEBUG_ASSERT(!a.empty());
+    BEMAN_BIG_INT_DEBUG_ASSERT(a.back() != 0);
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.size() >= a.size() + p2.size());
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != a.data());
+
+    const std::size_t limb_offset = p2.size() - 1;
+    const auto        bit_shift   = static_cast<unsigned>(std::countr_zero(p2.back()));
+    const auto        dst         = result.subspan(limb_offset);
+
+    std::ranges::copy(a, dst.begin());
+    return limb_offset + shift_left_n(dst, a.size(), bit_shift);
+}
 
 // ---------------------------------------------------------------------------
 // Top-level multiplication dispatcher.

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -275,12 +275,31 @@ constexpr std::size_t multiply_dispatch(const std::span<uint_multiprecision_t>  
         return multiply_single_limb(result, a, b[0]);
     }
 
-    // Choose algorithm to use based off the tuned cutoffs.
+    // This check has 0 runtime cost, but could speed up/reduce depth of constant evaluation
+    if BEMAN_BIG_INT_IS_CONSTEVAL {
+        if (is_power_of_two_span(b)) {
+            return multiply_power_of_two(result, a, b);
+        }
+        if (is_power_of_two_span(a)) {
+            return multiply_power_of_two(result, b, a);
+        }
+    }
+
+    // Choose an algorithm to use based off the tuned cutoffs.
     // Avoid these at compile time because the recursion depth could blow up consteval limits;
     // long multiplication works just fine in that case.
     if BEMAN_BIG_INT_IS_NOT_CONSTEVAL {
         const std::size_t min_size = std::min(a.size(), b.size());
         if (min_size >= karatsuba_cutoff) {
+            // Power-of-two operands reduce to a shifted copy of the other operand.
+            // This is only worth checking if we're about to do a big number mul anyway
+            if (is_power_of_two_span(b)) {
+                return multiply_power_of_two(result, a, b);
+            }
+            if (is_power_of_two_span(a)) {
+                return multiply_power_of_two(result, b, a);
+            }
+
             const std::size_t s            = std::max(a.size(), b.size());
             const std::size_t result_total = a.size() + b.size();
 

--- a/include/beman/big_int/detail/span_ops.hpp
+++ b/include/beman/big_int/detail/span_ops.hpp
@@ -6,6 +6,7 @@
 
 #include <beman/big_int/detail/config.hpp>
 #include <algorithm>
+#include <bit>
 #include <initializer_list>
 #include <ranges>
 #include <utility>
@@ -41,6 +42,14 @@ namespace beman::big_int::detail {
 // Returns true if all limbs in the span are zero
 constexpr bool is_span_zero(const std::span<const uint_multiprecision_t> s) noexcept {
     return std::ranges::all_of(s, [](const uint_multiprecision_t limb) { return limb == 0; });
+}
+
+// Returns true if the trimmed span holds exactly a power of two (a single set
+// bit in the top limb, all lower limbs zero). Cheap for ordinary values: the
+// single-bit test on the top limb almost always fails, and the zero-scan exits
+// at the first non-zero low limb.
+[[nodiscard]] constexpr bool is_power_of_two_span(const std::span<const uint_multiprecision_t> s) noexcept {
+    return !s.empty() && std::has_single_bit(s.back()) && is_span_zero(s.first(s.size() - 1));
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/beman/big_int/multiplication.test.cpp
+++ b/tests/beman/big_int/multiplication.test.cpp
@@ -67,6 +67,17 @@ consteval bool move_heap_mul() {
 }
 static_assert(move_heap_mul());
 
+consteval bool ce_power_of_two_multi_limb() {
+    // At compile time power-of-two operands take the shifted-copy path
+    // unconditionally (no cutoff gate), keeping large products within
+    // consteval step limits.
+    const big_int a = big_int{1} << 2600;
+    const big_int b = big_int{1} << 2600;
+    const big_int c = big_int{1} << 130;
+    return (a * b) == (big_int{1} << 5200) && (c * c) == (big_int{1} << 260);
+}
+static_assert(ce_power_of_two_multi_limb());
+
 // ----- runtime tests -----
 
 TEST(Multiplication, SmallPositivePositive) {
@@ -329,6 +340,69 @@ TEST(Multiplication, MultiLimbSquaring) {
     const big_int r        = a * a;
     const big_int expected = (big_int{1} << 256) + (-(big_int{1} << 129)) + big_int{1};
     EXPECT_EQ(r, expected);
+}
+
+TEST(Multiplication, PowerOfTwoMultiLimbTimesDense) {
+    // The power-of-two dispatch path engages once BOTH operands clear the
+    // karatsuba cutoff (here only k = 4096: a 65-limb 2^k against the 79-limb
+    // dense operand); smaller k values exercise tiny-pow2 * large-dense via
+    // the long-mul fallback. The result must match the independently
+    // implemented shift operator. Bit positions cover limb-aligned shifts,
+    // top-bit carry-out, and both operand orders.
+    const big_int dense = (big_int{1} << 5000) - 1;
+    for (const unsigned k : {64U, 65U, 127U, 128U, 191U, 200U, 4096U}) {
+        const big_int p2 = big_int{1} << k;
+        EXPECT_EQ(dense * p2, dense << k);
+        EXPECT_EQ(p2 * dense, dense << k);
+    }
+}
+
+TEST(Multiplication, PowerOfTwoTimesPowerOfTwo) {
+    // Bit positions below and above the karatsuba cutoff (40 limbs = 2560
+    // bits) cover both the long-mul fallback and the shifted-copy path
+    // (4096 x 4096 is the pair where both operands clear the cutoff).
+    for (const unsigned j : {64U, 127U, 128U, 1000U, 4096U}) {
+        for (const unsigned k : {64U, 127U, 128U, 1000U, 4096U}) {
+            const big_int lhs = big_int{1} << j;
+            const big_int rhs = big_int{1} << k;
+            EXPECT_EQ(lhs * rhs, big_int{1} << (j + k));
+        }
+    }
+}
+
+TEST(Multiplication, NearPowerOfTwoNotMisdetected) {
+    // Values whose top limb is a single bit but with non-zero limbs below must
+    // not take the shift path; verify products via algebraic identities.
+    const big_int m = (big_int{1} << 300) - 1;
+
+    const big_int just_above = (big_int{1} << 256) + 1;
+    EXPECT_EQ(just_above * m, (m << 256) + m);
+
+    const big_int two_sparse_bits = (big_int{1} << 256) + (big_int{1} << 32);
+    EXPECT_EQ(two_sparse_bits * m, (m << 256) + (m << 32));
+
+    const big_int three_p2 = big_int{3} << 256;
+    EXPECT_EQ(three_p2 * m, (m << 257) + (m << 256));
+
+    const big_int all_ones = (big_int{1} << 256) - 1;
+    EXPECT_EQ(all_ones * m, (m << 256) - m);
+}
+
+TEST(Multiplication, PowerOfTwoSignsPreserved) {
+    const big_int x  = (big_int{1} << 200) - 12345;
+    const big_int p2 = big_int{1} << 100;
+    EXPECT_EQ((-x) * p2, -(x << 100));
+    EXPECT_EQ(x * (-p2), -(x << 100));
+    EXPECT_EQ((-x) * (-p2), x << 100);
+}
+
+TEST(Multiplication, PowerOfTwoLargeOperands) {
+    // Sizes that previously dispatched into Karatsuba / Toom-Cook.
+    const big_int  dense = (big_int{1} << 320000) - 1; // 5000 limbs
+    const unsigned k     = 320000U;
+    const big_int  p2    = big_int{1} << k;
+    EXPECT_EQ(dense * p2, dense << k);
+    EXPECT_EQ(p2 * p2, big_int{1} << (2U * k));
 }
 
 TEST(Multiplication, Mersenne) {


### PR DESCRIPTION
We only check if we can do a power of two mul when we're about to use a Toom-Cook algorithm or at compile time since those will cost 0 or effectively 0 compared to the full sparse multiplication. For values in the schoolbook or karatsuba range nothing is changed as those are already very cheap. In the mersenne benchmark we are between 333 and 668 times faster. 

For future investigations we should look into an optimized path for squaring.