### PR TITLE
Asym Kara cutoff and fallback

### DIFF
--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -66,7 +66,8 @@ constexpr void multiply_long(const std::span<uint_multiprecision_t>       result
 
 // Minimum number of limbs for Karatsuba to be worthwhile
 // Directly from Boost, and reconfirmed as correct
-inline constexpr std::size_t karatsuba_cutoff = 40;
+inline constexpr std::size_t karatsuba_cutoff   = 48;
+inline constexpr std::size_t karatsuba_fallback = 24;
 
 // Heuristic estimate of scratch space needed for Karatsuba multiplication.
 // One Karatsuba level uses ~2*s limbs (t1=2n+2, t2=t3=n+1 with n=s/2+1). The

--- a/src/karatsuba.cpp
+++ b/src/karatsuba.cpp
@@ -19,7 +19,7 @@ void multiply_karatsuba(const std::span<uint_multiprecision_t>       result,
     const auto b = b_untrimmed.first(trimmed_size_span(b_untrimmed));
 
     // First, check if we have enough limbs to justify karatsuba
-    if (a.size() < karatsuba_cutoff || b.size() < karatsuba_cutoff) {
+    if (a.size() < karatsuba_fallback || b.size() < karatsuba_fallback) {
         multiply_long(result.first(a.size() + b.size()), a, b);
         return;
     }

--- a/tests/beman/big_int/perf/README.md
+++ b/tests/beman/big_int/perf/README.md
@@ -112,14 +112,14 @@ two big integers produces a result having double the width of its operands.
 The time and the relative time compared with the best time (see the square brackets)
 are shown for each big integer type at each digit setting.
 
-| 64-bit limbs   | approx base-10 digits | us per mul  `big_int`  | us per mul  `cpp_int`  | us per mul  `gmp_int` |
-|----------------|-----------------------|------------------------|------------------------|-----------------------|
-| 128            | 2,500                 |   9.2   [2.1]          |   8.6   [2.0]          |   4.3   [1.0]         |
-| 512            | 9,900                 |   84    [2.9]          |   71    [2.7]          |   29    [1.0]         |
-| 1,024          | 20,000                |   200   [2.6]          |   250   [3.0]          |   77    [1.0]         |
-| 2,048          | 39,000                |   580   [2.9]          |   760   [3.6]          |   200   [1.0]         |
-| 8,192          | 160,000               |   4,600 [3.5]          |   6,400 [4.9], see (2) |   1,300 [1.0]         |
-| 32,768         | 631,000               |  28,000 [4.7], see (1) |  58,000 [9.8]          |   5,900 [1.0]         |
+| 64-bit limbs   | bit width    | approx base-10 digits | us per mul  `big_int`  | us per mul  `cpp_int`  | us per mul  `gmp_int` |
+|----------------|--------------|-----------------------|------------------------|------------------------|-----------------------|
+| 128            | 8,192        | 2,500                 |   8.2   [2.0]          |   9.6   [2.3]          |   4.1   [1.0]         |
+| 512            | 32,768       | 9,900                 |   74    [2.6]          |   85    [2.9]          |   29    [1.0]         |
+| 1,024          | 65,536       | 20,000                |   210   [2.7]          |   250   [3.2]          |   78    [1.0]         |
+| 2,048          | 131,072      | 39,000                |   590   [3.0]          |   760   [3.6]          |   200   [1.0]         |
+| 8,192          | 524,288      | 160,000               |   4,100 [3.2]          |   6,800 [5.2], see (2) |   1,300 [1.0]         |
+| 32,768         | 2,097,152    | 631,000               |  28,000 [4.7], see (1) |  58,000 [9.8]          |   5,900 [1.0]         |
 
 GMP is written in hand-coded assembly in its hot-spots and is known as the _industry_ _standard_
 of performance. The relative multiplication timing of `beman.big_int` compared with `gmp_int`


### PR DESCRIPTION
This PR investigates an asymmetric Karatsuba cutoff and fallback. Instead of $40/40$, use $48/24$.

On a few of my compilers, I obtain a not huge, but worthwhile performance improvement. I observed this phenomenon in another project and would  like to see if it makes sense here.

I need an independent confirmation of the asymmetric improvement.

I get:

| 64-bit limbs     | time mul [us] (asym)  | time mul [us] (40/40) |
|-----------------|-------------------------|------------------------|
| 48                    | 1.8                               | 1.9      |
| 128                  | 7.9                               | 8.8      |
| 256                  | 24.3                           | 27.5      |

Cc: @mborland 