### PR TITLE
Update perf docs and add division bench

### DIFF
--- a/tests/beman/big_int/perf/README.md
+++ b/tests/beman/big_int/perf/README.md
@@ -23,10 +23,18 @@ The code for this comparison can be found in [./elliptic_ecc.perf.cpp](./ellipti
 
 ## Multiplication
 
+Multiplication graduates to successively _higher_ algorithms as the limb count grows.
+For small limb counts under $48$ limbs, we use schoolbook multiplication.
+Above $48$ limbs. the library crosses over to Karatsuba multiplication.
+Successive Toom-Cook orders of $3$, $4$, $6.5$ and $8.5$ cross over
+at $400$, $1,600$, $2,400$ and $15,000$ limbs, respectively for the non-SIMD path.
+FFT multiplication crosses over at $24,000$ limbs for the non-SIMD path
+and $4,500$ limbs for the SIMD path, thereby not using Toom-Cook $8.5$ in
+the SIMD path at all. See the "Optional: SIMD-accelerated multiplication"
+note in the top-level README.
+
 When measuring, localize the time of `big_int` multiplication only, running a chrono
 stopwatch just before and after the multiplication operation, summing and averaging the times.
-
-TODO: Follow the evolution of high-order multiplication and add relevant content accordingly.
 
 Various runs use limb counts to emphasize crossover points such as the limb-cutoff
 where Karatsuba --> Toom-Cook. Additional runs use higher limb counts, landing directly
@@ -51,6 +59,7 @@ Karatsuba + Toom-Cook 3, and so forth.
 | 43,000-45,000  | 2,752,000-2,880,000  |   ---                |  ---                     |  ---                  |  72,300us per mul |  59,700us per mul   |
 
 #### Toom-Cook 3 computational complexity
+
 From the final two Toom-Cook 3 points, we seek the order of complexity, $x$
 
 $$
@@ -102,12 +111,13 @@ across all orders of limb count.
 
 ![](./crossover_main.png)
 
-### Compare multiplication timing `beman.big_int`, `boost.gmp_int`, `boost.cpp_int`
+### Compare multiplication timing `beman.big_int`, `boost.cpp_int`, `boost.gmp_int`
 
-Detailed measurements (with a table) comparing the multiplication performance
-of `big_int` with those of `boost.cpp_int` and GMP (wrapped by `boost.gmp_int`) are presented.
-The result of multiplication adds the widths of its operands. So multiplying
-two big integers produces a result having double the width of its operands.
+Detailed measurements comparing the multiplication performance of `big_int`
+with those of `boost.cpp_int` and GMP (wrapped by `boost.gmp_int`) are presented
+in the table below. The result of multiplication adds the widths of its operands.
+So multiplying two big integers produces a result having double the width
+of its operands.
 
 The time and the relative time compared with the best (GMP) time (in square
 brackets) are shown for each big-integer type at each width. These were measured
@@ -136,16 +146,55 @@ to reproduce a row.
 
 (1) `beman.big_int` now has FFT multiplication (a small-prime NTT, vectorized via
 the optional SIMD path). Earlier it topped out at Toom-Cook, so `gmp_int` pulled
-far ahead at very high digit counts (about 5.3x at 131,072 limbs); the FFT brings
-that back to about 2.7x, tracking GMP's asymptotic complexity.
+far ahead at very high digit counts (about $5.3x$ at $131,072$ limbs); the FFT brings
+that back to about $2.7x$, tracking GMP's asymptotic complexity.
 
 (2) `cpp_int` only reaches _as_ _high_ as Karatsuba multiplication, so both
 `big_int` and `gmp_int` pull ahead at medium-high digit counts -- `big_int`'s lead
-over `cpp_int` grows to roughly 6x by 131,072 limbs.
+over `cpp_int` grows to roughly $6x$ by $131,072$ limbs.
 
 ## Division
 
-TODO: Follow the progress of sub-quadratic division.
+Division uses a combination of Knuth long division for small limb counts
+and crosses over to the Burnikel-Ziegler algorithm somewhere between $40$ and $100$ limbs.
+The performance of division relies predominantly on the speed of the underlying
+multiplication algorithms as the limb count grows.
+
+### Compare division timing `beman.big_int`, `boost.cpp_int`, `boost.gmp_int`
+
+Detailed measurements comparing the division performance of `big_int`
+with those of `boost.cpp_int` and GMP (wrapped by `boost.gmp_int`) are presented
+in the table below. The division is setup to divide an $N$-digit numerator
+by an $N/2$-digit denominator, producing an $N/2$-digit integer result.
+
+When measuring, localize the time of `big_int` division only, running a chrono
+stopwatch just before and after the multiplication operation, summing and averaging the times.
+
+The time and the relative time compared with the best (GMP) time (in square
+brackets) are shown for each big-integer type at each width. These were measured
+on an x86-64 machine with the SIMD multiplication path enabled (configured with
+`-DBEMAN_BIG_INT_SIMD_MUL=ON`, so the FFT tier uses the AVX2 kernel); see the
+"Optional: SIMD-accelerated multiplication" note in the top-level README.
+The performance of the underlying multiplication is propagated to division.
+
+| 64-bit limbs   | bit width    | approx base-10 digits | us per div  `big_int`  | us per div  `cpp_int`  | us per div  `gmp_int` |
+|----------------|--------------|-----------------------|------------------------|------------------------|-----------------------|
+| 128            | 8,192        | 2,500                 |   4.2   [2.5]          |  10.4   [6.1]          |   1.7   [1.0]         |
+| 512            | 32,768       | 9,900                 |   32    [1.7]          |  120    [6.7]          |   18    [1.0]         |
+| 1,024          | 65,536       | 20,000                |   120   [2.3]          |   420   [7.9]          |   53    [1.0]         |
+| 2,048          | 131,072      | 39,000                |   360   [3.0]          |  1,500  [13], see (1)  |   120   [1.0]         |
+| 8,192          | 524,288      | 160,000               |   2,800 [2.9]          |  23,000 [24]           |   950   [1.0]         |
+| 32,768         | 2,097,152    | 631,000               |  23,000 [3.8]          | 370,000 [62]           |   6,000 [1.0]         |
+
+The code used for this comparison can be
+found in [div_big_int_vs_gmp_cpp.perf.cpp](./div_big_int_vs_gmp_cpp.perf.cpp);
+pass an operand width in limbs (and optionally a trial count) on the command line
+to reproduce a row.
+
+(1) `cpp_int` uses a variation of Knuth long division for all limb counts.
+This algorithm has quadratic complexity . `big_int` and `gmp_int` pull ahead
+rapidly at medium-high digit counts -- `big_int`'s lead
+over `cpp_int` grows to roughly $8x$ by $8,192$ limbs.
 
 ## Base-conversion
 

--- a/tests/beman/big_int/perf/div_big_int_vs_gmp_cpp.perf.cpp
+++ b/tests/beman/big_int/perf/div_big_int_vs_gmp_cpp.perf.cpp
@@ -1,6 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-License-Identifier: BSL-1.0
 
+// cd /mnt/c/Users/ckorm/Documents/Ks/PC_Software/NumericalPrograms/ExtendedNumberTypes/std-big-int/VS
+
+// Build on Ubuntu x86_64 using SIMD.
+// g++-13 -march=native -std=c++23 -O3 -Wall -Wextra -Wpedantic -I../include -I/mnt/c/boost/boost_1_90_0 -DBEMAN_BIG_INT_SIMD_MUL ./test.cpp ../src/divide.cpp ../src/fft_mul_fp.cpp ../src/karatsuba.cpp ../src/mulmod_bnm1.cpp ../src/mul_dispatch.cpp ../src/ntt.cpp ../src/ntt_fp_avx2.cpp ../src/ntt_fp_dispatch.cpp ../src/ntt_fp_scalar.cpp ../src/toom_cook_3.cpp ../src/toom_cook_4.cpp ../src/toom_cook_6_5.cpp ../src/toom_cook_8_5.cpp -lgmp -o test.exe
+
+// Build on Ubuntu x86_64 *without* SIMD.
+// g++-13 -march=native -std=c++23 -O3 -Wall -Wextra -Wpedantic -I../include -I/mnt/c/boost/boost_1_90_0 ./test.cpp ../src/divide.cpp ../src/fft_mul.cpp ../src/karatsuba.cpp ../src/mulmod_bnm1.cpp ../src/mul_dispatch.cpp ../src/ntt.cpp ../src/toom_cook_3.cpp ../src/toom_cook_4.cpp ../src/toom_cook_6_5.cpp ../src/toom_cook_8_5.cpp -lgmp -o test.exe
+
 #include <beman/big_int/big_int.hpp>
 #include <boost/multiprecision/gmp.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
@@ -82,7 +90,7 @@ auto get_hex_string_pair(const unsigned len_in_bits) -> std::pair<std::string, s
 
 auto get_hex_string_pair(const unsigned len_in_bits) -> std::pair<std::string, std::string> {
     const std::string str_a{bmp::random_big_int(len_in_bits)};
-    const std::string str_b{bmp::random_big_int(len_in_bits)};
+    const std::string str_b{bmp::random_big_int(len_in_bits / 2)};
 
     return {str_a, str_b};
 }
@@ -125,9 +133,9 @@ auto main(int argc, char** argv) -> int {
                                              : static_cast<std::uint32_t>(UINT32_C(0x4000))};
     auto                trial = static_cast<std::uint32_t>(UINT32_C(0));
 
-    std::uint64_t elapsed_total_muls_bn{};
-    std::uint64_t elapsed_total_muls_gm{};
-    std::uint64_t elapsed_total_muls_cp{};
+    std::uint64_t elapsed_total_divs_bn{};
+    std::uint64_t elapsed_total_divs_gm{};
+    std::uint64_t elapsed_total_divs_cp{};
 
     const unsigned length_in_bits{limbs * limb_bits};
 
@@ -156,73 +164,73 @@ auto main(int argc, char** argv) -> int {
         {
             const auto start{std::chrono::high_resolution_clock::now()};
 
-            const local::big_int mul_result = bn_a * bn_b;
+            const local::big_int mul_result = bn_a / bn_b;
 
             const auto stop{std::chrono::high_resolution_clock::now()};
 
-            const auto elapsed_one_mul{std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start).count()};
+            const auto elapsed_one_div{std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start).count()};
 
-            elapsed_total_muls_bn = elapsed_total_muls_bn + static_cast<std::uint64_t>(elapsed_one_mul);
+            elapsed_total_divs_bn = elapsed_total_divs_bn + static_cast<std::uint64_t>(elapsed_one_div);
         }
 
         {
             const auto start{std::chrono::high_resolution_clock::now()};
 
-            const local::cpp_int mul_result = cp_a * cp_b;
+            const local::cpp_int mul_result = cp_a / cp_b;
 
             const auto stop{std::chrono::high_resolution_clock::now()};
 
-            const auto elapsed_one_mul{std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start).count()};
+            const auto elapsed_one_div{std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start).count()};
 
