### PR TITLE
Add additional conceptual requirements for `wider<T>`

### DIFF
--- a/include/beman/big_int/detail/config.hpp
+++ b/include/beman/big_int/detail/config.hpp
@@ -159,6 +159,14 @@ using int128_t  = std::_Signed128;
 using uint128_t = std::_Unsigned128;
 #endif
 
+// True when some 128-bit integer type exists (fundamental or class type).
+// 32-bit targets such as arm-none-eabi typically have none.
+#ifdef BEMAN_BIG_INT_HAS_INT128
+inline constexpr bool has_int128_v = true;
+#else
+inline constexpr bool has_int128_v = false;
+#endif
+
 } // namespace beman::big_int::detail
 
 // Limb type selection =========================================================

--- a/include/beman/big_int/detail/wide_ops.hpp
+++ b/include/beman/big_int/detail/wide_ops.hpp
@@ -14,6 +14,11 @@
 
 namespace beman::big_int::detail {
 
+// Maps an integer type to the integer type of twice its width and the same
+// signedness. SFINAE-friendly: when no such type exists (e.g. 64 -> 128 on a
+// target without any 128-bit integer type), no specialization matches and the
+// primary template is left incomplete, so `requires { typename wider_t<T>; }`
+// is false instead of a hard error.
 template <class T>
 struct wider;
 
@@ -30,16 +35,19 @@ struct wider<uint_multiprecision_t> {
 
 #ifdef BEMAN_BIG_INT_HAS_BITINT
 template <std::size_t N>
+    requires(2 * N <= BEMAN_BIG_INT_BITINT_MAXWIDTH)
 struct wider<bit_int<N>> {
     using type = bit_int<2 * N>;
 };
 template <std::size_t N>
+    requires(2 * N <= BEMAN_BIG_INT_BITINT_MAXWIDTH)
 struct wider<bit_uint<N>> {
     using type = bit_uint<2 * N>;
 };
 #endif
 
 template <signed_integer T>
+    requires(width_v<T> == 8 || width_v<T> == 16 || width_v<T> == 32 || (width_v<T> == 64 && has_int128_v))
 struct wider<T> {
     [[nodiscard]] static consteval auto select() {
         if constexpr (width_v<T> == 8) {
@@ -61,6 +69,7 @@ struct wider<T> {
     using type = decltype(select());
 };
 template <unsigned_integer T>
+    requires(width_v<T> == 8 || width_v<T> == 16 || width_v<T> == 32 || (width_v<T> == 64 && has_int128_v))
 struct wider<T> {
     [[nodiscard]] static consteval auto select() {
         if constexpr (width_v<T> == 8) {
@@ -87,6 +96,12 @@ struct wider<T> {
 template <signed_or_unsigned T>
 using wider_t = typename wider<T>::type;
 
+// Modeled if a doubled-width counterpart of `T` exists. Unlike a bare
+// requires-expression with a concrete type, a concept-id is always checked
+// via substitution, so this is usable with non-dependent arguments.
+template <class T>
+concept has_wider = requires { typename wider_t<T>; };
+
 template <signed_or_unsigned T>
 struct wide {
     T low_bits;
@@ -96,7 +111,7 @@ struct wide {
 };
 
 template <signed_or_unsigned T>
-    requires requires { typename wider_t<T>; }
+    requires has_wider<T>
 struct wide<T> {
     T low_bits;
     T high_bits;
@@ -523,6 +538,32 @@ struct wide_div_result {
     wide<T> remainder;
 };
 
+// Portable bit-by-bit restoring long division of the 2-limb unsigned value `x`
+// by the single limb `y`, for targets where no wider type backs narrowing_div.
+// Precondition: `x.high_bits < y`, so the quotient fits in a single limb.
+template <unsigned_integer T>
+[[nodiscard]] constexpr div_result<T> narrowing_div_portable(const wide<T> x, const T y) noexcept {
+    BEMAN_BIG_INT_DEBUG_ASSERT(x.high_bits < y);
+
+    constexpr std::size_t limb_bits = width_v<T>;
+
+    T q = 0;
+    T r = x.high_bits;
+
+    for (std::size_t i = limb_bits; i-- > 0;) {
+        // The shifted remainder can spill into a virtual top bit; if it does,
+        // it certainly exceeds y, and the truncated subtraction is still exact.
+        const T r_top = static_cast<T>(r >> (limb_bits - 1));
+        r             = static_cast<T>((r << 1) | ((x.low_bits >> i) & T{1}));
+        q <<= 1;
+        if (r_top != 0 || r >= y) {
+            r = static_cast<T>(r - y);
+            q |= T{1};
+        }
+    }
+    return {.quotient = q, .remainder = r};
+}
+
 // Returns the quotient and remainder of the division `x / y`.
 // The behavior is undefined if the quotient is not representable as `T`,
 // which is the case if and only if `x.high_bits < y`.
@@ -567,14 +608,17 @@ template <unsigned_integer T>
     }
 #endif // BEMAN_BIG_INT_LIMB_WIDTH == 64
 
-    // In the general case, we rely on `wider_t<T>` and `to_int()` existing.
-    // There is no software fallback, so this might fail due to lack of 128-bit support
-    // if the function is instantiated with a 64-bit type.
-    const auto x_int = x.to_int();
-    return {
-        .quotient  = static_cast<T>(x_int / y),
-        .remainder = static_cast<T>(x_int % y),
-    };
+    // In the general case, use `wider_t<T>` division when it exists. Otherwise
+    // (64-bit limbs without any 128-bit type), divide in software.
+    if constexpr (has_wider<T>) {
+        const auto x_int = x.to_int();
+        return {
+            .quotient  = static_cast<T>(x_int / y),
+            .remainder = static_cast<T>(x_int % y),
+        };
+    } else {
+        return narrowing_div_portable(x, y);
+    }
 }
 
 // Portable bit-by-bit restoring long division of the 2-limb unsigned value `a`
@@ -619,7 +663,7 @@ template <unsigned_integer T>
 [[nodiscard]] constexpr wide_div_result<T> divide_wide_by_wide(const wide<T> a, const wide<T> b) noexcept {
     BEMAN_BIG_INT_DEBUG_ASSERT(b.high_bits != 0);
 
-    if constexpr (requires { typename wider_t<T>; }) {
+    if constexpr (has_wider<T>) {
         const auto a_int = a.to_int();
         const auto b_int = b.to_int();
         return {

--- a/tests/beman/big_int/wide_ops.test.cpp
+++ b/tests/beman/big_int/wide_ops.test.cpp
@@ -542,6 +542,9 @@ TEST(WideOps, WiderTraitMatchesPlatform) {
     static_assert(has_wider<std::int64_t> == has_int128_v);
 }
 
+BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
+BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Wuseless-cast")
+
 TEST(WideOps, NarrowingDivPortable) {
     using beman::big_int::detail::narrowing_div_portable;
 
@@ -590,6 +593,8 @@ TEST(WideOps, NarrowingDivPortable) {
     static_assert(narrowing_div_portable(wide<std::uint64_t>{.low_bits = 5u, .high_bits = 1u}, std::uint64_t{3}) ==
                   beman::big_int::div_result<std::uint64_t>{6'148'914'691'236'517'207ull, 0ull});
 }
+
+BEMAN_BIG_INT_DIAGNOSTIC_POP()
 
 // v must equal floor((B^2 - 1) / d) - B, computed independently via wider_t.
 template <class T>

--- a/tests/beman/big_int/wide_ops.test.cpp
+++ b/tests/beman/big_int/wide_ops.test.cpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <limits>
 #include <random>
+#include <type_traits>
 
 #include "testing.hpp"
 
@@ -520,6 +521,75 @@ using beman::big_int::detail::reciprocal_word;
 using beman::big_int::detail::reciprocal_word_3by2;
 using beman::big_int::detail::wide;
 using beman::big_int::detail::widening_mul;
+
+TEST(WideOps, WiderTraitMatchesPlatform) {
+    using beman::big_int::detail::has_int128_v;
+    using beman::big_int::detail::has_wider;
+    using beman::big_int::detail::wider_t;
+
+    static_assert(std::is_same_v<wider_t<std::uint8_t>, std::uint16_t>);
+    static_assert(std::is_same_v<wider_t<std::uint16_t>, std::uint32_t>);
+    static_assert(std::is_same_v<wider_t<std::uint32_t>, std::uint64_t>);
+    static_assert(std::is_same_v<wider_t<std::int8_t>, std::int16_t>);
+    static_assert(std::is_same_v<wider_t<std::int16_t>, std::int32_t>);
+    static_assert(std::is_same_v<wider_t<std::int32_t>, std::int64_t>);
+
+    // On targets without any 128-bit type, wider_t<uint64_t> must be quietly
+    // absent, so that wide<uint64_t> falls back onto the data-only primary
+    // template. A hard error from this query is what used to break the NTT's
+    // Montgomery arithmetic on 32-bit microcontrollers.
+    static_assert(has_wider<std::uint64_t> == has_int128_v);
+    static_assert(has_wider<std::int64_t> == has_int128_v);
+}
+
+TEST(WideOps, NarrowingDivPortable) {
+    using beman::big_int::detail::narrowing_div_portable;
+
+    // Check the bit-by-bit loop with uint16 limbs against uint32 division.
+    using T = std::uint16_t;
+
+    auto check = [](T x_lo, T x_hi, T y) {
+        const auto          r = narrowing_div_portable(wide<T>{.low_bits = x_lo, .high_bits = x_hi}, y);
+        const std::uint32_t x = (static_cast<std::uint32_t>(x_hi) << 16) | x_lo;
+        EXPECT_EQ(r.quotient, static_cast<T>(x / y)) << "x=" << x << " y=" << y;
+        EXPECT_EQ(r.remainder, static_cast<T>(x % y)) << "x=" << x << " y=" << y;
+    };
+
+    check(0x0000, 0x0000, 0x0001); // 0 / 1.
+    check(0xFFFF, 0x0000, 0x0001); // single-limb dividend, identity quotient.
+    check(0xFFFF, 0xFFFE, 0xFFFF); // largest dividend for the largest divisor.
+    check(0x0001, 0x8000, 0x8001); // quotient near B with a near-normalized divisor.
+    check(0xDEAD, 0x1234, 0x5678); // arbitrary pattern.
+
+    for (std::uint32_t x_hi : {0u, 1u, 2u, 0x7FFFu, 0x8000u, 0xABCDu, 0xFFFEu}) {
+        for (std::uint32_t y : {1u, 2u, 3u, 0x7FFFu, 0x8000u, 0xABCDu, 0xFFFFu}) {
+            if (x_hi >= y) {
+                continue; // precondition: the quotient must fit in one limb
+            }
+            for (std::uint32_t x_lo : {0u, 1u, 0x00FFu, 0x5A5Au, 0xA5A5u, 0xFFFFu}) {
+                check(static_cast<T>(x_lo), static_cast<T>(x_hi), static_cast<T>(y));
+            }
+        }
+    }
+
+    // The limb-width instantiation must agree with narrowing_div.
+    std::mt19937_64 rng{0x47u};
+    for (int i = 0; i < 1000; ++i) {
+        const auto y    = static_cast<uint_multiprecision_t>(rng() | 1u);
+        const auto x_hi = static_cast<uint_multiprecision_t>(rng() % y);
+        const auto x_lo = static_cast<uint_multiprecision_t>(rng());
+
+        const wide<uint_multiprecision_t> x{.low_bits = x_lo, .high_bits = x_hi};
+        const auto                        expected = narrowing_div(x, y);
+        const auto                        actual   = narrowing_div_portable(x, y);
+        EXPECT_EQ(actual.quotient, expected.quotient);
+        EXPECT_EQ(actual.remainder, expected.remainder);
+    }
+
+    // The portable path must also work during constant evaluation.
+    static_assert(narrowing_div_portable(wide<std::uint64_t>{.low_bits = 5u, .high_bits = 1u}, std::uint64_t{3}) ==
+                  beman::big_int::div_result<std::uint64_t>{6'148'914'691'236'517'207ull, 0ull});
+}
 
 // v must equal floor((B^2 - 1) / d) - B, computed independently via wider_t.
 template <class T>


### PR DESCRIPTION
Fixes the case where a 32-bit system has a 64-bit integer but not a 128-bit integer

Closes: #250 