### PR TITLE
Add special cases for squaring

### DIFF
--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -472,12 +472,23 @@ constexpr std::size_t multiply_dispatch(const std::span<uint_multiprecision_t>  
         if (is_power_of_two_span(a)) {
             return multiply_power_of_two(result, b, a);
         }
+        // Squaring halves the widening muls, and so the consteval step count.
+        if (a.data() == b.data() && a.size() == b.size()) {
+            square_long(result, a);
+            return trimmed_size_span(std::span<const uint_multiprecision_t>{result.data(), 2 * a.size()});
+        }
     }
 
     // Choose an algorithm to use based off the tuned cutoffs.
     // Avoid these at compile time because the recursion depth could blow up consteval limits;
     // long multiplication works just fine in that case.
     if BEMAN_BIG_INT_IS_NOT_CONSTEVAL {
+        // x * x and x *= x pass the same span twice, so squaring detection is
+        // a pointer compare that almost always fails fast for ordinary mul
+        if (a.data() == b.data() && a.size() == b.size()) {
+            return square_dispatch(result, a, alloc);
+        }
+
         const std::size_t min_size = std::min(a.size(), b.size());
         if (min_size >= karatsuba_cutoff) {
             // Power-of-two operands reduce to a shifted copy of the other operand.

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -168,9 +168,9 @@ void square_karatsuba(const std::span<uint_multiprecision_t>       result,
                       scratch_allocator_base&                      scratch,
                       const std::size_t                            cutoff_override = 0) noexcept;
 
-// Minimum number of limbs for Toom-Cook 3 to be worthwhile.
-// See multiplication_stress_bench for tuning
-inline constexpr std::size_t toom_cook_3_cutoff = 300;
+// Minimum number of limbs for Toom-Cook 3 to be worthwhile. Karatsuba still
+// wins at 300-350 limbs (~15%); Toom-3 reliably overtakes from ~400.
+// Tuned via multiplication_stress_bench.
 inline constexpr std::size_t toom_cook_3_cutoff = 400;
 
 // Heuristic estimate of scratch space needed for Toom-Cook 3 multiplication.
@@ -229,9 +229,9 @@ void square_toom_cook_3(const std::span<uint_multiprecision_t>       result,
                         scratch_allocator_base&                      scratch,
                         const std::size_t                            cutoff_override = 0) noexcept;
 
-// Minimum number of limbs for Toom-Cook 4 to be worthwhile.
-// Empirically tuned on Apple Silicon via multiplication_stress_bench
-inline constexpr std::size_t toom_cook_4_cutoff = 1400;
+// Minimum number of limbs for Toom-Cook 4 to be worthwhile. Toom-3 still wins
+// at 1400 (~9%); Toom-4 reliably overtakes from ~1600.
+// Tuned via multiplication_stress_bench.
 inline constexpr std::size_t toom_cook_4_cutoff = 1600;
 
 // Heuristic estimate of scratch space needed for Toom-Cook 4 multiplication.
@@ -290,8 +290,10 @@ void square_toom_cook_4(const std::span<uint_multiprecision_t>       result,
                         scratch_allocator_base&                      scratch,
                         const std::size_t                            cutoff_override = 0) noexcept;
 
-// See tests/beman/big_int/perf crossover_speedup.png
-inline constexpr std::size_t toom_cook_6_5_cutoff = 3000;
+// See tests/beman/big_int/perf crossover_speedup.png. Toom-6.5 overtakes Toom-4
+// cleanly and monotonically from ~2400 limbs (re-measured 2026-06-04; the old
+// 3000 left a ~2400-3000 band on the slower Toom-4).
+// Tuned via multiplication_stress_bench.
 inline constexpr std::size_t toom_cook_6_5_cutoff = 2400;
 
 // Heuristic estimate of scratch space needed for Toom-Cook 6.5 multiplication.

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -261,6 +261,25 @@ void multiply_toom_cook_4(const std::span<uint_multiprecision_t>       result,
                           scratch_allocator_base&                      scratch,
                           const std::size_t                            cutoff_override = 0) noexcept;
 
+// Minimum number of limbs for the Toom-Cook 4 squaring variant; roughly twice
+// the general toom_cook_4_cutoff, mirroring the SQR/MUL threshold ratio.
+// Tuned via multiplication_stress_bench.
+inline constexpr std::size_t square_toom_cook_4_cutoff = 2000;
+
+// ---------------------------------------------------------------------------
+// Squaring counterpart of multiply_toom_cook_4: one evaluation per point
+// instead of two, all seven products are recursive squares, and the squared
+// evaluations at -1 and -2 are non-negative, removing the sign handling from
+// interpolation. Falls back to square_toom_cook_3 below the cutoff.
+// `result` must be pre-zeroed and have space for 2 * a.size() limbs.
+// `result` must NOT alias `a`. `scratch` provides pre-allocated workspace.
+// `cutoff_override` is a benchmark-only escape hatch as in the general kernel.
+// ---------------------------------------------------------------------------
+void square_toom_cook_4(const std::span<uint_multiprecision_t>       result,
+                        const std::span<const uint_multiprecision_t> a_untrimmed,
+                        scratch_allocator_base&                      scratch,
+                        const std::size_t                            cutoff_override = 0) noexcept;
+
 // See tests/beman/big_int/perf crossover_speedup.png
 inline constexpr std::size_t toom_cook_6_5_cutoff = 3000;
 

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -119,7 +119,7 @@ inline constexpr std::size_t square_long_cutoff = 8;
 // Minimum number of limbs for Karatsuba to be worthwhile
 // Directly from Boost, and reconfirmed as correct
 inline constexpr std::size_t karatsuba_cutoff   = 48;
-inline constexpr std::size_t karatsuba_fallback = 24;
+inline constexpr std::size_t karatsuba_fallback = 40;
 
 // Heuristic estimate of scratch space needed for Karatsuba multiplication.
 // One Karatsuba level uses ~2*s limbs (t1=2n+2, t2=t3=n+1 with n=s/2+1). The
@@ -171,6 +171,7 @@ void square_karatsuba(const std::span<uint_multiprecision_t>       result,
 // Minimum number of limbs for Toom-Cook 3 to be worthwhile.
 // See multiplication_stress_bench for tuning
 inline constexpr std::size_t toom_cook_3_cutoff = 300;
+inline constexpr std::size_t toom_cook_3_cutoff = 400;
 
 // Heuristic estimate of scratch space needed for Toom-Cook 3 multiplication.
 // One Toom-3 level uses 8k+10 limbs (~2.67*s where k = ceil(s/3)). The
@@ -227,6 +228,7 @@ void square_toom_cook_3(const std::span<uint_multiprecision_t>       result,
 // Minimum number of limbs for Toom-Cook 4 to be worthwhile.
 // Empirically tuned on Apple Silicon via multiplication_stress_bench
 inline constexpr std::size_t toom_cook_4_cutoff = 1400;
+inline constexpr std::size_t toom_cook_4_cutoff = 1600;
 
 // Heuristic estimate of scratch space needed for Toom-Cook 4 multiplication.
 // One Toom-4 level uses 14k+16 limbs (~3.5*s where k = ceil(s/4)). The geometric
@@ -286,6 +288,7 @@ void square_toom_cook_4(const std::span<uint_multiprecision_t>       result,
 
 // See tests/beman/big_int/perf crossover_speedup.png
 inline constexpr std::size_t toom_cook_6_5_cutoff = 3000;
+inline constexpr std::size_t toom_cook_6_5_cutoff = 2400;
 
 // Heuristic estimate of scratch space needed for Toom-Cook 6.5 multiplication.
 // One Toom-6.5 level uses 24k+26 limbs (~4*s where k = ceil(min/6)) for ten

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -143,6 +143,27 @@ void multiply_karatsuba(const std::span<uint_multiprecision_t>       result,
                         const std::span<const uint_multiprecision_t> b_untrimmed,
                         scratch_allocator_base&                      scratch) noexcept;
 
+// Minimum number of limbs for the Karatsuba squaring variant: the squaring
+// basecase stays ahead of recursion roughly twice as long as schoolbook does
+// against general Karatsuba (the same SQR/MUL threshold ratio GMP observes).
+// Tuned via multiplication_stress_bench.
+inline constexpr std::size_t square_karatsuba_cutoff = 80;
+
+// ---------------------------------------------------------------------------
+// Squaring counterpart of multiply_karatsuba: one evaluation (a_h + a_l) per
+// level instead of two, and all three sub-products are recursive squares.
+// `result` must have space for 2 * a.size() limbs or more; slack beyond the
+// product follows the same caller-pre-zeroed convention as the general kernel.
+// `result` must NOT alias `a`. `scratch` provides pre-allocated workspace.
+// ---------------------------------------------------------------------------
+// `cutoff_override` is a benchmark-only escape hatch: when non-zero it
+// replaces `square_karatsuba_cutoff` for this call only; recursive
+// sub-squares always use the default.
+void square_karatsuba(const std::span<uint_multiprecision_t>       result,
+                      const std::span<const uint_multiprecision_t> a_untrimmed,
+                      scratch_allocator_base&                      scratch,
+                      const std::size_t                            cutoff_override = 0) noexcept;
+
 // Minimum number of limbs for Toom-Cook 3 to be worthwhile.
 // See multiplication_stress_bench for tuning
 inline constexpr std::size_t toom_cook_3_cutoff = 300;

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -199,6 +199,27 @@ void multiply_toom_cook_3(const std::span<uint_multiprecision_t>       result,
                           const std::span<const uint_multiprecision_t> b_untrimmed,
                           scratch_allocator_base&                      scratch) noexcept;
 
+// Minimum number of limbs for the Toom-Cook 3 squaring variant; roughly twice
+// the general toom_cook_3_cutoff, mirroring the SQR/MUL threshold ratio.
+// Tuned via multiplication_stress_bench.
+inline constexpr std::size_t square_toom_cook_3_cutoff = 400;
+
+// ---------------------------------------------------------------------------
+// Squaring counterpart of multiply_toom_cook_3: one evaluation per point
+// instead of two, all five products are recursive squares, and p(-1)^2 >= 0
+// removes the sign handling from interpolation. Falls back to
+// square_karatsuba below the cutoff.
+// `result` must be pre-zeroed and have space for 2 * a.size() limbs.
+// `result` must NOT alias `a`. `scratch` provides pre-allocated workspace.
+// ---------------------------------------------------------------------------
+// `cutoff_override` is a benchmark-only escape hatch: when non-zero it
+// replaces `square_toom_cook_3_cutoff` for this call only; recursive
+// sub-squares always use the default.
+void square_toom_cook_3(const std::span<uint_multiprecision_t>       result,
+                        const std::span<const uint_multiprecision_t> a_untrimmed,
+                        scratch_allocator_base&                      scratch,
+                        const std::size_t                            cutoff_override = 0) noexcept;
+
 // Minimum number of limbs for Toom-Cook 4 to be worthwhile.
 // Empirically tuned on Apple Silicon via multiplication_stress_bench
 inline constexpr std::size_t toom_cook_4_cutoff = 1400;

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -379,6 +379,58 @@ constexpr std::size_t multiply_power_of_two(const std::span<uint_multiprecision_
 }
 
 // ---------------------------------------------------------------------------
+// Squaring dispatcher: result <- a * a using kernels that exploit the
+// symmetric cross products. Same contract as multiply_dispatch: `result` must
+// be pre-zeroed with space for 2 * a.size() limbs and must NOT alias `a`.
+// `a` must be trimmed with at least two limbs. Returns the number of
+// significant result limbs.
+// ---------------------------------------------------------------------------
+template <class Allocator>
+std::size_t square_dispatch(const std::span<uint_multiprecision_t>       result,
+                            const std::span<const uint_multiprecision_t> a,
+                            Allocator&                                   alloc) {
+    BEMAN_BIG_INT_DEBUG_ASSERT(a.size() >= 2);
+    BEMAN_BIG_INT_DEBUG_ASSERT(a.back() != 0);
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.size() >= 2 * a.size());
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != a.data());
+
+    const std::size_t n            = a.size();
+    const std::size_t result_total = 2 * n;
+
+    // Tiny squares: plain schoolbook beats the three-pass squaring basecase.
+    if (n < square_long_cutoff) {
+        multiply_long(result.first(result_total), a, a);
+        return trimmed_size_span(std::span<const uint_multiprecision_t>{result.data(), result_total});
+    }
+
+    // (2^k)^2 = 2^(2k): a shifted copy beats any squaring kernel.
+    if (is_power_of_two_span(a)) {
+        return multiply_power_of_two(result, a, a);
+    }
+
+    if (n < square_karatsuba_cutoff) {
+        square_long(result, a);
+        return trimmed_size_span(std::span<const uint_multiprecision_t>{result.data(), result_total});
+    }
+
+    if (n < square_toom_cook_3_cutoff) {
+        scratch_allocator<Allocator> scratch(karatsuba_storage_size(n), alloc);
+        square_karatsuba(result.first(result_total), a, scratch);
+    } else if (n < square_toom_cook_4_cutoff) {
+        scratch_allocator<Allocator> scratch(toom_cook_3_storage_size(n), alloc);
+        square_toom_cook_3(result.first(result_total), a, scratch);
+    } else if (n < square_toom_cook_6_5_cutoff) {
+        scratch_allocator<Allocator> scratch(toom_cook_4_storage_size(n), alloc);
+        square_toom_cook_4(result.first(result_total), a, scratch);
+    } else {
+        scratch_allocator<Allocator> scratch(toom_cook_6_5_storage_size(n), alloc);
+        square_toom_cook_6_5(result.first(result_total), a, scratch);
+    }
+
+    return trimmed_size_span(std::span<const uint_multiprecision_t>{result.data(), result_total});
+}
+
+// ---------------------------------------------------------------------------
 // Top-level multiplication dispatcher.
 // `result` must be pre-zeroed and have space for a.size() + b.size() limbs.
 // `result` must NOT alias `a` or `b`.

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -64,6 +64,58 @@ constexpr void multiply_long(const std::span<uint_multiprecision_t>       result
     }
 }
 
+// ---------------------------------------------------------------------------
+// Schoolbook squaring: result <- a * a (HAC algorithm 14.16). Computes the
+// off-diagonal upper triangle once (n*(n-1)/2 widening muls), doubles it with
+// a one-bit shift, then folds in the n diagonal squares: roughly half the
+// widening muls of multiply_long. Unlike multiply_long, `result` MUST be
+// pre-zeroed and have space for 2 * a.size() limbs. `result` must NOT alias `a`.
+// ---------------------------------------------------------------------------
+constexpr void square_long(const std::span<uint_multiprecision_t>       result,
+                           const std::span<const uint_multiprecision_t> a) noexcept {
+    BEMAN_BIG_INT_DEBUG_ASSERT(!a.empty());
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.size() >= 2 * a.size());
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != a.data());
+
+    const std::size_t n = a.size();
+
+    // Off-diagonal upper triangle: result += sum_{i<j} a[i]*a[j] * B^(i+j).
+    for (std::size_t i = 0; i + 1 < n; ++i) {
+        uint_multiprecision_t carry = 0;
+        for (std::size_t j = i + 1; j < n; ++j) {
+            const auto [lo, hi] = widening_mul(a[i], a[j]);
+            const auto [s1, c1] = carrying_add(lo, result[i + j]);
+            const auto [s2, c2] = carrying_add(s1, carry);
+            result[i + j]       = s2;
+            carry               = hi + static_cast<uint_multiprecision_t>(c1) + static_cast<uint_multiprecision_t>(c2);
+        }
+        result[i + n] = carry;
+    }
+
+    // Double the triangle; cannot overflow 2n limbs since a*a < B^(2n).
+    [[maybe_unused]] const auto doubled_size = shift_left_n(result.first(2 * n), 2 * n, 1u);
+    BEMAN_BIG_INT_DEBUG_ASSERT(doubled_size == 2 * n);
+
+    // Diagonal: result += sum a[i]^2 * B^(2i). The carry out of slot 2i+1
+    // lands in slot 2i+2, the next iteration's low slot, so one flag suffices.
+    bool carry_flag = false;
+    for (std::size_t i = 0; i < n; ++i) {
+        const auto [lo, hi] = widening_mul(a[i], a[i]);
+        const auto [s1, c1] = carrying_add(result[2 * i], lo, carry_flag);
+        result[2 * i]       = s1;
+        const auto [s2, c2] = carrying_add(result[2 * i + 1], hi, c1);
+        result[2 * i + 1]   = s2;
+        carry_flag          = c2;
+    }
+    BEMAN_BIG_INT_DEBUG_ASSERT(!carry_flag);
+}
+
+// Below this limb count square_dispatch routes squares back to plain
+// schoolbook: the three-pass structure of square_long loses there (OpenJDK's
+// MULTIPLY_SQUARE_THRESHOLD draws the same line at 640 bits).
+// Tuned via multiplication_stress_bench.
+inline constexpr std::size_t square_long_cutoff = 8;
+
 // Minimum number of limbs for Karatsuba to be worthwhile
 // Directly from Boost, and reconfirmed as correct
 inline constexpr std::size_t karatsuba_cutoff   = 48;

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -147,7 +147,7 @@ void multiply_karatsuba(const std::span<uint_multiprecision_t>       result,
 // basecase stays ahead of recursion roughly twice as long as schoolbook does
 // against general Karatsuba (the same SQR/MUL threshold ratio GMP observes).
 // Tuned via multiplication_stress_bench.
-inline constexpr std::size_t square_karatsuba_cutoff = 80;
+inline constexpr std::size_t square_karatsuba_cutoff = 72;
 
 // ---------------------------------------------------------------------------
 // Squaring counterpart of multiply_karatsuba: one evaluation (a_h + a_l) per
@@ -202,7 +202,7 @@ void multiply_toom_cook_3(const std::span<uint_multiprecision_t>       result,
 // Minimum number of limbs for the Toom-Cook 3 squaring variant; roughly twice
 // the general toom_cook_3_cutoff, mirroring the SQR/MUL threshold ratio.
 // Tuned via multiplication_stress_bench.
-inline constexpr std::size_t square_toom_cook_3_cutoff = 400;
+inline constexpr std::size_t square_toom_cook_3_cutoff = 300;
 
 // ---------------------------------------------------------------------------
 // Squaring counterpart of multiply_toom_cook_3: one evaluation per point
@@ -334,7 +334,7 @@ void multiply_toom_cook_6_5(const std::span<uint_multiprecision_t>       result,
 // Minimum number of limbs for the Toom-6.5 squaring variant; roughly twice
 // the general toom_cook_6_5_cutoff, mirroring the SQR/MUL threshold ratio.
 // Tuned via multiplication_stress_bench.
-inline constexpr std::size_t square_toom_cook_6_5_cutoff = 2900;
+inline constexpr std::size_t square_toom_cook_6_5_cutoff = 2400;
 
 // ---------------------------------------------------------------------------
 // Squaring counterpart of multiply_toom_cook_6_5. Squaring is always balanced,

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -198,11 +198,15 @@ constexpr std::size_t toom_cook_3_storage_size(const std::size_t s) noexcept { r
 // `result` must be pre-zeroed and have space for a.size() + b.size() limbs.
 // `result` must NOT alias `a` or `b`.
 // `scratch` provides pre-allocated workspace for temporaries.
+// `cutoff_override` is a benchmark-only escape hatch: when non-zero it replaces
+// `toom_cook_3_cutoff` for this call only; recursive sub-products always use the
+// default. Production callers omit it.
 // ---------------------------------------------------------------------------
 void multiply_toom_cook_3(const std::span<uint_multiprecision_t>       result,
                           const std::span<const uint_multiprecision_t> a_untrimmed,
                           const std::span<const uint_multiprecision_t> b_untrimmed,
-                          scratch_allocator_base&                      scratch) noexcept;
+                          scratch_allocator_base&                      scratch,
+                          const std::size_t                            cutoff_override = 0) noexcept;
 
 // Minimum number of limbs for the Toom-Cook 3 squaring variant; roughly twice
 // the general toom_cook_3_cutoff, mirroring the SQR/MUL threshold ratio.

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -138,10 +138,14 @@ constexpr std::size_t karatsuba_storage_size(const std::size_t s) noexcept { ret
 // `result` must NOT alias `a` or `b`.
 // `scratch` provides pre-allocated workspace for temporaries.
 // ---------------------------------------------------------------------------
+// `cutoff_override` is a benchmark-only escape hatch: when non-zero it replaces
+// `karatsuba_fallback` for this call only (forcing a split at smaller sizes);
+// recursive sub-products always use the default. Production callers omit it.
 void multiply_karatsuba(const std::span<uint_multiprecision_t>       result,
                         const std::span<const uint_multiprecision_t> a_untrimmed,
                         const std::span<const uint_multiprecision_t> b_untrimmed,
-                        scratch_allocator_base&                      scratch) noexcept;
+                        scratch_allocator_base&                      scratch,
+                        const std::size_t                            cutoff_override = 0) noexcept;
 
 // Minimum number of limbs for the Karatsuba squaring variant: the squaring
 // basecase stays ahead of recursion roughly twice as long as schoolbook does

--- a/include/beman/big_int/detail/mul_impl.hpp
+++ b/include/beman/big_int/detail/mul_impl.hpp
@@ -331,6 +331,29 @@ void multiply_toom_cook_6_5(const std::span<uint_multiprecision_t>       result,
                             scratch_allocator_base&                      scratch,
                             const std::size_t                            cutoff_override = 0) noexcept;
 
+// Minimum number of limbs for the Toom-6.5 squaring variant; roughly twice
+// the general toom_cook_6_5_cutoff, mirroring the SQR/MUL threshold ratio.
+// Tuned via multiplication_stress_bench.
+inline constexpr std::size_t square_toom_cook_6_5_cutoff = 2900;
+
+// ---------------------------------------------------------------------------
+// Squaring counterpart of multiply_toom_cook_6_5. Squaring is always balanced,
+// so the operand splits into exactly six pieces (b6 of the general kernel is
+// empty and c11 = 0). One evaluation per point instead of two; all eleven
+// products are recursive squares. The squared fractional-point evaluations
+// come out scaled by 2^10 / 4^10 instead of the 2^11 / 4^11 the interpolation
+// expects (the general kernel pairs a 6-piece and a 7-piece evaluation), so
+// vh/vmh are shifted left once and vq/vmq twice after squaring.
+// Falls back to square_toom_cook_4 below the cutoff.
+// `result` must be pre-zeroed and have space for 2 * a.size() limbs.
+// `result` must NOT alias `a`. `scratch` provides pre-allocated workspace.
+// `cutoff_override` is a benchmark-only escape hatch as in the general kernel.
+// ---------------------------------------------------------------------------
+void square_toom_cook_6_5(const std::span<uint_multiprecision_t>       result,
+                          const std::span<const uint_multiprecision_t> a_untrimmed,
+                          scratch_allocator_base&                      scratch,
+                          const std::size_t                            cutoff_override = 0) noexcept;
+
 // ---------------------------------------------------------------------------
 // result <- a * p2 where p2 is a trimmed power of two: a shifted copy of `a`
 // placed at limb offset p2.size() - 1, bit-shifted by countr_zero(p2.back()).

--- a/src/karatsuba.cpp
+++ b/src/karatsuba.cpp
@@ -8,7 +8,8 @@ namespace beman::big_int::detail {
 void multiply_karatsuba(const std::span<uint_multiprecision_t>       result,
                         const std::span<const uint_multiprecision_t> a_untrimmed,
                         const std::span<const uint_multiprecision_t> b_untrimmed,
-                        scratch_allocator_base&                      scratch) noexcept {
+                        scratch_allocator_base&                      scratch,
+                        const std::size_t                            cutoff_override) noexcept {
     BEMAN_BIG_INT_DEBUG_ASSERT(!a_untrimmed.empty());
     BEMAN_BIG_INT_DEBUG_ASSERT(!b_untrimmed.empty());
     BEMAN_BIG_INT_DEBUG_ASSERT(result.size() >= trimmed_size_span(a_untrimmed) + trimmed_size_span(b_untrimmed));
@@ -18,8 +19,10 @@ void multiply_karatsuba(const std::span<uint_multiprecision_t>       result,
     const auto a = a_untrimmed.first(trimmed_size_span(a_untrimmed));
     const auto b = b_untrimmed.first(trimmed_size_span(b_untrimmed));
 
+    const std::size_t effective_fallback = cutoff_override == 0 ? karatsuba_fallback : cutoff_override;
+
     // First, check if we have enough limbs to justify karatsuba
-    if (a.size() < karatsuba_fallback || b.size() < karatsuba_fallback) {
+    if (a.size() < effective_fallback || b.size() < effective_fallback) {
         multiply_long(result.first(a.size() + b.size()), a, b);
         return;
     }

--- a/src/karatsuba.cpp
+++ b/src/karatsuba.cpp
@@ -125,4 +125,83 @@ void multiply_karatsuba(const std::span<uint_multiprecision_t>       result,
     scratch.deallocate(total_scratch);
 }
 
+void square_karatsuba(const std::span<uint_multiprecision_t>       result,
+                      const std::span<const uint_multiprecision_t> a_untrimmed,
+                      scratch_allocator_base&                      scratch,
+                      const std::size_t                            cutoff_override) noexcept {
+    BEMAN_BIG_INT_DEBUG_ASSERT(!a_untrimmed.empty());
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.size() >= 2 * trimmed_size_span(a_untrimmed));
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != a_untrimmed.data());
+
+    const auto a = a_untrimmed.first(trimmed_size_span(a_untrimmed));
+
+    const std::size_t effective_cutoff = cutoff_override == 0 ? square_karatsuba_cutoff : cutoff_override;
+
+    // Below the cutoff the three-pass squaring basecase wins. Unlike
+    // multiply_long it accumulates, so its window must be zeroed first.
+    if (a.size() < effective_cutoff) {
+        std::ranges::fill(result.first(2 * a.size()), uint_multiprecision_t{0});
+        square_long(result.first(2 * a.size()), a);
+        return;
+    }
+
+    // Partition at n = a.size() / 2 + 1; the cutoff guarantees a_h is non-empty.
+    const std::size_t n = a.size() / 2 + 1;
+
+    const auto a_l = a.first(n);
+    const auto a_h = a.subspan(n);
+
+    // Scratch: one evaluation buffer (the general kernel needs two):
+    //   t1: holds (a_h + a_l)^2, needs up to 2*n + 2 limbs
+    //   t2: holds a_h + a_l, needs up to n + 1 limbs
+    const std::size_t t1_cap        = 2 * n + 2;
+    const std::size_t t2_cap        = n + 1;
+    const std::size_t total_scratch = t1_cap + t2_cap;
+
+    auto scratch_block = scratch.allocate(total_scratch);
+    auto t1            = scratch_block.first(t1_cap);
+    auto t2            = scratch_block.subspan(t1_cap, t2_cap);
+
+    auto result_low  = result.first(2 * n);
+    auto result_high = result.subspan(2 * n);
+
+    // result_low = a_l^2
+    square_karatsuba(result_low, a_l, scratch);
+    const std::size_t result_low_size =
+        trimmed_size_span(std::span<const uint_multiprecision_t>{result_low.data(), 2 * a_l.size()});
+    std::ranges::fill(result_low.subspan(result_low_size), uint_multiprecision_t{0});
+
+    // result_high = a_h^2
+    square_karatsuba(result_high, a_h, scratch);
+    const std::size_t result_high_size =
+        trimmed_size_span(std::span<const uint_multiprecision_t>{result_high.data(), 2 * a_h.size()});
+    std::ranges::fill(result_high.subspan(result_high_size), uint_multiprecision_t{0});
+
+    // t2 = a_h + a_l
+    std::size_t t2_size = std::max(a_h.size(), a_l.size());
+    if (add_unsigned_spans(t2.first(t2_size), a_l, a_h)) {
+        t2[t2_size] = 1;
+        ++t2_size;
+    }
+
+    // t1 = (a_h + a_l)^2
+    std::ranges::fill(t1, uint_multiprecision_t{0});
+    square_karatsuba(t1, std::span<const uint_multiprecision_t>{t2.data(), t2_size}, scratch);
+    std::size_t t1_size = trimmed_size_span(std::span<const uint_multiprecision_t>{t1.data(), 2 * t2_size});
+
+    // t1 -= a_h^2; t1 -= a_l^2, leaving the doubled cross term 2*a_l*a_h.
+    t1_size = subtract_unsigned_spans(t1.first(t1_size),
+                                      std::span<const uint_multiprecision_t>{t1.data(), t1_size},
+                                      std::span<const uint_multiprecision_t>{result_high.data(), result_high_size});
+    t1_size = subtract_unsigned_spans(t1.first(t1_size),
+                                      std::span<const uint_multiprecision_t>{t1.data(), t1_size},
+                                      std::span<const uint_multiprecision_t>{result_low.data(), result_low_size});
+
+    // Add t1 shifted left by n limbs into result: result[n...] += t1
+    add_shifted(result, n, std::span<const uint_multiprecision_t>{t1.data(), t1_size});
+
+    // Move bump pointer back so the next sibling recursive call reuses the same region.
+    scratch.deallocate(total_scratch);
+}
+
 } // namespace beman::big_int::detail

--- a/src/toom_cook_3.cpp
+++ b/src/toom_cook_3.cpp
@@ -175,4 +175,127 @@ void multiply_toom_cook_3(const std::span<uint_multiprecision_t>       result,
     scratch.deallocate(total_scratch);
 }
 
+void square_toom_cook_3(const std::span<uint_multiprecision_t>       result,
+                        const std::span<const uint_multiprecision_t> a_untrimmed,
+                        scratch_allocator_base&                      scratch,
+                        const std::size_t                            cutoff_override) noexcept {
+    BEMAN_BIG_INT_DEBUG_ASSERT(!a_untrimmed.empty());
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.size() >= 2 * trimmed_size_span(a_untrimmed));
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != a_untrimmed.data());
+
+    const auto a = a_untrimmed.first(trimmed_size_span(a_untrimmed));
+
+    // Partition at k = ceil(an / 3).
+    const std::size_t k = (a.size() + 2) / 3;
+
+    const std::size_t effective_cutoff = cutoff_override == 0 ? square_toom_cook_3_cutoff : cutoff_override;
+
+    // Fall through to the Karatsuba squaring variant below the performance
+    // cutoff or below the algorithm's 2*k invariant (a2 must be non-empty).
+    if (a.size() < effective_cutoff || a.size() <= 2 * k) {
+        square_karatsuba(result, a, scratch);
+        return;
+    }
+
+    // Split into three pieces; the 2*k gate guarantees a2 is non-empty.
+    const auto a0 = a.first(k);
+    const auto a1 = a.subspan(k, k);
+    const auto a2 = a.subspan(2 * k);
+
+    // Carve scratch: one evaluation buffer (the general kernel needs two):
+    //   tmpa: k+2 limbs
+    //   v1, vm1, v2: 2k+2 limbs each, hold three squares through interpolation
+    //   v0 = a0^2 and vinf = a2^2 live directly in result.
+    const std::size_t tmp_cap       = k + 2;
+    const std::size_t prod_cap      = 2 * k + 2;
+    const std::size_t total_scratch = tmp_cap + 3 * prod_cap;
+
+    auto block = scratch.allocate(total_scratch);
+    auto tmpa  = block.first(tmp_cap);
+    auto v1    = block.subspan(tmp_cap, prod_cap);
+    auto vm1   = block.subspan(tmp_cap + prod_cap, prod_cap);
+    auto v2    = block.subspan(tmp_cap + 2 * prod_cap, prod_cap);
+
+    // ---- v0 = a0^2, written into result[0..2k) (caller pre-zeroed). ----
+    square_toom_cook_3(result.first(2 * a0.size()), a0, scratch);
+
+    // ---- vinf = a2^2, written into result[4k..). ----
+    square_toom_cook_3(result.subspan(4 * k, 2 * a2.size()), a2, scratch);
+
+    // ---- Evaluate at x = 1: tmpa = a0 + a1 + a2. ----
+    std::size_t tmpa_size = add_many_into_tmp(tmpa, {a0, a1, a2});
+
+    // v1 = p(1)^2. Pre-zeroed for the recursive recompose step.
+    std::ranges::fill(v1, uint_multiprecision_t{0});
+    square_toom_cook_3(v1, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size}, scratch);
+
+    // ---- Evaluate at x = -1: tmpa = |(a0 + a2) - a1|; squaring erases the sign,
+    // so the sign-aware interpolation branches of the general kernel collapse
+    // to their non-negative arms below. ----
+    tmpa_size = add_many_into_tmp(tmpa, {a0, a2});
+    const auto sub_a =
+        subtract_unsigned_spans_signed(tmpa, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size}, a1);
+    tmpa_size = sub_a.size;
+
+    // vm1 = p(-1)^2
+    std::ranges::fill(vm1, uint_multiprecision_t{0});
+    if (tmpa_size != 0) {
+        square_toom_cook_3(vm1, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size}, scratch);
+    }
+
+    // ---- Evaluate at x = 2: tmpa = 4*a2 + 2*a1 + a0 (Horner). ----
+    tmpa_size = horner_eval_into_tmp(tmpa, {a2, a1, a0}, 1u);
+
+    // v2 = p(2)^2
+    std::ranges::fill(v2, uint_multiprecision_t{0});
+    square_toom_cook_3(v2, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size}, scratch);
+
+    // ---- Bodrato interpolation (as the general kernel with sign_vm1 == false) ----
+    const auto v0_view   = std::span<const uint_multiprecision_t>{result.data(), 2 * k};
+    const auto vinf_size = std::min(result.size() - 4 * k, 2 * k);
+    const auto vinf_view = std::span<const uint_multiprecision_t>{result.data() + 4 * k, vinf_size};
+    const auto v1_view   = std::span<const uint_multiprecision_t>{v1};
+    const auto vm1_view  = std::span<const uint_multiprecision_t>{vm1};
+    const auto v2_view   = std::span<const uint_multiprecision_t>{v2};
+
+    // Step 1: v2 <- (v2 - vm1) / 3.
+    subtract_unsigned_spans_no_borrow(v2, v2_view, vm1_view);
+    {
+        const auto rem = divide_unsigned_short(v2, v2_view, uint_multiprecision_t{3});
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Step 2: vm1 <- (v1 - vm1) / 2.
+    {
+        const auto rem = subtract_unsigned_spans_and_shift_right_one(vm1, v1_view, vm1_view);
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Step 3: v1 <- v1 - v0.
+    subtract_unsigned_spans(v1, v1_view, v0_view);
+
+    // Step 4: v2 <- (v2 - v1) / 2.
+    {
+        const auto rem = subtract_unsigned_spans_and_shift_right_one(v2, v2_view, v1_view);
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Step 5: v1 <- v1 - vm1 - vinf.
+    subtract_unsigned_spans(v1, v1_view, vm1_view);
+    subtract_unsigned_spans(v1, v1_view, vinf_view);
+
+    // Step 6: v2 <- v2 - 2*vinf.
+    subtract_unsigned_spans(v2, v2_view, vinf_view);
+    subtract_unsigned_spans(v2, v2_view, vinf_view);
+
+    // Step 7: vm1 <- vm1 - v2.
+    subtract_unsigned_spans(vm1, vm1_view, v2_view);
+
+    // ---- Recompose: result += vm1*B^k + v1*B^(2k) + v2*B^(3k) ----
+    recompose(result, k, {vm1_view, v1_view, v2_view});
+
+    // Move bump pointer back so the next sibling recursive call reuses the same region.
+    scratch.deallocate(total_scratch);
+}
+
 } // namespace beman::big_int::detail

--- a/src/toom_cook_3.cpp
+++ b/src/toom_cook_3.cpp
@@ -8,7 +8,8 @@ namespace beman::big_int::detail {
 void multiply_toom_cook_3(const std::span<uint_multiprecision_t>       result,
                           const std::span<const uint_multiprecision_t> a_untrimmed,
                           const std::span<const uint_multiprecision_t> b_untrimmed,
-                          scratch_allocator_base&                      scratch) noexcept {
+                          scratch_allocator_base&                      scratch,
+                          const std::size_t                            cutoff_override) noexcept {
     BEMAN_BIG_INT_DEBUG_ASSERT(!a_untrimmed.empty());
     BEMAN_BIG_INT_DEBUG_ASSERT(!b_untrimmed.empty());
     BEMAN_BIG_INT_DEBUG_ASSERT(result.size() >= trimmed_size_span(a_untrimmed) + trimmed_size_span(b_untrimmed));
@@ -19,13 +20,14 @@ void multiply_toom_cook_3(const std::span<uint_multiprecision_t>       result,
     const auto b = b_untrimmed.first(trimmed_size_span(b_untrimmed));
 
     // Partition at k = ceil(max(an, bn) / 3).
-    const std::size_t min_size = std::min(a.size(), b.size());
-    const std::size_t k        = (std::max(a.size(), b.size()) + 2) / 3;
+    const std::size_t min_size         = std::min(a.size(), b.size());
+    const std::size_t k                = (std::max(a.size(), b.size()) + 2) / 3;
+    const std::size_t effective_cutoff = cutoff_override == 0 ? toom_cook_3_cutoff : cutoff_override;
 
     // Fall through to Karatsuba (and on through to schoolbook) when the smaller
     // operand is below the performance cutoff or below the algorithm's 2*k
     // invariant (Toom-Cook 3 needs both a2 and b2 non-empty).
-    if (min_size < toom_cook_3_cutoff || min_size <= 2 * k) {
+    if (min_size < effective_cutoff || min_size <= 2 * k) {
         multiply_karatsuba(result, a, b, scratch);
         return;
     }

--- a/src/toom_cook_4.cpp
+++ b/src/toom_cook_4.cpp
@@ -404,13 +404,12 @@ void square_toom_cook_4(const std::span<uint_multiprecision_t>       result,
     // ---- Evaluate at x = -1: tmpa = |(a0 + a2) - (a1 + a3)|; squaring erases
     // the sign, so the interpolation below uses the non-negative arms of the
     // general kernel's sign-aware steps. ----
-    tmpa_size = add_many_into_tmp(tmpa, {a0, a2});
-    aux_size  = add_many_into_tmp(aux, {a1, a3});
-    const auto sub_m1 =
-        subtract_unsigned_spans_signed(tmpa,
-                                       std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
-                                       std::span<const uint_multiprecision_t>{aux.data(), aux_size});
-    tmpa_size = sub_m1.size;
+    tmpa_size         = add_many_into_tmp(tmpa, {a0, a2});
+    aux_size          = add_many_into_tmp(aux, {a1, a3});
+    const auto sub_m1 = subtract_unsigned_spans_signed(tmpa,
+                                                       std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                                                       std::span<const uint_multiprecision_t>{aux.data(), aux_size});
+    tmpa_size         = sub_m1.size;
 
     // vm1 = p(-1)^2
     std::ranges::fill(vm1, uint_multiprecision_t{0});
@@ -432,11 +431,10 @@ void square_toom_cook_4(const std::span<uint_multiprecision_t>       result,
     aux_size = horner_eval_into_tmp(aux, {a3, a1}, 3u);
     aux_size = add_into_tmp(aux, aux_size, a1);
 
-    const auto sub_m2 =
-        subtract_unsigned_spans_signed(tmpa,
-                                       std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
-                                       std::span<const uint_multiprecision_t>{aux.data(), aux_size});
-    tmpa_size = sub_m2.size;
+    const auto sub_m2 = subtract_unsigned_spans_signed(tmpa,
+                                                       std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                                                       std::span<const uint_multiprecision_t>{aux.data(), aux_size});
+    tmpa_size         = sub_m2.size;
 
     // vm2 = p(-2)^2
     std::ranges::fill(vm2, uint_multiprecision_t{0});

--- a/src/toom_cook_4.cpp
+++ b/src/toom_cook_4.cpp
@@ -343,4 +343,255 @@ void multiply_toom_cook_4(const std::span<uint_multiprecision_t>       result,
     scratch.deallocate(total_scratch);
 }
 
+void square_toom_cook_4(const std::span<uint_multiprecision_t>       result,
+                        const std::span<const uint_multiprecision_t> a_untrimmed,
+                        scratch_allocator_base&                      scratch,
+                        const std::size_t                            cutoff_override) noexcept {
+    BEMAN_BIG_INT_DEBUG_ASSERT(!a_untrimmed.empty());
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.size() >= 2 * trimmed_size_span(a_untrimmed));
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != a_untrimmed.data());
+
+    const auto a = a_untrimmed.first(trimmed_size_span(a_untrimmed));
+
+    // Partition at k = ceil(an / 4).
+    const std::size_t k                = (a.size() + 3) / 4;
+    const std::size_t effective_cutoff = cutoff_override == 0 ? square_toom_cook_4_cutoff : cutoff_override;
+
+    // Fall through to the Toom-3 squaring variant below the performance cutoff
+    // or below the algorithm's 3*k invariant (a3 must be non-empty).
+    if (a.size() < effective_cutoff || a.size() <= 3 * k) {
+        square_toom_cook_3(result, a, scratch);
+        return;
+    }
+
+    // Split into four pieces; the 3*k gate guarantees a3 is non-empty.
+    const auto a0 = a.first(k);
+    const auto a1 = a.subspan(k, k);
+    const auto a2 = a.subspan(2 * k, k);
+    const auto a3 = a.subspan(3 * k);
+
+    // Carve scratch: one evaluation buffer tmpa plus one aux buffer for the
+    // negative halves of the signed points (the general kernel needs tmpa and
+    // tmpb); five squares and the tmp_double shift scratch.
+    const std::size_t tmp_cap       = k + 2;
+    const std::size_t prod_cap      = 2 * k + 2;
+    const std::size_t total_scratch = 2 * tmp_cap + 6 * prod_cap;
+
+    auto block      = scratch.allocate(total_scratch);
+    auto tmpa       = block.first(tmp_cap);
+    auto aux        = block.subspan(tmp_cap, tmp_cap);
+    auto v1         = block.subspan(2 * tmp_cap, prod_cap);
+    auto vm1        = block.subspan(2 * tmp_cap + prod_cap, prod_cap);
+    auto v2         = block.subspan(2 * tmp_cap + 2 * prod_cap, prod_cap);
+    auto vm2        = block.subspan(2 * tmp_cap + 3 * prod_cap, prod_cap);
+    auto vh         = block.subspan(2 * tmp_cap + 4 * prod_cap, prod_cap);
+    auto tmp_double = block.subspan(2 * tmp_cap + 5 * prod_cap, prod_cap);
+
+    // ---- c0 = a0^2, written into result[0..2k) (caller pre-zeroed). ----
+    square_toom_cook_4(result.first(2 * a0.size()), a0, scratch);
+
+    // ---- c6 = a3^2, written into result[6k..). ----
+    square_toom_cook_4(result.subspan(6 * k, 2 * a3.size()), a3, scratch);
+
+    // ---- Evaluate at x = 1: tmpa = a0 + a1 + a2 + a3. ----
+    std::size_t tmpa_size = add_many_into_tmp(tmpa, {a0, a1, a2, a3});
+    std::size_t aux_size  = 0;
+
+    // v1 = p(1)^2
+    std::ranges::fill(v1, uint_multiprecision_t{0});
+    square_toom_cook_4(v1, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size}, scratch);
+
+    // ---- Evaluate at x = -1: tmpa = |(a0 + a2) - (a1 + a3)|; squaring erases
+    // the sign, so the interpolation below uses the non-negative arms of the
+    // general kernel's sign-aware steps. ----
+    tmpa_size = add_many_into_tmp(tmpa, {a0, a2});
+    aux_size  = add_many_into_tmp(aux, {a1, a3});
+    const auto sub_m1 =
+        subtract_unsigned_spans_signed(tmpa,
+                                       std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                                       std::span<const uint_multiprecision_t>{aux.data(), aux_size});
+    tmpa_size = sub_m1.size;
+
+    // vm1 = p(-1)^2
+    std::ranges::fill(vm1, uint_multiprecision_t{0});
+    if (tmpa_size != 0) {
+        square_toom_cook_4(vm1, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size}, scratch);
+    }
+
+    // ---- Evaluate at x = 2: tmpa = ((a3*2 + a2)*2 + a1)*2 + a0 (Horner). ----
+    tmpa_size = horner_eval_into_tmp(tmpa, {a3, a2, a1, a0}, 1u);
+
+    // v2 = p(2)^2
+    std::ranges::fill(v2, uint_multiprecision_t{0});
+    square_toom_cook_4(v2, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size}, scratch);
+
+    // ---- Evaluate at x = -2: tmpa = |(a0 + 4*a2) - (2*a1 + 8*a3)|. ----
+    tmpa_size = horner_eval_into_tmp(tmpa, {a2, a0}, 2u);
+
+    // aux holds 8*a3 + a1; trailing add_into_tmp doubles a1 to yield 8*a3 + 2*a1.
+    aux_size = horner_eval_into_tmp(aux, {a3, a1}, 3u);
+    aux_size = add_into_tmp(aux, aux_size, a1);
+
+    const auto sub_m2 =
+        subtract_unsigned_spans_signed(tmpa,
+                                       std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                                       std::span<const uint_multiprecision_t>{aux.data(), aux_size});
+    tmpa_size = sub_m2.size;
+
+    // vm2 = p(-2)^2
+    std::ranges::fill(vm2, uint_multiprecision_t{0});
+    if (tmpa_size != 0) {
+        square_toom_cook_4(vm2, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size}, scratch);
+    }
+
+    // ---- Evaluate at x = 1/2 (scaled by 8): tmpa = ((a0*2 + a1)*2 + a2)*2 + a3;
+    // this equals 8*a(1/2), so the resulting square is 64*c(1/2). ----
+    tmpa_size = horner_eval_into_tmp(tmpa, {a0, a1, a2, a3}, 1u);
+
+    // vh = (8*p(1/2))^2
+    std::ranges::fill(vh, uint_multiprecision_t{0});
+    square_toom_cook_4(vh, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size}, scratch);
+
+    // ---- Interpolation: the general kernel's sequence with sign_vm1 and
+    // sign_vm2 pinned to false (squares are non-negative). ----
+    const auto v0_view   = std::span<const uint_multiprecision_t>{result.data(), 2 * k};
+    const auto vinf_size = std::min(result.size() - 6 * k, 2 * k);
+    const auto vinf_view = std::span<const uint_multiprecision_t>{result.data() + 6 * k, vinf_size};
+    const auto v1_view   = std::span<const uint_multiprecision_t>{v1};
+    const auto vm1_view  = std::span<const uint_multiprecision_t>{vm1};
+    const auto v2_view   = std::span<const uint_multiprecision_t>{v2};
+    const auto vm2_view  = std::span<const uint_multiprecision_t>{vm2};
+    const auto vh_view   = std::span<const uint_multiprecision_t>{vh};
+    const auto td_view   = std::span<const uint_multiprecision_t>{tmp_double};
+
+    // Step 1: v1 <- (v1 + vm1) / 2 = E1 = c0 + c2 + c4 + c6.
+    {
+        const auto rem = add_unsigned_spans_and_shift_right_one(v1, v1_view, vm1_view);
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Step 2: vm1 <- v1 - vm1 = D1 = c1 + c3 + c5.
+    subtract_unsigned_spans_no_borrow(vm1, v1_view, vm1_view);
+
+    // Step 3: v2 <- (v2 + vm2) / 2 = E2 = c0 + 4c2 + 16c4 + 64c6.
+    {
+        const auto rem = add_unsigned_spans_and_shift_right_one(v2, v2_view, vm2_view);
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Step 4: vm2 <- (v2 - vm2) / 2 = D2 = c1 + 4c3 + 16c5.
+    {
+        const auto rem = subtract_unsigned_spans_and_shift_right_one(vm2, v2_view, vm2_view);
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Phase 2: Solve even system for c2 (into v1) and c4 (into v2).
+
+    // Step 5: v2 -= v1.  v2 = 3*(c2 + 5c4 + 21c6).
+    subtract_unsigned_spans(v2, v2_view, v1_view);
+    // Step 6: v2 /= 3.  v2 = c2 + 5c4 + 21c6.
+    {
+        const auto rem = divide_unsigned_short(v2, v2_view, uint_multiprecision_t{3});
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Step 7: v1 -= c0.  v1 = c2 + c4 + c6.
+    subtract_unsigned_spans(v1, v1_view, v0_view);
+    // Step 8: v1 -= c6.  v1 = c2 + c4.
+    subtract_unsigned_spans(v1, v1_view, vinf_view);
+
+    // Step 9: v2 -= v1.  v2 = 4c4 + 21c6.
+    subtract_unsigned_spans(v2, v2_view, v1_view);
+
+    // Step 10-11: subtract 21*c6 from v2 using tmp_double for the doublings,
+    // then halve twice in one fused pass.  Net: v2 = c4.
+    subtract_unsigned_spans(v2, v2_view, vinf_view);
+    std::ranges::fill(tmp_double, uint_multiprecision_t{0});
+    std::ranges::copy(vinf_view, tmp_double.begin());
+    std::size_t td_size = vinf_view.size();
+    td_size             = shift_left_n(tmp_double, td_size, 2u);
+    subtract_unsigned_spans(v2, v2_view, std::span<const uint_multiprecision_t>{tmp_double.data(), td_size});
+    td_size = shift_left_n(tmp_double, td_size, 2u);
+    {
+        const auto rem = subtract_unsigned_spans_and_shift_right_n(
+            v2, v2_view, std::span<const uint_multiprecision_t>{tmp_double.data(), td_size}, 2u);
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Step 12: v1 -= v2.  v1 = c2.
+    subtract_unsigned_spans(v1, v1_view, v2_view);
+
+    // Phase 3: Reduce vh to T_odd = (vh - 64c0 - 16c2 - 4c4 - c6) / 2 = 16c1 + 4c3 + c5.
+
+    // Step 13: vh -= 64*c0.
+    subtract_shifted_unsigned(vh, vh_view, v0_view.first(trimmed_size_span(v0_view)), 6u);
+
+    // Step 14: vh -= 16*c2 (c2 lives in v1 now).
+    subtract_shifted_unsigned(vh, vh_view, v1_view.first(trimmed_size_span(v1_view)), 4u);
+
+    // Step 15: vh -= 4*c4 (c4 lives in v2 now).
+    subtract_shifted_unsigned(vh, vh_view, v2_view.first(trimmed_size_span(v2_view)), 2u);
+
+    // Step 16-17: vh = (vh - c6) / 2.  vh = 16c1 + 4c3 + c5 = T_odd.
+    {
+        const auto rem = subtract_unsigned_spans_and_shift_right_one(vh, vh_view, vinf_view);
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Phase 4: Solve odd system using vm1 = D1, vm2 = D2, vh = T_odd.
+
+    // Step 18: vm2 -= vm1.  vm2 = 3*(c3 + 5c5).
+    subtract_unsigned_spans(vm2, vm2_view, vm1_view);
+    // Step 19: vh -= vm1.  vh = 3*(5c1 + c3).
+    subtract_unsigned_spans(vh, vh_view, vm1_view);
+    // Step 20: vm2 /= 3.  vm2 = alpha = c3 + 5c5.
+    {
+        const auto rem = divide_unsigned_short(vm2, vm2_view, uint_multiprecision_t{3});
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+    // Step 21: vh /= 3.  vh = beta = 5c1 + c3.
+    {
+        const auto rem = divide_unsigned_short(vh, vh_view, uint_multiprecision_t{3});
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Step 22: tmp_double = D1; vm1 *= 4; vm1 += tmp_double  (-> 5*D1).
+    std::ranges::fill(tmp_double, uint_multiprecision_t{0});
+    std::ranges::copy(vm1_view, tmp_double.begin());
+    const auto sz_4d1 = shift_left_n(vm1, vm1.size(), 2u); // 4*D1 in one pass
+    BEMAN_BIG_INT_DEBUG_ASSERT(sz_4d1 == vm1.size());
+    {
+        const bool carry = add_unsigned_spans(vm1, vm1_view, td_view); // 5*D1
+        BEMAN_BIG_INT_DEBUG_ASSERT(!carry);
+    }
+    // Step 23: vm1 -= alpha; vm1 -= beta.  vm1 = 3*c3.
+    subtract_unsigned_spans(vm1, vm1_view, vm2_view);
+    subtract_unsigned_spans(vm1, vm1_view, vh_view);
+    // Step 24: vm1 /= 3.  vm1 = c3.
+    {
+        const auto rem = divide_unsigned_short(vm1, vm1_view, uint_multiprecision_t{3});
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Step 25: vh -= c3 -> 5*c1; vh /= 5.  vh = c1.
+    subtract_unsigned_spans(vh, vh_view, vm1_view);
+    {
+        const auto rem = divide_unsigned_short(vh, vh_view, uint_multiprecision_t{5});
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Step 26: vm2 -= c3 -> 5*c5; vm2 /= 5.  vm2 = c5.
+    subtract_unsigned_spans(vm2, vm2_view, vm1_view);
+    {
+        const auto rem = divide_unsigned_short(vm2, vm2_view, uint_multiprecision_t{5});
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Phase 5: Recompose (c0 and c6 are already in result).
+    recompose(result, k, {vh_view, v1_view, vm1_view, v2_view, vm2_view});
+
+    // Release scratch back to the bump pool for sibling reuse.
+    scratch.deallocate(total_scratch);
+}
+
 } // namespace beman::big_int::detail

--- a/src/toom_cook_6_5.cpp
+++ b/src/toom_cook_6_5.cpp
@@ -5,6 +5,177 @@
 
 namespace beman::big_int::detail {
 
+// Solves one palindromic 5x5 subsystem of the Toom-6.5 interpolation (shared
+// by the general and squaring kernels; works on a, b, c, d, e where
+// a=row-of-ones buffer, b/c=row-2/row-4 buffers, d=row-h buffer, e=row-q buffer).
+// After return, a holds the middle coeff, b holds |d_inner| with returned sign_d_inner,
+// c holds |d_outer| with returned sign_d_outer, d holds s_inner, e holds s_outer.
+// `tmp_double` is the caller's 2k+2-limb shift scratch.
+static subsystem_signs solve_subsystem(const std::span<uint_multiprecision_t> a_buf,
+                                       const std::span<uint_multiprecision_t> b_buf,
+                                       const std::span<uint_multiprecision_t> c_buf,
+                                       const std::span<uint_multiprecision_t> d_buf,
+                                       const std::span<uint_multiprecision_t> e_buf,
+                                       const std::span<uint_multiprecision_t> tmp_double) noexcept {
+    const auto a_v = std::span<const uint_multiprecision_t>{a_buf};
+    const auto b_v = std::span<const uint_multiprecision_t>{b_buf};
+    const auto c_v = std::span<const uint_multiprecision_t>{c_buf};
+    const auto d_v = std::span<const uint_multiprecision_t>{d_buf};
+    const auto e_v = std::span<const uint_multiprecision_t>{e_buf};
+
+    // Compute 4*d in tmp_double. d here is 5x palindromic row, value fits in 2k+~10 bits.
+    std::ranges::fill(tmp_double, uint_multiprecision_t{0});
+    std::ranges::copy(d_buf, tmp_double.begin());
+    std::size_t s = trimmed_size_span(d_v);
+    s             = shift_left_n(tmp_double, s, 2u);
+
+    // d_buf <- b + 4*d = S_2.
+    const bool s2_carry =
+        add_unsigned_spans(d_buf, b_v, std::span<const uint_multiprecision_t>{tmp_double.data(), s});
+    BEMAN_BIG_INT_DEBUG_ASSERT(!s2_carry);
+    // b_buf <- |b - 4*d| with sign.
+    const auto sub_d2 =
+        subtract_unsigned_spans_signed(b_buf, b_v, std::span<const uint_multiprecision_t>{tmp_double.data(), s});
+    const bool sign_D2 = sub_d2.negative;
+
+    // Compute 16*e in tmp_double.
+    std::ranges::fill(tmp_double, uint_multiprecision_t{0});
+    std::ranges::copy(e_buf, tmp_double.begin());
+    s = trimmed_size_span(e_v);
+    s = shift_left_n(tmp_double, s, 4u);
+
+    // e_buf <- c + 16*e = S_4.
+    const bool s4_carry =
+        add_unsigned_spans(e_buf, c_v, std::span<const uint_multiprecision_t>{tmp_double.data(), s});
+    BEMAN_BIG_INT_DEBUG_ASSERT(!s4_carry);
+    // c_buf <- |c - 16*e| with sign.
+    const auto sub_d4 =
+        subtract_unsigned_spans_signed(c_buf, c_v, std::span<const uint_multiprecision_t>{tmp_double.data(), s});
+    const bool sign_D4 = sub_d4.negative;
+
+    // Eliminate the middle coefficient m from S_2 and S_4 using a (the all-ones row).
+    const auto a_trim_first = a_v.first(trimmed_size_span(a_v));
+
+    // d_buf -= 128*a.
+    subtract_shifted_unsigned(d_buf, d_v, a_trim_first, 7u);
+
+    // e_buf -= 8192*a.
+    subtract_shifted_unsigned(e_buf, e_v, a_trim_first, 13u);
+
+    // After elimination:
+    //   d_buf = 900*s_o + 144*s_i
+    //   e_buf = 1040400*s_o + 57600*s_i
+
+    // Eliminate s_inner from e_buf: e_buf -= 400 * d_buf.
+    // (Trim to satisfy multiply_single_limb's `result.size() >= a.size() + 1` precondition.)
+    {
+        const auto d_trim = d_v.first(trimmed_size_span(d_v));
+        const auto m400   = multiply_single_limb(tmp_double, d_trim, uint_multiprecision_t{400});
+        subtract_unsigned_spans(e_buf, e_v, std::span<const uint_multiprecision_t>{tmp_double.data(), m400});
+    }
+    // e_buf = 680400 * s_o.
+    {
+        const auto rem = divide_unsigned_short(e_buf, e_v, uint_multiprecision_t{680400});
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+    // e_buf = s_o now.
+
+    // Recover s_inner: d_buf = 900*s_o + 144*s_i -> d_buf -= 900*s_o; d_buf /= 144.
+    {
+        const auto e_trim = e_v.first(trimmed_size_span(e_v));
+        const auto m900   = multiply_single_limb(tmp_double, e_trim, uint_multiprecision_t{900});
+        subtract_unsigned_spans(d_buf, d_v, std::span<const uint_multiprecision_t>{tmp_double.data(), m900});
+    }
+    {
+        const auto rem = divide_unsigned_short(d_buf, d_v, uint_multiprecision_t{144});
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+    // d_buf = s_i.
+
+    // Recover middle: a_buf -= s_o; a_buf -= s_i.
+    subtract_unsigned_spans(a_buf, a_v, e_v);
+    subtract_unsigned_spans(a_buf, a_v, d_v);
+    // a_buf = m.
+
+    // Now solve the 2x2 for d_outer/d_inner from D_2 (b_buf, sign_D2) and D_4 (c_buf, sign_D4):
+    //   -D_2 = 1020 d_o + 240 d_i
+    //   -D_4 = 1048560 d_o + 65280 d_i
+    // Goal: c_buf <- |d_outer| with sign_d_outer; b_buf <- |d_inner| with sign_d_inner.
+    //
+    // Eliminate d_inner: compute X = -D_4 - 272*(-D_2) = -D_4 + 272*D_2 = 771120 * d_outer.
+    // In signed form: X_signed = 272 * b_signed - c_signed, where b_signed = D_2_signed = (sign_D2 ? -|b| : +|b|)
+    // and c_signed = D_4_signed similarly.
+    //
+    // Implementation: compute 272*|b| into tmp_double. Then combine with |c| based on sign relations.
+
+    const auto b_diff_trim = b_v.first(trimmed_size_span(b_v));
+    const auto m272        = multiply_single_limb(tmp_double, b_diff_trim, uint_multiprecision_t{272});
+    const auto td272       = std::span<const uint_multiprecision_t>{tmp_double.data(), m272};
+    // X_signed = (sign_D2 ? -272|b| : +272|b|) - (sign_D4 ? -|c| : +|c|)
+    //          = sign_D2 ? (-272|b| - (sign_D4 ? -|c| : +|c|)) : (272|b| - (sign_D4 ? -|c| : +|c|))
+    // Cases:
+    //   sign_D2=false, sign_D4=false: X = 272|b| - |c|.  Use subtract_signed.
+    //   sign_D2=false, sign_D4=true:  X = 272|b| + |c|.  Add (positive).
+    //   sign_D2=true,  sign_D4=false: X = -272|b| - |c| = -(272|b|+|c|).  Add, sign true.
+    //   sign_D2=true,  sign_D4=true:  X = -272|b| + |c| = |c| - 272|b|.  Use subtract_signed (swap).
+    bool sign_X = false;
+    if (sign_D2 == sign_D4) {
+        // Same sign: result magnitude = |272|b| - |c||; sign = sign_D2 XOR (sub_negative).
+        const auto sx = subtract_unsigned_spans_signed(c_buf, td272, c_v);
+        sign_X        = sign_D2 ^ sx.negative;
+    } else {
+        // Different signs: result magnitude = 272|b| + |c|; sign = sign_D2.
+        const bool carry = add_unsigned_spans(c_buf, td272, c_v);
+        BEMAN_BIG_INT_DEBUG_ASSERT(!carry);
+        sign_X = sign_D2;
+    }
+    // c_buf now holds |X|; X_signed = 771120 * d_outer; therefore
+    // sign of d_outer = sign_X (771120 > 0); magnitude |d_outer| = |X|/771120.
+    {
+        const auto rem = divide_unsigned_short(
+            c_buf, std::span<const uint_multiprecision_t>{c_buf}, uint_multiprecision_t{771120});
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+    const bool sign_d_outer = sign_X;
+    // c_buf = |d_outer|.
+
+    // Recover d_inner from -D_2 = 1020*d_outer + 240*d_inner, i.e.,
+    //   240 * d_inner_signed = (-D_2) - 1020 * d_outer
+    //                        = -(sign_D2 ? -|b| : +|b|) - 1020 * (sign_d_outer ? -|c| : +|c|)
+    // Compute 1020 * |c| into tmp_double, sign = sign_d_outer.
+    const auto c_buf_view = std::span<const uint_multiprecision_t>{c_buf};
+    const auto c_trim     = c_buf_view.first(trimmed_size_span(c_buf_view));
+    const auto m1020      = multiply_single_limb(tmp_double, c_trim, uint_multiprecision_t{1020});
+    const auto td1020     = std::span<const uint_multiprecision_t>{tmp_double.data(), m1020};
+    // -D_2 has sign !sign_D2. So we compute (-D_2) + (-(1020*d_outer)) signed-result.
+    // = (-D_2) - 1020*d_outer signed.
+    // sign of -D_2 = !sign_D2 (we ADD its magnitude to nothing yet; first put it).
+    // Let's compute Y = (-D_2) - 1020 * d_outer in signed form.
+    //   first_term: |b| with sign !sign_D2 (since first_term = -D_2 = -(sign_D2 ? -|b| : +|b|))
+    //   second_term: 1020 * (sign_d_outer ? -|c| : +|c|) = sign_d_outer ? -1020|c| : +1020|c|
+    //   Y = first_term - second_term
+    const bool sign_first  = !sign_D2;
+    const bool sign_second = sign_d_outer;
+    bool       sign_Y      = false;
+    if (sign_first == sign_second) {
+        const auto sy = subtract_unsigned_spans_signed(b_buf, b_v, td1020);
+        sign_Y        = sign_first ^ sy.negative;
+    } else {
+        const bool carry = add_unsigned_spans(b_buf, b_v, td1020);
+        BEMAN_BIG_INT_DEBUG_ASSERT(!carry);
+        sign_Y = sign_first;
+    }
+    // Y = 240 * d_inner. Therefore |d_inner| = |Y|/240, sign_d_inner = sign_Y.
+    {
+        const auto rem = divide_unsigned_short(
+            b_buf, std::span<const uint_multiprecision_t>{b_buf}, uint_multiprecision_t{240});
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+    const bool sign_d_inner = sign_Y;
+
+    return {sign_d_outer, sign_d_inner};
+}
+
 void multiply_toom_cook_6_5(const std::span<uint_multiprecision_t>       result,
                             const std::span<const uint_multiprecision_t> a_untrimmed,
                             const std::span<const uint_multiprecision_t> b_untrimmed,
@@ -513,183 +684,15 @@ void multiply_toom_cook_6_5(const std::span<uint_multiprecision_t>       result,
     // Finally recover c2,c10 (or c1,c9) and c4,c8 (or c3,c7) using sign-aware
     // half-sum-and-difference in v2/vh and v4/vq respectively. --
 
-    // Lambda capturing the elimination for one side (works on a, b, c, d, e where
-    // a=row-of-ones buffer, b/c=row-2/row-4 buffers, d=row-h buffer, e=row-q buffer).
-    // After return, a holds the middle coeff, b holds |d_inner| with returned sign_d_inner,
-    // c holds |d_outer| with returned sign_d_outer, d holds s_inner, e holds s_outer.
-    const auto solve_subsystem =
-        [&](const std::span<uint_multiprecision_t> a_buf,
-            const std::span<uint_multiprecision_t> b_buf,
-            const std::span<uint_multiprecision_t> c_buf,
-            const std::span<uint_multiprecision_t> d_buf,
-            const std::span<uint_multiprecision_t> e_buf) constexpr noexcept -> subsystem_signs {
-        const auto a_v = std::span<const uint_multiprecision_t>{a_buf};
-        const auto b_v = std::span<const uint_multiprecision_t>{b_buf};
-        const auto c_v = std::span<const uint_multiprecision_t>{c_buf};
-        const auto d_v = std::span<const uint_multiprecision_t>{d_buf};
-        const auto e_v = std::span<const uint_multiprecision_t>{e_buf};
-
-        // Compute 4*d in tmp_double. d here is 5x palindromic row, value fits in 2k+~10 bits.
-        std::ranges::fill(tmp_double, uint_multiprecision_t{0});
-        std::ranges::copy(d_buf, tmp_double.begin());
-        std::size_t s = trimmed_size_span(d_v);
-        s             = shift_left_n(tmp_double, s, 2u);
-
-        // d_buf <- b + 4*d = S_2.
-        const bool s2_carry =
-            add_unsigned_spans(d_buf, b_v, std::span<const uint_multiprecision_t>{tmp_double.data(), s});
-        BEMAN_BIG_INT_DEBUG_ASSERT(!s2_carry);
-        // b_buf <- |b - 4*d| with sign.
-        const auto sub_d2 =
-            subtract_unsigned_spans_signed(b_buf, b_v, std::span<const uint_multiprecision_t>{tmp_double.data(), s});
-        const bool sign_D2 = sub_d2.negative;
-
-        // Compute 16*e in tmp_double.
-        std::ranges::fill(tmp_double, uint_multiprecision_t{0});
-        std::ranges::copy(e_buf, tmp_double.begin());
-        s = trimmed_size_span(e_v);
-        s = shift_left_n(tmp_double, s, 4u);
-
-        // e_buf <- c + 16*e = S_4.
-        const bool s4_carry =
-            add_unsigned_spans(e_buf, c_v, std::span<const uint_multiprecision_t>{tmp_double.data(), s});
-        BEMAN_BIG_INT_DEBUG_ASSERT(!s4_carry);
-        // c_buf <- |c - 16*e| with sign.
-        const auto sub_d4 =
-            subtract_unsigned_spans_signed(c_buf, c_v, std::span<const uint_multiprecision_t>{tmp_double.data(), s});
-        const bool sign_D4 = sub_d4.negative;
-
-        // Eliminate the middle coefficient m from S_2 and S_4 using a (the all-ones row).
-        const auto a_trim_first = a_v.first(trimmed_size_span(a_v));
-
-        // d_buf -= 128*a.
-        subtract_shifted_unsigned(d_buf, d_v, a_trim_first, 7u);
-
-        // e_buf -= 8192*a.
-        subtract_shifted_unsigned(e_buf, e_v, a_trim_first, 13u);
-
-        // After elimination:
-        //   d_buf = 900*s_o + 144*s_i
-        //   e_buf = 1040400*s_o + 57600*s_i
-
-        // Eliminate s_inner from e_buf: e_buf -= 400 * d_buf.
-        // (Trim to satisfy multiply_single_limb's `result.size() >= a.size() + 1` precondition.)
-        {
-            const auto d_trim = d_v.first(trimmed_size_span(d_v));
-            const auto m400   = multiply_single_limb(tmp_double, d_trim, uint_multiprecision_t{400});
-            subtract_unsigned_spans(e_buf, e_v, std::span<const uint_multiprecision_t>{tmp_double.data(), m400});
-        }
-        // e_buf = 680400 * s_o.
-        {
-            const auto rem = divide_unsigned_short(e_buf, e_v, uint_multiprecision_t{680400});
-            BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
-        }
-        // e_buf = s_o now.
-
-        // Recover s_inner: d_buf = 900*s_o + 144*s_i -> d_buf -= 900*s_o; d_buf /= 144.
-        {
-            const auto e_trim = e_v.first(trimmed_size_span(e_v));
-            const auto m900   = multiply_single_limb(tmp_double, e_trim, uint_multiprecision_t{900});
-            subtract_unsigned_spans(d_buf, d_v, std::span<const uint_multiprecision_t>{tmp_double.data(), m900});
-        }
-        {
-            const auto rem = divide_unsigned_short(d_buf, d_v, uint_multiprecision_t{144});
-            BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
-        }
-        // d_buf = s_i.
-
-        // Recover middle: a_buf -= s_o; a_buf -= s_i.
-        subtract_unsigned_spans(a_buf, a_v, e_v);
-        subtract_unsigned_spans(a_buf, a_v, d_v);
-        // a_buf = m.
-
-        // Now solve the 2x2 for d_outer/d_inner from D_2 (b_buf, sign_D2) and D_4 (c_buf, sign_D4):
-        //   -D_2 = 1020 d_o + 240 d_i
-        //   -D_4 = 1048560 d_o + 65280 d_i
-        // Goal: c_buf <- |d_outer| with sign_d_outer; b_buf <- |d_inner| with sign_d_inner.
-        //
-        // Eliminate d_inner: compute X = -D_4 - 272*(-D_2) = -D_4 + 272*D_2 = 771120 * d_outer.
-        // In signed form: X_signed = 272 * b_signed - c_signed, where b_signed = D_2_signed = (sign_D2 ? -|b| : +|b|)
-        // and c_signed = D_4_signed similarly.
-        //
-        // Implementation: compute 272*|b| into tmp_double. Then combine with |c| based on sign relations.
-
-        const auto b_diff_trim = b_v.first(trimmed_size_span(b_v));
-        const auto m272        = multiply_single_limb(tmp_double, b_diff_trim, uint_multiprecision_t{272});
-        const auto td272       = std::span<const uint_multiprecision_t>{tmp_double.data(), m272};
-        // X_signed = (sign_D2 ? -272|b| : +272|b|) - (sign_D4 ? -|c| : +|c|)
-        //          = sign_D2 ? (-272|b| - (sign_D4 ? -|c| : +|c|)) : (272|b| - (sign_D4 ? -|c| : +|c|))
-        // Cases:
-        //   sign_D2=false, sign_D4=false: X = 272|b| - |c|.  Use subtract_signed.
-        //   sign_D2=false, sign_D4=true:  X = 272|b| + |c|.  Add (positive).
-        //   sign_D2=true,  sign_D4=false: X = -272|b| - |c| = -(272|b|+|c|).  Add, sign true.
-        //   sign_D2=true,  sign_D4=true:  X = -272|b| + |c| = |c| - 272|b|.  Use subtract_signed (swap).
-        bool sign_X = false;
-        if (sign_D2 == sign_D4) {
-            // Same sign: result magnitude = |272|b| - |c||; sign = sign_D2 XOR (sub_negative).
-            const auto sx = subtract_unsigned_spans_signed(c_buf, td272, c_v);
-            sign_X        = sign_D2 ^ sx.negative;
-        } else {
-            // Different signs: result magnitude = 272|b| + |c|; sign = sign_D2.
-            const bool carry = add_unsigned_spans(c_buf, td272, c_v);
-            BEMAN_BIG_INT_DEBUG_ASSERT(!carry);
-            sign_X = sign_D2;
-        }
-        // c_buf now holds |X|; X_signed = 771120 * d_outer; therefore
-        // sign of d_outer = sign_X (771120 > 0); magnitude |d_outer| = |X|/771120.
-        {
-            const auto rem = divide_unsigned_short(
-                c_buf, std::span<const uint_multiprecision_t>{c_buf}, uint_multiprecision_t{771120});
-            BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
-        }
-        const bool sign_d_outer = sign_X;
-        // c_buf = |d_outer|.
-
-        // Recover d_inner from -D_2 = 1020*d_outer + 240*d_inner, i.e.,
-        //   240 * d_inner_signed = (-D_2) - 1020 * d_outer
-        //                        = -(sign_D2 ? -|b| : +|b|) - 1020 * (sign_d_outer ? -|c| : +|c|)
-        // Compute 1020 * |c| into tmp_double, sign = sign_d_outer.
-        const auto c_buf_view = std::span<const uint_multiprecision_t>{c_buf};
-        const auto c_trim     = c_buf_view.first(trimmed_size_span(c_buf_view));
-        const auto m1020      = multiply_single_limb(tmp_double, c_trim, uint_multiprecision_t{1020});
-        const auto td1020     = std::span<const uint_multiprecision_t>{tmp_double.data(), m1020};
-        // -D_2 has sign !sign_D2. So we compute (-D_2) + (-(1020*d_outer)) signed-result.
-        // = (-D_2) - 1020*d_outer signed.
-        // sign of -D_2 = !sign_D2 (we ADD its magnitude to nothing yet; first put it).
-        // Let's compute Y = (-D_2) - 1020 * d_outer in signed form.
-        //   first_term: |b| with sign !sign_D2 (since first_term = -D_2 = -(sign_D2 ? -|b| : +|b|))
-        //   second_term: 1020 * (sign_d_outer ? -|c| : +|c|) = sign_d_outer ? -1020|c| : +1020|c|
-        //   Y = first_term - second_term
-        const bool sign_first  = !sign_D2;
-        const bool sign_second = sign_d_outer;
-        bool       sign_Y      = false;
-        if (sign_first == sign_second) {
-            const auto sy = subtract_unsigned_spans_signed(b_buf, b_v, td1020);
-            sign_Y        = sign_first ^ sy.negative;
-        } else {
-            const bool carry = add_unsigned_spans(b_buf, b_v, td1020);
-            BEMAN_BIG_INT_DEBUG_ASSERT(!carry);
-            sign_Y = sign_first;
-        }
-        // Y = 240 * d_inner. Therefore |d_inner| = |Y|/240, sign_d_inner = sign_Y.
-        {
-            const auto rem = divide_unsigned_short(
-                b_buf, std::span<const uint_multiprecision_t>{b_buf}, uint_multiprecision_t{240});
-            BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
-        }
-        const bool sign_d_inner = sign_Y;
-
-        return {sign_d_outer, sign_d_inner};
-    };
 
     // Solve even subsystem in {v1, v2, v4, vh, vq}.
-    const auto [sign_d_outer_e, sign_d_inner_e] = solve_subsystem(v1, v2, v4, vh, vq);
+    const auto [sign_d_outer_e, sign_d_inner_e] = solve_subsystem(v1, v2, v4, vh, vq, tmp_double);
     // Now:  v1 = c6;  vh = c4+c8;  vq = c2+c10;  v4 = |c2 - c10|, sign_d_outer_e;  v2 = |c4 - c8|, sign_d_inner_e.
 
     // Solve odd subsystem in {vm1, vm2, vm4, vmh, vmq}. The odd buffers were
     // pre-scaled in Phase 2 (vm2*=4, vm4*=16) so the same elimination chain
     // applies.
-    const auto [sign_d_outer_o, sign_d_inner_o] = solve_subsystem(vm1, vm2, vm4, vmh, vmq);
+    const auto [sign_d_outer_o, sign_d_inner_o] = solve_subsystem(vm1, vm2, vm4, vmh, vmq, tmp_double);
     // Now:  vm1 = c5;  vmh = c3+c7;  vmq = c1+c9;  vm4 = |c1 - c9|, sign_d_outer_o;  vm2 = |c3 - c7|, sign_d_inner_o.
 
     // -- Recover individual c-values from sum/diff pairs --
@@ -765,6 +768,349 @@ void multiply_toom_cook_6_5(const std::span<uint_multiprecision_t>       result,
     //   c8  in vh  -> offset  8*k
     //   c9  in vmq -> offset  9*k
     //   c10 in vq  -> offset 10*k
+    recompose(
+        result, k, {vm4_view, v4_view, vm2_view, v2_view, vm1_view, v1_view, vmh_view, vh_view, vmq_view, vq_view});
+
+    // Release scratch back to the bump pool for sibling reuse.
+    scratch.deallocate(total_scratch);
+}
+
+void square_toom_cook_6_5(const std::span<uint_multiprecision_t>       result,
+                          const std::span<const uint_multiprecision_t> a_untrimmed,
+                          scratch_allocator_base&                      scratch,
+                          const std::size_t                            cutoff_override) noexcept {
+    BEMAN_BIG_INT_DEBUG_ASSERT(!a_untrimmed.empty());
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.size() >= 2 * trimmed_size_span(a_untrimmed));
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.data() != a_untrimmed.data());
+
+    const auto a = a_untrimmed.first(trimmed_size_span(a_untrimmed));
+
+    const std::size_t k                = (a.size() + 5) / 6; // ceil(n/6)
+    const std::size_t effective_cutoff = cutoff_override == 0 ? square_toom_cook_6_5_cutoff : cutoff_override;
+
+    // Fall through to the Toom-4 squaring variant below the performance cutoff
+    // or below the algorithm's 5*k invariant (a5 must be non-empty). Squaring
+    // is always balanced, so the general kernel's 7:6 ratio gate cannot trip.
+    if (a.size() < effective_cutoff || a.size() <= 5 * k) {
+        square_toom_cook_4(result, a, scratch);
+        return;
+    }
+
+    // Split into six pieces of size k (a5 may be partial).
+    const auto a0 = a.first(k);
+    const auto a1 = a.subspan(k, k);
+    const auto a2 = a.subspan(2 * k, k);
+    const auto a3 = a.subspan(3 * k, k);
+    const auto a4 = a.subspan(4 * k, k);
+    const auto a5 = a.subspan(5 * k);
+
+    // Carve scratch: one evaluation buffer tmpa (the general kernel needs
+    // tmpa and tmpb); ten squares; tmp_double for in-place scaling. The
+    // negative halves of the signed points stage in the corresponding vmX
+    // buffer before it receives its square, as in the general kernel.
+    const std::size_t tmp_cap       = k + 2;
+    const std::size_t prod_cap      = 2 * k + 2;
+    const std::size_t total_scratch = tmp_cap + 11 * prod_cap;
+
+    auto block      = scratch.allocate(total_scratch);
+    auto tmpa       = block.first(tmp_cap);
+    auto v1         = block.subspan(tmp_cap + 0 * prod_cap, prod_cap);
+    auto vm1        = block.subspan(tmp_cap + 1 * prod_cap, prod_cap);
+    auto v2         = block.subspan(tmp_cap + 2 * prod_cap, prod_cap);
+    auto vm2        = block.subspan(tmp_cap + 3 * prod_cap, prod_cap);
+    auto v4         = block.subspan(tmp_cap + 4 * prod_cap, prod_cap);
+    auto vm4        = block.subspan(tmp_cap + 5 * prod_cap, prod_cap);
+    auto vh         = block.subspan(tmp_cap + 6 * prod_cap, prod_cap);
+    auto vmh        = block.subspan(tmp_cap + 7 * prod_cap, prod_cap);
+    auto vq         = block.subspan(tmp_cap + 8 * prod_cap, prod_cap);
+    auto vmq        = block.subspan(tmp_cap + 9 * prod_cap, prod_cap);
+    auto tmp_double = block.subspan(tmp_cap + 10 * prod_cap, prod_cap);
+
+    // ---- c0 = a0^2, written into result[0..2k). Caller pre-zeroed result.
+    // c11 = 0 for balanced squaring (the general kernel's b6 is empty), so
+    // result[11k..) correctly stays zero. ----
+    square_toom_cook_6_5(result.first(2 * a0.size()), a0, scratch);
+
+    std::size_t tmpa_size = 0;
+    std::size_t aux_size  = 0;
+
+    // ---- Evaluate at x = 1: tmpa = a0+a1+a2+a3+a4+a5. ----
+    tmpa_size = add_many_into_tmp(tmpa, {a0, a1, a2, a3, a4, a5});
+
+    std::ranges::fill(v1, uint_multiprecision_t{0});
+    square_toom_cook_6_5(v1, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size}, scratch);
+
+    // ---- Evaluate at x = -1: tmpa = |(a0+a2+a4) - (a1+a3+a5)|. The square
+    // erases the sign, here and at every signed point below, so the
+    // interpolation uses the non-negative arms of the general kernel. ----
+    tmpa_size = add_many_into_tmp(tmpa, {a0, a2, a4});
+    // Use vm1 (currently unused) as scratch for (a1+a3+a5).
+    aux_size = add_many_into_tmp(vm1, {a1, a3, a5});
+    const auto sub_m1 =
+        subtract_unsigned_spans_signed(tmpa,
+                                       std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                                       std::span<const uint_multiprecision_t>{vm1.data(), aux_size});
+    tmpa_size = sub_m1.size;
+
+    std::ranges::fill(vm1, uint_multiprecision_t{0});
+    if (tmpa_size != 0) {
+        square_toom_cook_6_5(vm1, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size}, scratch);
+    }
+
+    // ---- Evaluate at x = 2: tmpa = 32a5+16a4+8a3+4a2+2a1+a0 (Horner). ----
+    tmpa_size = horner_eval_into_tmp(tmpa, {a5, a4, a3, a2, a1, a0}, 1u);
+
+    std::ranges::fill(v2, uint_multiprecision_t{0});
+    square_toom_cook_6_5(v2, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size}, scratch);
+
+    // ---- Evaluate at x = -2: tmpa = |(a0+4a2+16a4) - (2a1+8a3+32a5)|. ----
+    tmpa_size = horner_eval_into_tmp(tmpa, {a4, a2, a0}, 2u);
+    // negative part 2a1+8a3+32a5 into vm2 (currently unused).
+    aux_size = horner_eval_into_tmp(vm2, {a5, a3, a1}, 2u);
+    aux_size = shift_left_one(vm2, aux_size);
+    const auto sub_m2 =
+        subtract_unsigned_spans_signed(tmpa,
+                                       std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                                       std::span<const uint_multiprecision_t>{vm2.data(), aux_size});
+    tmpa_size = sub_m2.size;
+
+    std::ranges::fill(vm2, uint_multiprecision_t{0});
+    if (tmpa_size != 0) {
+        square_toom_cook_6_5(vm2, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size}, scratch);
+    }
+
+    // ---- Evaluate at x = 4: tmpa = 1024a5 + 256a4 + 64a3 + 16a2 + 4a1 + a0. ----
+    tmpa_size = horner_eval_into_tmp(tmpa, {a5, a4, a3, a2, a1, a0}, 2u);
+
+    std::ranges::fill(v4, uint_multiprecision_t{0});
+    square_toom_cook_6_5(v4, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size}, scratch);
+
+    // ---- Evaluate at x = -4: tmpa = |(a0+16a2+256a4) - (4a1+64a3+1024a5)|. ----
+    tmpa_size = horner_eval_into_tmp(tmpa, {a4, a2, a0}, 4u);
+    // negative part 4a1+64a3+1024a5 into vm4.
+    aux_size = horner_eval_into_tmp(vm4, {a5, a3, a1}, 4u);
+    aux_size = shift_left_n(vm4, aux_size, 2u);
+    const auto sub_m4 =
+        subtract_unsigned_spans_signed(tmpa,
+                                       std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                                       std::span<const uint_multiprecision_t>{vm4.data(), aux_size});
+    tmpa_size = sub_m4.size;
+
+    std::ranges::fill(vm4, uint_multiprecision_t{0});
+    if (tmpa_size != 0) {
+        square_toom_cook_6_5(vm4, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size}, scratch);
+    }
+
+    // ---- Evaluate at x = 1/2 (scaled): tmpa = 32a0+16a1+8a2+4a3+2a4+a5
+    // = 32*p(1/2). The square is 1024*r(1/2); the interpolation expects the
+    // general kernel's 2048*r(1/2) (it pairs a 6-piece and a 7-piece
+    // evaluation), so shift left once after squaring. ----
+    tmpa_size = horner_eval_into_tmp(tmpa, {a0, a1, a2, a3, a4, a5}, 1u);
+
+    std::ranges::fill(vh, uint_multiprecision_t{0});
+    square_toom_cook_6_5(vh, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size}, scratch);
+    {
+        [[maybe_unused]] const auto sz = shift_left_one(vh, vh.size());
+        BEMAN_BIG_INT_DEBUG_ASSERT(sz == vh.size());
+    }
+
+    // ---- Evaluate at x = -1/2 (scaled): tmpa = |(32a0+8a2+2a4) - (16a1+4a3+a5)|
+    // = |32*p(-1/2)|. Same 2x rescale as vh after squaring. ----
+    tmpa_size = horner_eval_into_tmp(tmpa, {a0, a2, a4}, 2u);
+    tmpa_size = shift_left_one(tmpa, tmpa_size);
+    // negative part 16a1+4a3+a5 into vmh.
+    aux_size = horner_eval_into_tmp(vmh, {a1, a3, a5}, 2u);
+    const auto sub_mh =
+        subtract_unsigned_spans_signed(tmpa,
+                                       std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                                       std::span<const uint_multiprecision_t>{vmh.data(), aux_size});
+    tmpa_size = sub_mh.size;
+
+    std::ranges::fill(vmh, uint_multiprecision_t{0});
+    if (tmpa_size != 0) {
+        square_toom_cook_6_5(vmh, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size}, scratch);
+        [[maybe_unused]] const auto sz = shift_left_one(vmh, vmh.size());
+        BEMAN_BIG_INT_DEBUG_ASSERT(sz == vmh.size());
+    }
+
+    // ---- Evaluate at x = 1/4 (scaled): tmpa = 1024a0+256a1+64a2+16a3+4a4+a5
+    // = 1024*p(1/4). The square is 4^10*r(1/4); shift left twice for the
+    // general kernel's 4^11 scaling. ----
+    tmpa_size = horner_eval_into_tmp(tmpa, {a0, a1, a2, a3, a4, a5}, 2u);
+
+    std::ranges::fill(vq, uint_multiprecision_t{0});
+    square_toom_cook_6_5(vq, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size}, scratch);
+    {
+        [[maybe_unused]] const auto sz = shift_left_n(vq, vq.size(), 2u);
+        BEMAN_BIG_INT_DEBUG_ASSERT(sz == vq.size());
+    }
+
+    // ---- Evaluate at x = -1/4 (scaled): tmpa = |(1024a0+64a2+4a4) - (256a1+16a3+a5)|.
+    // Same 4x rescale as vq after squaring. ----
+    tmpa_size = horner_eval_into_tmp(tmpa, {a0, a2, a4}, 4u);
+    tmpa_size = shift_left_n(tmpa, tmpa_size, 2u);
+    // negative part 256a1+16a3+a5 into vmq.
+    aux_size = horner_eval_into_tmp(vmq, {a1, a3, a5}, 4u);
+    const auto sub_mq =
+        subtract_unsigned_spans_signed(tmpa,
+                                       std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                                       std::span<const uint_multiprecision_t>{vmq.data(), aux_size});
+    tmpa_size = sub_mq.size;
+
+    std::ranges::fill(vmq, uint_multiprecision_t{0});
+    if (tmpa_size != 0) {
+        square_toom_cook_6_5(vmq, std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size}, scratch);
+        [[maybe_unused]] const auto sz = shift_left_n(vmq, vmq.size(), 2u);
+        BEMAN_BIG_INT_DEBUG_ASSERT(sz == vmq.size());
+    }
+
+    // ---- Interpolation: the general kernel's sequence with every sign flag
+    // pinned to false (squares are non-negative) and c11 = 0. ----
+
+    const auto v0_view  = std::span<const uint_multiprecision_t>{result.data(), 2 * k};
+    const auto v1_view  = std::span<const uint_multiprecision_t>{v1};
+    const auto vm1_view = std::span<const uint_multiprecision_t>{vm1};
+    const auto v2_view  = std::span<const uint_multiprecision_t>{v2};
+    const auto vm2_view = std::span<const uint_multiprecision_t>{vm2};
+    const auto v4_view  = std::span<const uint_multiprecision_t>{v4};
+    const auto vm4_view = std::span<const uint_multiprecision_t>{vm4};
+    const auto vh_view  = std::span<const uint_multiprecision_t>{vh};
+    const auto vmh_view = std::span<const uint_multiprecision_t>{vmh};
+    const auto vq_view  = std::span<const uint_multiprecision_t>{vq};
+    const auto vmq_view = std::span<const uint_multiprecision_t>{vmq};
+
+    // -- Phase 1: symmetrize each pair. v_x <- E_x; vm_x <- D_x. --
+    {
+        const auto rem = add_unsigned_spans_and_shift_right_one(v1, v1_view, vm1_view);
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+    subtract_unsigned_spans_no_borrow(vm1, v1_view, vm1_view);
+
+    {
+        const auto rem = add_unsigned_spans_and_shift_right_one(v2, v2_view, vm2_view);
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+    {
+        const auto rem = subtract_unsigned_spans_and_shift_right_one(vm2, v2_view, vm2_view);
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    {
+        const auto rem = add_unsigned_spans_and_shift_right_one(v4, v4_view, vm4_view);
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+    {
+        const auto rem = subtract_unsigned_spans_and_shift_right_n(vm4, v4_view, vm4_view, 2u);
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    {
+        const auto rem = add_unsigned_spans_and_shift_right_one(vh, vh_view, vmh_view);
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+    subtract_unsigned_spans_no_borrow(vmh, vh_view, vmh_view);
+
+    {
+        const auto rem = add_unsigned_spans_and_shift_right_one(vq, vq_view, vmq_view);
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+    subtract_unsigned_spans_no_borrow(vmq, vq_view, vmq_view);
+
+    // -- Phase 2: subtract the c0 contributions from the even rows; with
+    // c11 = 0 the odd-row reductions collapse to plain exact shifts. --
+
+    subtract_unsigned_spans(v1, v1_view, v0_view);
+    subtract_unsigned_spans(v2, v2_view, v0_view);
+    subtract_unsigned_spans(v4, v4_view, v0_view);
+
+    // vh = (vh - 2048*c0) / 2.
+    std::ranges::fill(tmp_double, uint_multiprecision_t{0});
+    std::ranges::copy(v0_view, tmp_double.begin());
+    std::size_t td_size = trimmed_size_span(v0_view);
+    td_size             = shift_left_n(tmp_double, td_size, 11u);
+    {
+        const auto rem = subtract_unsigned_spans_and_shift_right_one(
+            vh, vh_view, std::span<const uint_multiprecision_t>{tmp_double.data(), td_size});
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // vq = (vq - 4194304*c0) / 4.
+    std::ranges::fill(tmp_double, uint_multiprecision_t{0});
+    std::ranges::copy(v0_view, tmp_double.begin());
+    td_size = trimmed_size_span(v0_view);
+    td_size = shift_left_n(tmp_double, td_size, 22u);
+    {
+        const auto rem = subtract_unsigned_spans_and_shift_right_n(
+            vq, vq_view, std::span<const uint_multiprecision_t>{tmp_double.data(), td_size}, 2u);
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Odd side: c11 = 0, so (vmh - c11)/4 and (vmq - c11)/16 are plain exact
+    // shifts and the c11 subtractions from vm1/vm2/vm4 vanish.
+    {
+        const auto rem = shift_right_n(vmh, 2u);
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+    {
+        const auto rem = shift_right_n(vmq, 4u);
+        BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
+    }
+
+    // Pre-scale the odd rows so both subsystems share the same 5x5 matrix
+    // (see the general kernel for the derivation).
+    {
+        // vm2 *= 4.
+        std::size_t s = trimmed_size_span(vm2_view);
+        s             = shift_left_n(vm2, s, 2u);
+        BEMAN_BIG_INT_DEBUG_ASSERT(s <= vm2.size());
+    }
+    {
+        // vm4 *= 16.
+        std::size_t s = trimmed_size_span(vm4_view);
+        s             = shift_left_n(vm4, s, 4u);
+        BEMAN_BIG_INT_DEBUG_ASSERT(s <= vm4.size());
+    }
+
+    // -- Phase 3: solve the two 5x5 subsystems with the shared elimination. --
+    const auto [sign_d_outer_e, sign_d_inner_e] = solve_subsystem(v1, v2, v4, vh, vq, tmp_double);
+    const auto [sign_d_outer_o, sign_d_inner_o] = solve_subsystem(vm1, vm2, vm4, vmh, vmq, tmp_double);
+
+    // -- Recover individual c-values from the sum/diff pairs (see the general
+    // kernel for the aliasing discussion). --
+    recover_pair(v4,
+                 vq,
+                 std::span<const uint_multiprecision_t>{vq},
+                 std::span<const uint_multiprecision_t>{v4},
+                 sign_d_outer_e,
+                 tmp_double);
+    // After: v4 = c2, vq = c10.
+
+    recover_pair(v2,
+                 vh,
+                 std::span<const uint_multiprecision_t>{vh},
+                 std::span<const uint_multiprecision_t>{v2},
+                 sign_d_inner_e,
+                 tmp_double);
+    // After: v2 = c4, vh = c8.
+
+    recover_pair(vm4,
+                 vmq,
+                 std::span<const uint_multiprecision_t>{vmq},
+                 std::span<const uint_multiprecision_t>{vm4},
+                 sign_d_outer_o,
+                 tmp_double);
+    // After: vm4 = c1, vmq = c9.
+
+    recover_pair(vm2,
+                 vmh,
+                 std::span<const uint_multiprecision_t>{vmh},
+                 std::span<const uint_multiprecision_t>{vm2},
+                 sign_d_inner_o,
+                 tmp_double);
+    // After: vm2 = c3, vmh = c7.
+
+    // -- Recompose: place each c_i at offset i*k in result; c0 is already in
+    // position and c11 = 0. --
     recompose(
         result, k, {vm4_view, v4_view, vm2_view, v2_view, vm1_view, v1_view, vmh_view, vh_view, vmq_view, vq_view});
 

--- a/src/toom_cook_6_5.cpp
+++ b/src/toom_cook_6_5.cpp
@@ -30,8 +30,7 @@ static subsystem_signs solve_subsystem(const std::span<uint_multiprecision_t> a_
     s             = shift_left_n(tmp_double, s, 2u);
 
     // d_buf <- b + 4*d = S_2.
-    const bool s2_carry =
-        add_unsigned_spans(d_buf, b_v, std::span<const uint_multiprecision_t>{tmp_double.data(), s});
+    const bool s2_carry = add_unsigned_spans(d_buf, b_v, std::span<const uint_multiprecision_t>{tmp_double.data(), s});
     BEMAN_BIG_INT_DEBUG_ASSERT(!s2_carry);
     // b_buf <- |b - 4*d| with sign.
     const auto sub_d2 =
@@ -45,8 +44,7 @@ static subsystem_signs solve_subsystem(const std::span<uint_multiprecision_t> a_
     s = shift_left_n(tmp_double, s, 4u);
 
     // e_buf <- c + 16*e = S_4.
-    const bool s4_carry =
-        add_unsigned_spans(e_buf, c_v, std::span<const uint_multiprecision_t>{tmp_double.data(), s});
+    const bool s4_carry = add_unsigned_spans(e_buf, c_v, std::span<const uint_multiprecision_t>{tmp_double.data(), s});
     BEMAN_BIG_INT_DEBUG_ASSERT(!s4_carry);
     // c_buf <- |c - 16*e| with sign.
     const auto sub_d4 =
@@ -132,8 +130,8 @@ static subsystem_signs solve_subsystem(const std::span<uint_multiprecision_t> a_
     // c_buf now holds |X|; X_signed = 771120 * d_outer; therefore
     // sign of d_outer = sign_X (771120 > 0); magnitude |d_outer| = |X|/771120.
     {
-        const auto rem = divide_unsigned_short(
-            c_buf, std::span<const uint_multiprecision_t>{c_buf}, uint_multiprecision_t{771120});
+        const auto rem =
+            divide_unsigned_short(c_buf, std::span<const uint_multiprecision_t>{c_buf}, uint_multiprecision_t{771120});
         BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
     }
     const bool sign_d_outer = sign_X;
@@ -167,8 +165,8 @@ static subsystem_signs solve_subsystem(const std::span<uint_multiprecision_t> a_
     }
     // Y = 240 * d_inner. Therefore |d_inner| = |Y|/240, sign_d_inner = sign_Y.
     {
-        const auto rem = divide_unsigned_short(
-            b_buf, std::span<const uint_multiprecision_t>{b_buf}, uint_multiprecision_t{240});
+        const auto rem =
+            divide_unsigned_short(b_buf, std::span<const uint_multiprecision_t>{b_buf}, uint_multiprecision_t{240});
         BEMAN_BIG_INT_DEBUG_ASSERT(rem == 0);
     }
     const bool sign_d_inner = sign_Y;
@@ -684,7 +682,6 @@ void multiply_toom_cook_6_5(const std::span<uint_multiprecision_t>       result,
     // Finally recover c2,c10 (or c1,c9) and c4,c8 (or c3,c7) using sign-aware
     // half-sum-and-difference in v2/vh and v4/vq respectively. --
 
-
     // Solve even subsystem in {v1, v2, v4, vh, vq}.
     const auto [sign_d_outer_e, sign_d_inner_e] = solve_subsystem(v1, v2, v4, vh, vq, tmp_double);
     // Now:  v1 = c6;  vh = c4+c8;  vq = c2+c10;  v4 = |c2 - c10|, sign_d_outer_e;  v2 = |c4 - c8|, sign_d_inner_e.
@@ -845,12 +842,11 @@ void square_toom_cook_6_5(const std::span<uint_multiprecision_t>       result,
     // interpolation uses the non-negative arms of the general kernel. ----
     tmpa_size = add_many_into_tmp(tmpa, {a0, a2, a4});
     // Use vm1 (currently unused) as scratch for (a1+a3+a5).
-    aux_size = add_many_into_tmp(vm1, {a1, a3, a5});
-    const auto sub_m1 =
-        subtract_unsigned_spans_signed(tmpa,
-                                       std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
-                                       std::span<const uint_multiprecision_t>{vm1.data(), aux_size});
-    tmpa_size = sub_m1.size;
+    aux_size          = add_many_into_tmp(vm1, {a1, a3, a5});
+    const auto sub_m1 = subtract_unsigned_spans_signed(tmpa,
+                                                       std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                                                       std::span<const uint_multiprecision_t>{vm1.data(), aux_size});
+    tmpa_size         = sub_m1.size;
 
     std::ranges::fill(vm1, uint_multiprecision_t{0});
     if (tmpa_size != 0) {
@@ -866,13 +862,12 @@ void square_toom_cook_6_5(const std::span<uint_multiprecision_t>       result,
     // ---- Evaluate at x = -2: tmpa = |(a0+4a2+16a4) - (2a1+8a3+32a5)|. ----
     tmpa_size = horner_eval_into_tmp(tmpa, {a4, a2, a0}, 2u);
     // negative part 2a1+8a3+32a5 into vm2 (currently unused).
-    aux_size = horner_eval_into_tmp(vm2, {a5, a3, a1}, 2u);
-    aux_size = shift_left_one(vm2, aux_size);
-    const auto sub_m2 =
-        subtract_unsigned_spans_signed(tmpa,
-                                       std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
-                                       std::span<const uint_multiprecision_t>{vm2.data(), aux_size});
-    tmpa_size = sub_m2.size;
+    aux_size          = horner_eval_into_tmp(vm2, {a5, a3, a1}, 2u);
+    aux_size          = shift_left_one(vm2, aux_size);
+    const auto sub_m2 = subtract_unsigned_spans_signed(tmpa,
+                                                       std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                                                       std::span<const uint_multiprecision_t>{vm2.data(), aux_size});
+    tmpa_size         = sub_m2.size;
 
     std::ranges::fill(vm2, uint_multiprecision_t{0});
     if (tmpa_size != 0) {
@@ -888,13 +883,12 @@ void square_toom_cook_6_5(const std::span<uint_multiprecision_t>       result,
     // ---- Evaluate at x = -4: tmpa = |(a0+16a2+256a4) - (4a1+64a3+1024a5)|. ----
     tmpa_size = horner_eval_into_tmp(tmpa, {a4, a2, a0}, 4u);
     // negative part 4a1+64a3+1024a5 into vm4.
-    aux_size = horner_eval_into_tmp(vm4, {a5, a3, a1}, 4u);
-    aux_size = shift_left_n(vm4, aux_size, 2u);
-    const auto sub_m4 =
-        subtract_unsigned_spans_signed(tmpa,
-                                       std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
-                                       std::span<const uint_multiprecision_t>{vm4.data(), aux_size});
-    tmpa_size = sub_m4.size;
+    aux_size          = horner_eval_into_tmp(vm4, {a5, a3, a1}, 4u);
+    aux_size          = shift_left_n(vm4, aux_size, 2u);
+    const auto sub_m4 = subtract_unsigned_spans_signed(tmpa,
+                                                       std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                                                       std::span<const uint_multiprecision_t>{vm4.data(), aux_size});
+    tmpa_size         = sub_m4.size;
 
     std::ranges::fill(vm4, uint_multiprecision_t{0});
     if (tmpa_size != 0) {
@@ -919,12 +913,11 @@ void square_toom_cook_6_5(const std::span<uint_multiprecision_t>       result,
     tmpa_size = horner_eval_into_tmp(tmpa, {a0, a2, a4}, 2u);
     tmpa_size = shift_left_one(tmpa, tmpa_size);
     // negative part 16a1+4a3+a5 into vmh.
-    aux_size = horner_eval_into_tmp(vmh, {a1, a3, a5}, 2u);
-    const auto sub_mh =
-        subtract_unsigned_spans_signed(tmpa,
-                                       std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
-                                       std::span<const uint_multiprecision_t>{vmh.data(), aux_size});
-    tmpa_size = sub_mh.size;
+    aux_size          = horner_eval_into_tmp(vmh, {a1, a3, a5}, 2u);
+    const auto sub_mh = subtract_unsigned_spans_signed(tmpa,
+                                                       std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                                                       std::span<const uint_multiprecision_t>{vmh.data(), aux_size});
+    tmpa_size         = sub_mh.size;
 
     std::ranges::fill(vmh, uint_multiprecision_t{0});
     if (tmpa_size != 0) {
@@ -950,12 +943,11 @@ void square_toom_cook_6_5(const std::span<uint_multiprecision_t>       result,
     tmpa_size = horner_eval_into_tmp(tmpa, {a0, a2, a4}, 4u);
     tmpa_size = shift_left_n(tmpa, tmpa_size, 2u);
     // negative part 256a1+16a3+a5 into vmq.
-    aux_size = horner_eval_into_tmp(vmq, {a1, a3, a5}, 4u);
-    const auto sub_mq =
-        subtract_unsigned_spans_signed(tmpa,
-                                       std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
-                                       std::span<const uint_multiprecision_t>{vmq.data(), aux_size});
-    tmpa_size = sub_mq.size;
+    aux_size          = horner_eval_into_tmp(vmq, {a1, a3, a5}, 4u);
+    const auto sub_mq = subtract_unsigned_spans_signed(tmpa,
+                                                       std::span<const uint_multiprecision_t>{tmpa.data(), tmpa_size},
+                                                       std::span<const uint_multiprecision_t>{vmq.data(), aux_size});
+    tmpa_size         = sub_mq.size;
 
     std::ranges::fill(vmq, uint_multiprecision_t{0});
     if (tmpa_size != 0) {

--- a/tests/beman/big_int/multiplication.test.cpp
+++ b/tests/beman/big_int/multiplication.test.cpp
@@ -4,6 +4,7 @@
 #include <bit>
 #include <cstdint>
 #include <limits>
+#include <random>
 #include <string>
 #include <system_error>
 
@@ -77,6 +78,14 @@ consteval bool ce_power_of_two_multi_limb() {
     return (a * b) == (big_int{1} << 5200) && (c * c) == (big_int{1} << 260);
 }
 static_assert(ce_power_of_two_multi_limb());
+
+consteval bool ce_squaring_multi_limb() {
+    // Same-object multiplication takes the consteval squaring path; verify
+    // against the closed form (2^N - 5)^2 = 2^(2N) - 5*2^(N+1) + 25.
+    const big_int x = (big_int{1} << 1024) - 5;
+    return x * x == (big_int{1} << 2048) - (big_int{5} << 1025) + 25;
+}
+static_assert(ce_squaring_multi_limb());
 
 // ----- runtime tests -----
 
@@ -403,6 +412,50 @@ TEST(Multiplication, PowerOfTwoLargeOperands) {
     const big_int  p2    = big_int{1} << k;
     EXPECT_EQ(dense * p2, dense << k);
     EXPECT_EQ(p2 * p2, big_int{1} << (2U * k));
+}
+
+TEST(Multiplication, SquaringClosedForm) {
+    // (2^N - 1)^2 = 2^(2N) - 2^(N+1) + 1, with N spanning every squaring tier
+    // up to square_toom_cook_6_5.
+    for (const unsigned n : {640U, 6400U, 64000U, 320000U, 3840000U}) {
+        const big_int x        = (big_int{1} << n) - 1;
+        const big_int expected = (big_int{1} << (2U * n)) - (big_int{1} << (n + 1U)) + 1;
+        EXPECT_EQ(x * x, expected) << "n=" << n;
+    }
+}
+
+TEST(Multiplication, SquaringRandomDifferential) {
+    // x * x passes the same span twice and takes the squaring path; x * copy
+    // goes through the general kernels. Random values exercise the
+    // sign-dependent evaluation branches at every dispatch tier.
+    std::mt19937_64                    rng{0x5EEDU};
+    std::uniform_int_distribution<int> pick{0, 15};
+    constexpr const char*              digits = "0123456789abcdef";
+    for (const std::size_t hex_len : {48UL, 112UL, 160UL, 480UL, 1024UL, 3100UL, 25000UL, 90000UL, 200000UL, 800000UL}) {
+        std::string s(hex_len, '0');
+        for (auto& ch : s) {
+            ch = digits[pick(rng)];
+        }
+        s.front() = 'f'; // keep the top limb significant
+
+        big_int x;
+        const auto [p, ec] = from_chars(s.data(), s.data() + s.size(), x, 16);
+        ASSERT_EQ(ec, std::errc{});
+        ASSERT_EQ(p, s.data() + s.size());
+
+        const big_int x_copy = x;
+        EXPECT_EQ(x * x, x * x_copy) << "hex_len=" << hex_len;
+        EXPECT_EQ((-x) * (-x), x * x_copy) << "hex_len=" << hex_len;
+    }
+}
+
+TEST(Multiplication, CompoundSelfSquaring) {
+    // y *= y routes through the same operand-identity detection.
+    big_int       y  = (big_int{1} << 1000) - 12345;
+    const big_int x  = y;
+    const big_int xc = y;
+    y *= y;
+    EXPECT_EQ(y, x * xc);
 }
 
 TEST(Multiplication, Mersenne) {

--- a/tests/beman/big_int/multiplication.test.cpp
+++ b/tests/beman/big_int/multiplication.test.cpp
@@ -431,7 +431,8 @@ TEST(Multiplication, SquaringRandomDifferential) {
     std::mt19937_64                    rng{0x5EEDU};
     std::uniform_int_distribution<int> pick{0, 15};
     constexpr const char*              digits = "0123456789abcdef";
-    for (const std::size_t hex_len : {48UL, 112UL, 160UL, 480UL, 1024UL, 3100UL, 25000UL, 90000UL, 200000UL, 800000UL}) {
+    for (const std::size_t hex_len :
+         {48UL, 112UL, 160UL, 480UL, 1024UL, 3100UL, 25000UL, 90000UL, 200000UL, 800000UL}) {
         std::string s(hex_len, '0');
         for (auto& ch : s) {
             ch = digits[pick(rng)];

--- a/tests/beman/big_int/multiplication_stress_bench.test.cpp
+++ b/tests/beman/big_int/multiplication_stress_bench.test.cpp
@@ -115,7 +115,10 @@ double run_karatsuba_at(const std::size_t limbs, const unsigned trials) {
                                 const std::span<const uint_t> a,
                                 const std::span<const uint_t> b,
                                 scratch_for_test&             s) {
-                                 ::beman::big_int::detail::multiply_karatsuba(r.first(a.size() + b.size()), a, b, s);
+                                 // cutoff_override=1 forces a Karatsuba split at any splittable size;
+                                 // recursive sub-products use the production fallback.
+                                 ::beman::big_int::detail::multiply_karatsuba(
+                                     r.first(a.size() + b.size()), a, b, s, std::size_t{1});
                              });
 }
 
@@ -127,7 +130,10 @@ double run_toom_cook_3_at(const std::size_t limbs, const unsigned trials) {
                                 const std::span<const uint_t> a,
                                 const std::span<const uint_t> b,
                                 scratch_for_test&             s) {
-                                 ::beman::big_int::detail::multiply_toom_cook_3(r.first(a.size() + b.size()), a, b, s);
+                                 // cutoff_override=1 forces the Toom-3 split; recursive sub-products
+                                 // fall back to Karatsuba/schoolbook at the production cutoffs.
+                                 ::beman::big_int::detail::multiply_toom_cook_3(
+                                     r.first(a.size() + b.size()), a, b, s, std::size_t{1});
                              });
 }
 

--- a/tests/beman/big_int/multiplication_stress_bench.test.cpp
+++ b/tests/beman/big_int/multiplication_stress_bench.test.cpp
@@ -164,6 +164,80 @@ double run_toom_cook_6_5_at(const std::size_t limbs, const unsigned trials) {
                              });
 }
 
+// Squaring runners: `b` is ignored, the algorithm squares `a`. The harness
+// zero-fills the result before every call, satisfying square_long's pre-zero
+// requirement.
+
+double run_square_long_at(const std::size_t limbs, const unsigned trials) {
+    return measure_algorithm(limbs,
+                             trials,
+                             /*scratch_size=*/0,
+                             [](const std::span<uint_t> r,
+                                const std::span<const uint_t> a,
+                                const std::span<const uint_t>,
+                                scratch_for_test&) { ::beman::big_int::detail::square_long(r.first(2 * a.size()), a); });
+}
+
+double run_square_karatsuba_at(const std::size_t limbs, const unsigned trials) {
+    // cutoff_override=1 forces at least one Karatsuba splitting level; recursive
+    // sub-squares use the default cutoff, as in production.
+    return measure_algorithm(limbs,
+                             trials,
+                             ::beman::big_int::detail::karatsuba_storage_size(limbs),
+                             [](const std::span<uint_t> r,
+                                const std::span<const uint_t> a,
+                                const std::span<const uint_t>,
+                                scratch_for_test& s) {
+                                 ::beman::big_int::detail::square_karatsuba(
+                                     r.first(2 * a.size()), a, s, std::size_t{1});
+                             });
+}
+
+double run_square_toom_cook_3_at(const std::size_t limbs, const unsigned trials) {
+    // cutoff_override=1 forces the Toom-3 squaring level; recursive sub-squares
+    // use the default cutoffs, as in production.
+    return measure_algorithm(limbs,
+                             trials,
+                             ::beman::big_int::detail::toom_cook_3_storage_size(limbs),
+                             [](const std::span<uint_t> r,
+                                const std::span<const uint_t> a,
+                                const std::span<const uint_t>,
+                                scratch_for_test& s) {
+                                 ::beman::big_int::detail::square_toom_cook_3(
+                                     r.first(2 * a.size()), a, s, std::size_t{1});
+                             });
+}
+
+double run_square_toom_cook_4_at(const std::size_t limbs, const unsigned trials) {
+    // cutoff_override=1 forces the Toom-4 squaring level; recursive sub-squares
+    // use the default cutoffs, as in production.
+    return measure_algorithm(limbs,
+                             trials,
+                             ::beman::big_int::detail::toom_cook_4_storage_size(limbs),
+                             [](const std::span<uint_t> r,
+                                const std::span<const uint_t> a,
+                                const std::span<const uint_t>,
+                                scratch_for_test& s) {
+                                 ::beman::big_int::detail::square_toom_cook_4(
+                                     r.first(2 * a.size()), a, s, std::size_t{1});
+                             });
+}
+
+double run_square_toom_cook_6_5_at(const std::size_t limbs, const unsigned trials) {
+    // cutoff_override=1 forces the Toom-6.5 squaring level; recursive sub-squares
+    // use the default cutoffs, as in production.
+    return measure_algorithm(limbs,
+                             trials,
+                             ::beman::big_int::detail::toom_cook_6_5_storage_size(limbs),
+                             [](const std::span<uint_t> r,
+                                const std::span<const uint_t> a,
+                                const std::span<const uint_t>,
+                                scratch_for_test& s) {
+                                 ::beman::big_int::detail::square_toom_cook_6_5(
+                                     r.first(2 * a.size()), a, s, std::size_t{1});
+                             });
+}
+
 // Registry of algorithms to sweep. Each entry constrains the sweep to a
 // reasonable range: too small and the algorithm's own internal cutoff just
 // falls back to the previous tier; too large and a single multiplication
@@ -181,6 +255,11 @@ constexpr algorithm_runner algorithms[] = {
     {"toom-cook-3", 300, 10000, run_toom_cook_3_at},
     {"toom-cook-4", 300, 30000, run_toom_cook_4_at},
     {"toom-cook-6.5", 1000, 80000, run_toom_cook_6_5_at},
+    {"square-long", 4, 400, run_square_long_at},
+    {"square-karatsuba", 32, 2000, run_square_karatsuba_at},
+    {"square-toom-cook-3", 200, 10000, run_square_toom_cook_3_at},
+    {"square-toom-cook-4", 300, 30000, run_square_toom_cook_4_at},
+    {"square-toom-cook-6.5", 1000, 80000, run_square_toom_cook_6_5_at},
 };
 
 // Limb counts to sample. Dense coverage at the low end for the

--- a/tests/beman/big_int/multiplication_stress_bench.test.cpp
+++ b/tests/beman/big_int/multiplication_stress_bench.test.cpp
@@ -169,13 +169,14 @@ double run_toom_cook_6_5_at(const std::size_t limbs, const unsigned trials) {
 // requirement.
 
 double run_square_long_at(const std::size_t limbs, const unsigned trials) {
-    return measure_algorithm(limbs,
-                             trials,
-                             /*scratch_size=*/0,
-                             [](const std::span<uint_t> r,
-                                const std::span<const uint_t> a,
-                                const std::span<const uint_t>,
-                                scratch_for_test&) { ::beman::big_int::detail::square_long(r.first(2 * a.size()), a); });
+    return measure_algorithm(
+        limbs,
+        trials,
+        /*scratch_size=*/0,
+        [](const std::span<uint_t>       r,
+           const std::span<const uint_t> a,
+           const std::span<const uint_t>,
+           scratch_for_test&) { ::beman::big_int::detail::square_long(r.first(2 * a.size()), a); });
 }
 
 double run_square_karatsuba_at(const std::size_t limbs, const unsigned trials) {
@@ -184,7 +185,7 @@ double run_square_karatsuba_at(const std::size_t limbs, const unsigned trials) {
     return measure_algorithm(limbs,
                              trials,
                              ::beman::big_int::detail::karatsuba_storage_size(limbs),
-                             [](const std::span<uint_t> r,
+                             [](const std::span<uint_t>       r,
                                 const std::span<const uint_t> a,
                                 const std::span<const uint_t>,
                                 scratch_for_test& s) {
@@ -199,7 +200,7 @@ double run_square_toom_cook_3_at(const std::size_t limbs, const unsigned trials)
     return measure_algorithm(limbs,
                              trials,
                              ::beman::big_int::detail::toom_cook_3_storage_size(limbs),
-                             [](const std::span<uint_t> r,
+                             [](const std::span<uint_t>       r,
                                 const std::span<const uint_t> a,
                                 const std::span<const uint_t>,
                                 scratch_for_test& s) {
@@ -214,7 +215,7 @@ double run_square_toom_cook_4_at(const std::size_t limbs, const unsigned trials)
     return measure_algorithm(limbs,
                              trials,
                              ::beman::big_int::detail::toom_cook_4_storage_size(limbs),
-                             [](const std::span<uint_t> r,
+                             [](const std::span<uint_t>       r,
                                 const std::span<const uint_t> a,
                                 const std::span<const uint_t>,
                                 scratch_for_test& s) {
@@ -229,7 +230,7 @@ double run_square_toom_cook_6_5_at(const std::size_t limbs, const unsigned trial
     return measure_algorithm(limbs,
                              trials,
                              ::beman::big_int::detail::toom_cook_6_5_storage_size(limbs),
-                             [](const std::span<uint_t> r,
+                             [](const std::span<uint_t>       r,
                                 const std::span<const uint_t> a,
                                 const std::span<const uint_t>,
                                 scratch_for_test& s) {


### PR DESCRIPTION
Adds a special case of each algorithm for the squaring case which we detect via a check to pointer and size. Provides a pretty uniform ~1.3x speedup for each algorithm for this case. The pointer and size check is sufficiently cheap, and should fail early on pointer compare, that it does not harm the base case of two separate values. 

CC: @ckormanyos 