-            elapsed_total_muls_cp = elapsed_total_muls_cp + static_cast<std::uint64_t>(elapsed_one_mul);
+            elapsed_total_divs_cp = elapsed_total_divs_cp + static_cast<std::uint64_t>(elapsed_one_div);
         }
 
         {
             const auto start{std::chrono::high_resolution_clock::now()};
 
-            const local::gmp_int mul_result = gm_a * gm_b;
+            const local::gmp_int mul_result = gm_a / gm_b;
 
             const auto stop{std::chrono::high_resolution_clock::now()};
 
-            const auto elapsed_one_mul{std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start).count()};
+            const auto elapsed_one_div{std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start).count()};
 
-            elapsed_total_muls_gm = elapsed_total_muls_gm + static_cast<std::uint64_t>(elapsed_one_mul);
+            elapsed_total_divs_gm = elapsed_total_divs_gm + static_cast<std::uint64_t>(elapsed_one_div);
         }
 
         {
             if ((trial > 0U) && ((trial % 32U) == UINT32_C(0))) {
-                const double average_mul_time_us_bn =
-                    (static_cast<double>(elapsed_total_muls_bn) / static_cast<double>(trial)) / 1000.0;
+                const double average_div_time_us_bn =
+                    (static_cast<double>(elapsed_total_divs_bn) / static_cast<double>(trial)) / 1000.0;
 
                 {
                     std::stringstream strm{};
 
-                    strm << "trial: " << trial << ", average_mul_time_us_bn: " << std::setprecision(1) << std::fixed
-                         << average_mul_time_us_bn;
+                    strm << "trial: " << trial << ", average_div_time_us_bn: " << std::setprecision(1) << std::fixed
+                         << average_div_time_us_bn;
 
                     std::cout << strm.str() << std::endl;
                 }
 
-                const double average_mul_time_us_cp =
-                    (static_cast<double>(elapsed_total_muls_cp) / static_cast<double>(trial)) / 1000.0;
+                const double average_div_time_us_cp =
+                    (static_cast<double>(elapsed_total_divs_cp) / static_cast<double>(trial)) / 1000.0;
 
                 {
                     std::stringstream strm{};
 
-                    strm << "trial: " << trial << ", average_mul_time_us_cp: " << std::setprecision(1) << std::fixed
-                         << average_mul_time_us_cp;
+                    strm << "trial: " << trial << ", average_div_time_us_cp: " << std::setprecision(1) << std::fixed
+                         << average_div_time_us_cp;
 
                     std::cout << strm.str() << std::endl;
                 }
 
-                const double average_mul_time_us_gm =
-                    (static_cast<double>(elapsed_total_muls_gm) / static_cast<double>(trial)) / 1000.0;
+                const double average_div_time_us_gm =
+                    (static_cast<double>(elapsed_total_divs_gm) / static_cast<double>(trial)) / 1000.0;
 
                 {
                     std::stringstream strm{};
 
-                    strm << "trial: " << trial << ", average_mul_time_us_gm: " << std::setprecision(1) << std::fixed
-                         << average_mul_time_us_gm;
+                    strm << "trial: " << trial << ", average_div_time_us_gm: " << std::setprecision(1) << std::fixed
+                         << average_div_time_us_gm;
 
                     std::cout << strm.str() << std::endl;
                 }
@@ -233,9 +241,9 @@ auto main(int argc, char** argv) -> int {
     result_total_is_ok = ((trial == max_trial) && result_total_is_ok);
 
     {
-        const double avg_bn = (trial != 0U ? static_cast<double>(elapsed_total_muls_bn) / trial : 0.0) / 1000.0;
-        const double avg_gm = (trial != 0U ? static_cast<double>(elapsed_total_muls_gm) / trial : 0.0) / 1000.0;
-        const double avg_cp = (trial != 0U ? static_cast<double>(elapsed_total_muls_cp) / trial : 0.0) / 1000.0;
+        const double avg_bn = (trial != 0U ? static_cast<double>(elapsed_total_divs_bn) / trial : 0.0) / 1000.0;
+        const double avg_gm = (trial != 0U ? static_cast<double>(elapsed_total_divs_gm) / trial : 0.0) / 1000.0;
+        const double avg_cp = (trial != 0U ? static_cast<double>(elapsed_total_divs_cp) / trial : 0.0) / 1000.0;
 
         std::stringstream strm;
 
@@ -243,10 +251,12 @@ auto main(int argc, char** argv) -> int {
         strm << "Summary                            : " << trial << " trial, " << limbs << " limbs" << '\n';
         strm << "result_total_is_ok                 : " << std::boolalpha << result_total_is_ok << '\n';
         strm << std::fixed << std::setprecision(1);
-        strm << "us per mul big_int / cpp_int / gmp : " << avg_bn << " / " << avg_cp << " / " << avg_gm << '\n';
+        strm << "us per div big_int / cpp_int / gmp : " << avg_bn << " / " << avg_cp << " / " << avg_gm << '\n';
 
         std::cout << strm.str() << std::endl;
     }
+
+    std::cout << "total trials: " << trial << std::endl;
 
     return (result_total_is_ok ? 0 : -1);
 }

--- a/tests/beman/big_int/perf/div_big_int_vs_gmp_cpp.perf.cpp
+++ b/tests/beman/big_int/perf/div_big_int_vs_gmp_cpp.perf.cpp
@@ -1,14 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-License-Identifier: BSL-1.0
 
-// cd /mnt/c/Users/ckorm/Documents/Ks/PC_Software/NumericalPrograms/ExtendedNumberTypes/std-big-int/VS
-
-// Build on Ubuntu x86_64 using SIMD.
-// g++-13 -march=native -std=c++23 -O3 -Wall -Wextra -Wpedantic -I../include -I/mnt/c/boost/boost_1_90_0 -DBEMAN_BIG_INT_SIMD_MUL ./test.cpp ../src/divide.cpp ../src/fft_mul_fp.cpp ../src/karatsuba.cpp ../src/mulmod_bnm1.cpp ../src/mul_dispatch.cpp ../src/ntt.cpp ../src/ntt_fp_avx2.cpp ../src/ntt_fp_dispatch.cpp ../src/ntt_fp_scalar.cpp ../src/toom_cook_3.cpp ../src/toom_cook_4.cpp ../src/toom_cook_6_5.cpp ../src/toom_cook_8_5.cpp -lgmp -o test.exe
-
-// Build on Ubuntu x86_64 *without* SIMD.
-// g++-13 -march=native -std=c++23 -O3 -Wall -Wextra -Wpedantic -I../include -I/mnt/c/boost/boost_1_90_0 ./test.cpp ../src/divide.cpp ../src/fft_mul.cpp ../src/karatsuba.cpp ../src/mulmod_bnm1.cpp ../src/mul_dispatch.cpp ../src/ntt.cpp ../src/toom_cook_3.cpp ../src/toom_cook_4.cpp ../src/toom_cook_6_5.cpp ../src/toom_cook_8_5.cpp -lgmp -o test.exe
-
 #include <beman/big_int/big_int.hpp>
 #include <boost/multiprecision/gmp.hpp>
 #include <boost/multiprecision/cpp_int.hpp>


### PR DESCRIPTION
Update performance docs for Burnikel-Ziegler division and add a dedicated division benchmark file, similar to the existing one for multiplication.

Cc: @mborland