### PR TITLE
Implement sub-quadratic base conversion and hook it into <charconv>

### DIFF
--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -3618,10 +3618,17 @@ from_chars(const char* const begin, const char* const end, basic_big_int<b, A>& 
             const char* const digit_block_begin = current_end - digit_block_length;
             BEMAN_BIG_INT_DEBUG_ASSERT(digit_block_length != 0);
 
-            const std::from_chars_result digit_block_result =
-                std::from_chars(digit_block_begin, current_end, out_limbs[out_limb_index], base);
             // We already validated the digit run and bounded each block to one limb.
-            BEMAN_BIG_INT_DEBUG_ASSERT(digit_block_result.ec == std::errc{});
+            // Pack the digit blocks ourselves for up to 6x performance improvement with libc++,
+            // since they don't have optimizations for any of the power of two cases.
+            // Libstdc++ does so we see a tiny improvement due to reduced overhead
+            uint_multiprecision_t limb = 0;
+            for (const char* digit = digit_block_begin; digit != current_end; ++digit) {
+                const int value = detail::digit_value(*digit);
+                BEMAN_BIG_INT_DEBUG_ASSERT(value >= 0 && value < base);
+                limb = (limb << bits_per_digit) | static_cast<uint_multiprecision_t>(value);
+            }
+            out_limbs[out_limb_index] = limb;
             ++out_limb_index;
 
             if (digit_block_begin == current_begin) {
@@ -3659,13 +3666,14 @@ from_chars(const char* const begin, const char* const end, basic_big_int<b, A>& 
             const char* const digit_block_begin  = current_end - digit_block_length;
             BEMAN_BIG_INT_DEBUG_ASSERT(digit_block_length != 0);
 
-            uint_multiprecision_t        bits{};
-            const std::from_chars_result digit_block_result =
-                std::from_chars(digit_block_begin, current_end, bits, base);
-            // We already pre-parsed the string when advancing current_end,
-            // and we made sure to only take as many digits as can fit into uint_multiprecision_t,
-            // so use of `std::from_chars` should be infallible.
-            BEMAN_BIG_INT_DEBUG_ASSERT(digit_block_result.ec == std::errc{});
+            // Pack the digit block (most-significant-first) with shift/or; see
+            // the max_pow == 0 case above for why std::from_chars is not used.
+            uint_multiprecision_t bits = 0;
+            for (const char* digit = digit_block_begin; digit != current_end; ++digit) {
+                const int value = detail::digit_value(*digit);
+                BEMAN_BIG_INT_DEBUG_ASSERT(value >= 0 && value < base); // pre-validated by the scan above
+                bits = (bits << bits_per_digit) | static_cast<uint_multiprecision_t>(value);
+            }
 
             out.unchecked_init_magnitude_bits_at(bits, bit_offset);
             bit_offset += bits_per_iteration;

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -25,6 +25,7 @@
     #include <stdfloat>
 #endif
 
+#include <beman/big_int/detail/base_tables.hpp>
 #include <beman/big_int/detail/config.hpp>
 #include <beman/big_int/detail/div_impl.hpp>
 #include <beman/big_int/detail/floats.hpp>
@@ -3315,112 +3316,6 @@ inline constexpr auto digit_value_table = []() consteval {
 // Returns `-1` if the `c` is not alphanumeric.
 [[nodiscard]] constexpr int digit_value(const char c) noexcept {
     return digit_value_table[static_cast<std::size_t>(c)];
-}
-
-[[nodiscard]] consteval unsigned char limb_max_input_digits_naive(const int base) {
-    BEMAN_BIG_INT_ASSERT(base >= 2);
-    const auto ubase = static_cast<uint_multiprecision_t>(base);
-    if (std::has_single_bit(ubase)) {
-        return detail::width_v<uint_multiprecision_t> / static_cast<unsigned char>(std::countr_zero(ubase));
-    }
-
-    uint_multiprecision_t x      = 1;
-    int                   result = 0;
-    while (true) {
-        const auto [product, overflow] = overflowing_mul(x, ubase);
-        if (overflow) {
-            return static_cast<unsigned char>(product == 0 ? result + 1 : result);
-        }
-        x = product;
-        ++result;
-        BEMAN_BIG_INT_ASSERT(product != 0);
-    }
-}
-
-inline constexpr auto limb_max_input_digits_table = []() consteval {
-    std::array<unsigned char, 37> result{};
-    for (std::size_t i = 2; i < result.size(); ++i) {
-        result[i] = limb_max_input_digits_naive(static_cast<int>(i));
-    }
-    return result;
-}();
-
-// Returns the amount of digits that `uint_multiprecision_t` can represent in the given base.
-// Mathematically, this is `floor(log(pow(2, width_v<uint_multiprecision_t>)) / log(base))`.
-[[nodiscard]] constexpr int limb_max_input_digits(const int base) {
-    BEMAN_BIG_INT_DEBUG_ASSERT(base >= 2 && base <= 36);
-    return limb_max_input_digits_table[std::size_t(base)];
-}
-
-[[nodiscard]] consteval uint_multiprecision_t limb_pow_naive(const uint_multiprecision_t x, const int y) {
-    uint_multiprecision_t result = 1;
-    for (int i = 0; i < y; ++i) {
-        result *= x;
-    }
-    return result;
-}
-
-inline constexpr auto limb_max_power_table = []() consteval {
-    std::array<uint_multiprecision_t, 37> result{};
-    for (std::size_t i = 2; i < result.size(); ++i) {
-        const int max_exponent = limb_max_input_digits(static_cast<int>(i));
-        result[i]              = limb_pow_naive(i, max_exponent);
-    }
-    return result;
-}();
-
-// Returns the greatest power of `base` representable in `uint_multiprecision_t`,
-// or zero if the next greater power is exactly `pow(2, width_v<uint_multiprecision_t>)`.
-//
-// A result of zero essentially communicates that no bit of `std::uint64_t` is wasted,
-// such as in the base-2 or base-16 case.
-[[nodiscard]] constexpr uint_multiprecision_t limb_max_power(const int base) {
-    BEMAN_BIG_INT_DEBUG_ASSERT(base >= 2 && base <= 36);
-    return limb_max_power_table[std::size_t(base)];
-}
-
-// Fixed-point ceil(log2(base)) coefficients in Q7.4 format.
-// Each entry stores ceil(log2(base) * 16), i.e. ceil(log2(base)) represented with 4 fractional bits.
-inline constexpr std::array<unsigned short, 37> approximate_ceil_mul_log2_q7_4_table{
-    0x00, 0x00, 0x10, 0x1A, 0x20, 0x26, 0x2A, 0x2D, 0x30, 0x33, 0x36, 0x38, 0x3A, 0x3C, 0x3D, 0x3F, 0x40, 0x42, 0x43,
-    0x44, 0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4D, 0x4E, 0x4F, 0x50, 0x50, 0x51, 0x52, 0x53, 0x53,
-};
-
-// Computes a fast approximation of the amount of bits
-// required to represent an integer in base `base` with `digit_count` digits.
-// Mathematically, this is `ceil(digit_count * log2(base))`.
-// For powers of two, the exact result is returned.
-[[nodiscard]] constexpr std::size_t approximate_ceil_mul_log2(const std::size_t digit_count, const int base) {
-    BEMAN_BIG_INT_DEBUG_ASSERT(base >= 2 && base <= 36);
-    constexpr std::size_t fractional_bits = 4;
-    constexpr std::size_t fractional_mask = (std::size_t{1} << fractional_bits) - 1;
-
-    const auto        coeff = static_cast<std::size_t>(approximate_ceil_mul_log2_q7_4_table[std::size_t(base)]);
-    const std::size_t scaled_result = digit_count * coeff;
-    return (scaled_result >> fractional_bits) + static_cast<std::size_t>((scaled_result & fractional_mask) != 0);
-}
-
-// Fixed-point ceil(1/log2(base)) coefficients in Q0.8 format.
-// Each entry stores ceil(256 / log2(base)) as an unsigned char.
-// Indices 0, 1, and 2 are unused; base 2 is handled separately in approximate_ceil_div_log2.
-inline constexpr std::array<unsigned char, 37> approximate_ceil_div_log2_q0_8_table{
-    0x00, 0x00, 0x00, 0xA2, 0x80, 0x6F, 0x64, 0x5C, 0x56, 0x51, 0x4E, 0x4B, 0x48, 0x46, 0x44, 0x42, 0x40, 0x3F, 0x3E,
-    0x3D, 0x3C, 0x3B, 0x3A, 0x39, 0x38, 0x38, 0x37, 0x36, 0x36, 0x35, 0x35, 0x34, 0x34, 0x33, 0x33, 0x32, 0x32,
-};
-
-// Computes a fast approximation of `ceil(x / log2(base))`.
-// For base 2, the exact result is returned.
-[[nodiscard]] constexpr std::size_t approximate_ceil_div_log2(const std::size_t x, const int base) {
-    BEMAN_BIG_INT_DEBUG_ASSERT(base >= 2 && base <= 36);
-    constexpr std::size_t fractional_bits = 8;
-    constexpr std::size_t fractional_mask = (std::size_t{1} << fractional_bits) - 1;
-
-    if (base == 2) {
-        return x;
-    }
-    const auto coeff = static_cast<std::size_t>(approximate_ceil_div_log2_q0_8_table[static_cast<std::size_t>(base)]);
-    const std::size_t scaled_result = x * coeff;
-    return (scaled_result >> fractional_bits) + static_cast<std::size_t>((scaled_result & fractional_mask) != 0);
 }
 
 } // namespace detail

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -25,6 +25,7 @@
     #include <stdfloat>
 #endif
 
+#include <beman/big_int/detail/base_conversion.hpp>
 #include <beman/big_int/detail/base_tables.hpp>
 #include <beman/big_int/detail/config.hpp>
 #include <beman/big_int/detail/div_impl.hpp>
@@ -3484,6 +3485,30 @@ to_chars(char* const begin, char* const end, const basic_big_int<b, A>& x, const
     case 34:
     case 35:
     case 36: {
+        // For magnitudes large enough that the divide-and-conquer ladder
+        // engages, the sub-quadratic FastIntegerOutput kernel replaces the
+        // repeated short-division loop. Smaller values (and constant
+        // evaluation) keep the inline path below.
+        if BEMAN_BIG_INT_IS_NOT_CONSTEVAL {
+            const std::span<const uint_multiprecision_t> value_span{x.limb_ptr(), x.limb_count()};
+            if (detail::fast_limbs_to_digits_profitable(value_span, base)) {
+                // The kernel emits the exact MSD-first digit VALUES; map them to
+                // ASCII in place. No reversal -- already most-significant-first.
+                auto                           alloc = x.get_allocator();
+                const std::size_t              bound = detail::base_conversion_digit_bound(value_span, base);
+                detail::digit_value_buffer<A>  values(alloc, bound);
+                const std::span<unsigned char> vspan = values.span();
+                const std::size_t              n     = detail::limbs_to_digits(vspan, value_span, base, alloc);
+                if (static_cast<std::size_t>(end - current_begin) < n) {
+                    return {end, std::errc::value_too_large};
+                }
+                for (std::size_t i = 0; i < n; ++i) {
+                    current_begin[i] = alphabet[vspan[i]];
+                }
+                return {current_begin + n, std::errc{}};
+            }
+        }
+
         auto remainder = x;
         remainder.unchecked_set_sign(false);
         // Zero should have been handled above already.
@@ -3670,6 +3695,34 @@ from_chars(const char* const begin, const char* const end, basic_big_int<b, A>& 
     //
     // For example, if `base` is `10`, instead of doing parsing base 10,
     // we do it base `1'000'000'000` assuming `uint_multiprecision_t` is 32-bit.
+    //
+    // For inputs large enough that the divide-and-conquer ladder engages, the
+    // sub-quadratic FastIntegerInput kernel replaces the Horner loop. Smaller
+    // inputs (and constant evaluation) keep the inline path below, whose fixed
+    // overhead is lower than the kernel's temp buffer plus owned scratch arena.
+    if BEMAN_BIG_INT_IS_NOT_CONSTEVAL {
+        if (detail::fast_digits_to_limbs_profitable(static_cast<std::size_t>(digit_count), base)) {
+            // Transcode the already-validated ASCII run into MSD-first digit
+            // VALUES (0..base-1), then run the kernel straight into out's limbs.
+            auto                           alloc = out.get_allocator();
+            detail::digit_value_buffer<A>  values(alloc, static_cast<std::size_t>(digit_count));
+            const std::span<unsigned char> vspan = values.span();
+            for (std::ptrdiff_t i = 0; i < static_cast<std::ptrdiff_t>(digit_count); ++i) {
+                vspan[static_cast<std::size_t>(i)] = static_cast<unsigned char>(detail::digit_value(current_begin[i]));
+            }
+            const std::size_t bound = detail::base_conversion_limb_bound(static_cast<std::size_t>(digit_count), base);
+            out.set_zero();
+            out.grow(bound);
+            const std::size_t count =
+                detail::digits_to_limbs(std::span<uint_multiprecision_t>{out.limb_ptr(), bound}, vspan, base, alloc);
+            out.unchecked_set_limb_count(static_cast<std::uint32_t>(count));
+            out.unchecked_trim_magnitude();
+            if (*begin == '-') {
+                out.negate();
+            }
+            return {returned_end, std::errc{}};
+        }
+    }
 
     // Parse the valid digit run in blocks that fit into `uint_multiprecision_t`.
     // The first block may be shorter so that all following blocks have the same width,

--- a/include/beman/big_int/detail/base_conversion.hpp
+++ b/include/beman/big_int/detail/base_conversion.hpp
@@ -88,17 +88,17 @@ static_assert(std::has_single_bit(fast_input_basecase_chunks),
 [[nodiscard]] constexpr std::size_t mul_add_single_limb_in_place(const std::span<uint_multiprecision_t> s,
                                                                  const std::size_t                      size,
                                                                  const uint_multiprecision_t            mul,
-                                                                 const uint_multiprecision_t add) noexcept {
+                                                                 const uint_multiprecision_t            add) noexcept {
     BEMAN_BIG_INT_DEBUG_ASSERT(size >= 1);
     BEMAN_BIG_INT_DEBUG_ASSERT(size <= s.size());
     BEMAN_BIG_INT_DEBUG_ASSERT(mul != 0);
 
     uint_multiprecision_t carry = add;
     for (std::size_t i = 0; i < size; ++i) {
-        const auto [lo, hi]        = widening_mul(s[i], mul);
+        const auto [lo, hi]              = widening_mul(s[i], mul);
         const uint_multiprecision_t next = lo + carry;
-        carry                      = hi + static_cast<uint_multiprecision_t>(next < lo);
-        s[i]                       = next;
+        carry                            = hi + static_cast<uint_multiprecision_t>(next < lo);
+        s[i]                             = next;
     }
     if (carry == 0) {
         return size;
@@ -228,7 +228,7 @@ constexpr void append_squared_power(base_power_table&       table,
                                     Allocator&              alloc) {
     constexpr std::size_t limb_bits = width_v<uint_multiprecision_t>;
 
-    const base_power_entry&                prev = table.entry[level - 1];
+    const base_power_entry& prev = table.entry[level - 1];
     BEMAN_BIG_INT_DEBUG_ASSERT(slot_limbs >= 2 * prev.value.size());
     const std::span<uint_multiprecision_t> slot = scratch.allocate(slot_limbs);
     std::ranges::fill(slot, uint_multiprecision_t{0});
@@ -379,9 +379,9 @@ constexpr std::size_t digits_to_limbs(const std::span<uint_multiprecision_t> res
     const std::size_t groups = div_to_pos_inf(chunks, group);
     std::ranges::fill(arena_a.first(groups * group), uint_multiprecision_t{0});
     for (std::size_t g = 0; g < groups; ++g) {
-        const std::size_t end   = digits.size() - g * group * cpl;
-        const std::size_t span  = group * cpl;
-        const std::size_t start = end > span ? end - span : 0;
+        const std::size_t                  end   = digits.size() - g * group * cpl;
+        const std::size_t                  span  = group * cpl;
+        const std::size_t                  start = end > span ? end - span : 0;
         [[maybe_unused]] const std::size_t size =
             basecase_digits_to_limbs(arena_a.subspan(g * group, group), digits.subspan(start, end - start), base);
     }
@@ -478,7 +478,7 @@ inline constexpr std::size_t fast_output_preinv_min_limbs = barrett_balanced_cut
 // Upper bound on the digits an n-limb value needs in `base` (the
 // to_basic_string sizing formula; overestimates by at most one digit).
 [[nodiscard]] constexpr std::size_t base_conversion_digit_bound(const std::span<const uint_multiprecision_t> value,
-                                                                const int                                     base) {
+                                                                const int                                    base) {
     const std::size_t width = value_bit_width(value.first(trimmed_size_span(value)));
     return width <= 1 ? std::size_t{1} : approximate_ceil_div_log2(width - 1, base) + 1;
 }
@@ -563,9 +563,8 @@ class digit_value_buffer {
                                                  const base_power_entry&                      power) noexcept {
     constexpr std::size_t limb_bits = width_v<uint_multiprecision_t>;
 
-    const std::size_t power_bits =
-        (power.low_zero_limbs + power.value.size() - 1) * limb_bits +
-        static_cast<std::size_t>(std::bit_width(power.value.back()));
+    const std::size_t power_bits = (power.low_zero_limbs + power.value.size() - 1) * limb_bits +
+                                   static_cast<std::size_t>(std::bit_width(power.value.back()));
     const std::size_t value_bits = value_bit_width(v);
     if (value_bits != power_bits) {
         return value_bits > power_bits;
@@ -597,8 +596,7 @@ constexpr void build_power_table_for_value(base_power_table&                    
     std::size_t r = init_power_table(table, base, scratch);
     while (true) {
         const base_power_entry& top = table.entry[table.levels - 1];
-        const std::size_t       top_bits =
-            top.low_zero_limbs * width_v<uint_multiprecision_t> + value_bit_width(top.value);
+        const std::size_t top_bits  = top.low_zero_limbs * width_v<uint_multiprecision_t> + value_bit_width(top.value);
         if (2 * top_bits - 1 > value_bits) {
             return;
         }
@@ -651,8 +649,8 @@ struct short_divisor {
     for (std::size_t i = size - 1; i > 0; --i) {
         const uint_multiprecision_t next = s[i - 1];
         const uint_multiprecision_t u    = funnel_shl(wide<uint_multiprecision_t>{.low_bits = next, .high_bits = cur},
-                                                   static_cast<unsigned>(divisor.shift));
-        const auto qr =
+                                                      static_cast<unsigned>(divisor.shift));
+        const auto                  qr =
             div_2by1_preinv(wide<uint_multiprecision_t>{.low_bits = u, .high_bits = r}, divisor.norm, divisor.recip);
         s[i] = qr.quotient;
         r    = qr.remainder;
@@ -904,9 +902,8 @@ constexpr void emit_digits(const std::span<unsigned char>               out,
                                                                  const int         base,
                                                                  const std::size_t basecase_override = 0) noexcept {
     BEMAN_BIG_INT_DEBUG_ASSERT(is_fast_conversion_base(base));
-    const std::size_t staging =
-        std::min(fast_output_group_size(basecase_override), limb_count + limb_count / 8 + 4);
-    std::size_t total = 10 * limb_count + 2 * staging + 256;
+    const std::size_t staging = std::min(fast_output_group_size(basecase_override), limb_count + limb_count / 8 + 4);
+    std::size_t       total   = 10 * limb_count + 2 * staging + 256;
     if (limb_count >= fast_output_preinv_min_limbs) {
         total += 4 * (limb_count + 2) + reciprocal_span_storage_size(limb_count + 2, reciprocal_span_cutoff) +
                  barrett_preinv_storage_size(limb_count / 2 + 2, 4);

--- a/include/beman/big_int/detail/base_conversion.hpp
+++ b/include/beman/big_int/detail/base_conversion.hpp
@@ -226,7 +226,7 @@ constexpr void append_squared_power(base_power_table&       table,
                                     std::size_t&            r,
                                     scratch_allocator_base& scratch,
                                     Allocator&              alloc) {
-    constexpr std::size_t limb_bits = width_v<uint_multiprecision_t>;
+    constexpr std::size_t local_limb_bits = width_v<uint_multiprecision_t>;
 
     const base_power_entry& prev = table.entry[level - 1];
     BEMAN_BIG_INT_DEBUG_ASSERT(slot_limbs >= 2 * prev.value.size());
@@ -234,8 +234,8 @@ constexpr void append_squared_power(base_power_table&       table,
     std::ranges::fill(slot, uint_multiprecision_t{0});
     std::size_t size = square_into(slot, prev.value, alloc);
 
-    const std::size_t drop = 2 * r >= limb_bits ? 1 : 0;
-    r                      = 2 * r - drop * limb_bits;
+    const std::size_t drop = 2 * r >= local_limb_bits ? 1 : 0;
+    r                      = 2 * r - drop * local_limb_bits;
     if (drop != 0) {
         BEMAN_BIG_INT_DEBUG_ASSERT(slot[0] == 0);
         std::ranges::copy(slot.subspan(1, size - 1), slot.begin());
@@ -561,9 +561,9 @@ class digit_value_buffer {
 // limbs are compared against the value's matching window.
 [[nodiscard]] constexpr bool value_reaches_power(const std::span<const uint_multiprecision_t> v,
                                                  const base_power_entry&                      power) noexcept {
-    constexpr std::size_t limb_bits = width_v<uint_multiprecision_t>;
+    constexpr std::size_t local_limb_bits = width_v<uint_multiprecision_t>;
 
-    const std::size_t power_bits = (power.low_zero_limbs + power.value.size() - 1) * limb_bits +
+    const std::size_t power_bits = (power.low_zero_limbs + power.value.size() - 1) * local_limb_bits +
                                    static_cast<std::size_t>(std::bit_width(power.value.back()));
     const std::size_t value_bits = value_bit_width(v);
     if (value_bits != power_bits) {
@@ -630,7 +630,7 @@ struct short_divisor {
 [[nodiscard]] constexpr uint_multiprecision_t divide_short_preinv_in_place(const std::span<uint_multiprecision_t> s,
                                                                            const std::size_t                      size,
                                                                            const short_divisor& divisor) noexcept {
-    constexpr std::size_t limb_bits = width_v<uint_multiprecision_t>;
+    constexpr std::size_t local_limb_bits = width_v<uint_multiprecision_t>;
     BEMAN_BIG_INT_DEBUG_ASSERT(size >= 1 && size <= s.size());
 
     if (divisor.shift == 0) {
@@ -645,7 +645,7 @@ struct short_divisor {
     }
 
     uint_multiprecision_t cur = s[size - 1];
-    uint_multiprecision_t r   = cur >> (limb_bits - divisor.shift);
+    uint_multiprecision_t r   = cur >> (local_limb_bits - divisor.shift);
     for (std::size_t i = size - 1; i > 0; --i) {
         const uint_multiprecision_t next = s[i - 1];
         const uint_multiprecision_t u    = funnel_shl(wide<uint_multiprecision_t>{.low_bits = next, .high_bits = cur},
@@ -674,7 +674,7 @@ struct short_divisor {
 // ---------------------------------------------------------------------------
 inline void
 attach_power_reciprocals(base_power_table& table, const std::size_t value_limbs, scratch_allocator_base& scratch) {
-    constexpr std::size_t limb_bits = width_v<uint_multiprecision_t>;
+    constexpr std::size_t local_limb_bits = width_v<uint_multiprecision_t>;
 
     for (std::size_t j = 1; j < table.levels; ++j) {
         base_power_entry& entry = table.entry[j];
@@ -692,7 +692,7 @@ attach_power_reciprocals(base_power_table& table, const std::size_t value_limbs,
             BEMAN_BIG_INT_DEBUG_ASSERT(norm_size == s);
             norm = std::span<const uint_multiprecision_t>{norm_slot.data(), s};
         }
-        BEMAN_BIG_INT_DEBUG_ASSERT(norm.back() >> (limb_bits - 1) == 1);
+        BEMAN_BIG_INT_DEBUG_ASSERT(norm.back() >> (local_limb_bits - 1) == 1);
 
         const std::span<uint_multiprecision_t> inv_slot = scratch.allocate(s);
         reciprocal_span(inv_slot, norm, scratch);

--- a/include/beman/big_int/detail/base_conversion.hpp
+++ b/include/beman/big_int/detail/base_conversion.hpp
@@ -1,0 +1,909 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: BSL-1.0
+
+#ifndef BEMAN_BIG_INT_BASE_CONVERSION_HPP
+#define BEMAN_BIG_INT_BASE_CONVERSION_HPP
+
+#include <beman/big_int/detail/config.hpp>
+#include <beman/big_int/detail/base_tables.hpp>
+#include <beman/big_int/detail/div_impl.hpp>
+#include <beman/big_int/detail/mul_impl.hpp>
+#include <beman/big_int/detail/scratch_allocator.hpp>
+#include <beman/big_int/detail/span_ops.hpp>
+#include <beman/big_int/detail/wide_ops.hpp>
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <cstddef>
+#include <span>
+#include <type_traits>
+
+namespace beman::big_int::detail {
+
+// ---------------------------------------------------------------------------
+// Sub-quadratic base conversion (Modern Computer Arithmetic, Brent &
+// Zimmermann, section 1.7.2: Algorithm 1.25 FastIntegerInput and Algorithm
+// 1.26 FastIntegerOutput). Both directions work at chunk granularity: groups
+// of limb_max_input_digits(base) digits pack into one limb (each chunk below
+// big_base = limb_max_power(base)), and the divide-and-conquer ladder
+// combines or splits chunks with the shared power chain
+// P_j = big_base^(2^j). The digit boundary is digit VALUES (0..base-1, one
+// unsigned char each, most significant first; the GMP mpn_set_str/get_str
+// convention) -- ASCII mapping and validation stay in the charconv layer.
+// Only non-power-of-two bases in [3, 36] are supported here; power-of-two
+// bases already convert in linear time elsewhere.
+// ---------------------------------------------------------------------------
+
+[[nodiscard]] constexpr bool is_fast_conversion_base(const int base) noexcept {
+    return base >= 3 && base <= 36 && !std::has_single_bit(static_cast<unsigned>(base));
+}
+
+// Upper bound on the limbs a digit_count-digit value in `base` can occupy.
+[[nodiscard]] constexpr std::size_t base_conversion_limb_bound(const std::size_t digit_count, const int base) {
+    BEMAN_BIG_INT_DEBUG_ASSERT(digit_count > 0);
+    return div_to_pos_inf(approximate_ceil_mul_log2(digit_count, base),
+                          static_cast<std::size_t>(width_v<uint_multiprecision_t>));
+}
+
+// Chunks (groups of limb_max_input_digits(base) digits, one limb each) covering digit_count digits.
+[[nodiscard]] constexpr std::size_t base_conversion_chunk_count(const std::size_t digit_count, const int base) {
+    return div_to_pos_inf(digit_count, static_cast<std::size_t>(limb_max_input_digits(base)));
+}
+
+// Leaf group size for digits_to_limbs: inputs below TWO full groups take the
+// fused Horner basecase outright (a (group, runt) split pays for the whole
+// power chain to combine a sliver and measured 15-40% below the basecase on
+// both architectures), and the ladder's leaves hold this many chunks. Power
+// of two: leaf groups must tile the ladder's strides.
+//
+// Tuned with the base_conversion_bench crossover sweep (RelWithDebInfo,
+// min-of-reps / median-of-samples, M4-class AArch64 + i9-11900K x86-64,
+// 2026-06-12). AArch64: splitting ties the pure Horner at 64-chunk inputs
+// and wins 8-15% by 128, leaves of 32 the best measured. x86-64's stronger
+// mul_1 keeps the basecase ahead much longer: po2-aligned splits first win
+// at 512 chunks (leaves 128, +5%), but arbitrary counts in the 300-700 band
+// lose 15-40% to the basecase for every leaf size tried, and 512-chunk
+// leaves with the two-full-groups gate were the first shape that never
+// measured below the basecase anywhere (at the cost of 15-25% off the
+// po2-aligned optimum at 1024+ chunks). The 2^k + 1 lone-top sawtooth
+// (Algorithm 1.25's unmultiplied top element) costs ~15% at the worst single
+// point on both architectures; GMP-style balanced splitting was considered
+// and deferred - the penalty amortizes to noise at neighboring sizes.
+#if defined(__x86_64__) || defined(_M_X64) || defined(__amd64__)
+inline constexpr std::size_t fast_input_basecase_chunks = 512;
+#else
+inline constexpr std::size_t fast_input_basecase_chunks = 32;
+#endif
+
+static_assert(std::has_single_bit(fast_input_basecase_chunks),
+              "leaf groups must tile the ladder's power-of-two strides");
+
+// ---------------------------------------------------------------------------
+// s.first(size) <- s.first(size) * mul + add, in place (the GMP mpn_mul_1 +
+// add fusion the Horner basecase folds with). `mul` must be non-zero, so the
+// value never shrinks and a trimmed value stays trimmed; `s` must allow one
+// limb of growth whenever the result needs it. Returns the new size.
+// ---------------------------------------------------------------------------
+[[nodiscard]] constexpr std::size_t mul_add_single_limb_in_place(const std::span<uint_multiprecision_t> s,
+                                                                 const std::size_t                      size,
+                                                                 const uint_multiprecision_t            mul,
+                                                                 const uint_multiprecision_t add) noexcept {
+    BEMAN_BIG_INT_DEBUG_ASSERT(size >= 1);
+    BEMAN_BIG_INT_DEBUG_ASSERT(size <= s.size());
+    BEMAN_BIG_INT_DEBUG_ASSERT(mul != 0);
+
+    uint_multiprecision_t carry = add;
+    for (std::size_t i = 0; i < size; ++i) {
+        const auto [lo, hi]        = widening_mul(s[i], mul);
+        const uint_multiprecision_t next = lo + carry;
+        carry                      = hi + static_cast<uint_multiprecision_t>(next < lo);
+        s[i]                       = next;
+    }
+    if (carry == 0) {
+        return size;
+    }
+    BEMAN_BIG_INT_DEBUG_ASSERT(size < s.size());
+    s[size] = carry;
+    return size + 1;
+}
+
+// ---------------------------------------------------------------------------
+// Quadratic basecase: packs the digit run into chunks (top chunk short) and
+// folds them MSD-first via acc = acc * big_base + chunk. `acc` must hold
+// base_conversion_chunk_count(digits.size(), base) limbs; only the returned
+// size is written.
+// ---------------------------------------------------------------------------
+[[nodiscard]] constexpr std::size_t basecase_digits_to_limbs(const std::span<uint_multiprecision_t> acc,
+                                                             const std::span<const unsigned char>   digits,
+                                                             const int                              base) {
+    const auto                  cpl      = static_cast<std::size_t>(limb_max_input_digits(base));
+    const auto                  ubase    = static_cast<uint_multiprecision_t>(base);
+    const uint_multiprecision_t big_base = limb_max_power(base);
+
+    const auto pack = [&](const std::size_t pos, const std::size_t width) {
+        uint_multiprecision_t chunk = 0;
+        for (std::size_t i = 0; i < width; ++i) {
+            BEMAN_BIG_INT_DEBUG_ASSERT(digits[pos + i] < base);
+            chunk = chunk * ubase + static_cast<uint_multiprecision_t>(digits[pos + i]);
+        }
+        return chunk;
+    };
+
+    const std::size_t top_width = digits.size() % cpl == 0 ? cpl : digits.size() % cpl;
+
+    acc[0]           = pack(0, top_width);
+    std::size_t size = 1;
+    for (std::size_t pos = top_width; pos < digits.size(); pos += cpl) {
+        size = mul_add_single_limb_in_place(acc, size, big_base, pack(pos, cpl));
+    }
+    return size;
+}
+
+// ---------------------------------------------------------------------------
+// One entry of the shared power chain, stored in the caller's scratch arena
+// as P_j = big_base^(2^j) = value * B^low_zero_limbs. For even bases
+// big_base = 2^z * odd, so P_j carries z * 2^j trailing zero bits and the
+// floor(z * 2^j / limb_bits) whole zero limbs are not stored: every multiply
+// or divide against the power shrinks by that much (the GMP powtab trick).
+// Odd bases store low_zero_limbs == 0 and take the same code paths.
+// ---------------------------------------------------------------------------
+struct base_power_entry {
+    std::span<const uint_multiprecision_t> value{};
+    std::size_t                            low_zero_limbs = 0;
+    // FastIntegerOutput preinv fields (attach_power_reciprocals, runtime
+    // only, large entries only): the normalized value (top bit set) and its
+    // reciprocal_span inverse, so every division by this power runs the
+    // Barrett march with no per-call reciprocal.
+    std::span<const uint_multiprecision_t> value_norm{};
+    std::span<const uint_multiprecision_t> reciprocal{};
+    std::size_t                            norm_shift = 0;
+};
+
+// The chain P_0 = big_base, P_{j+1} = P_j^2, shared by both conversion
+// directions. entry[j] is valid for j < levels.
+struct base_power_table {
+    std::array<base_power_entry, width_v<std::size_t>> entry{};
+    std::size_t                                        levels          = 0;
+    uint_multiprecision_t                              big_base        = 0;
+    int                                                base            = 0;
+    int                                                chars_per_chunk = 0;
+};
+
+// ---------------------------------------------------------------------------
+// dst <- src * src. Same contract as multiply_dispatch: `dst` pre-zeroed with
+// space for 2 * src.size() limbs, no aliasing, `src` trimmed. Returns the
+// trimmed product size. Routes to the squaring tiers at runtime;
+// multiply_dispatch's same-pointer detection covers constant evaluation.
+// ---------------------------------------------------------------------------
+template <class Allocator>
+constexpr std::size_t square_into(const std::span<uint_multiprecision_t>       dst,
+                                  const std::span<const uint_multiprecision_t> src,
+                                  Allocator&                                   alloc) {
+    if BEMAN_BIG_INT_IS_NOT_CONSTEVAL {
+        if (src.size() >= 2) {
+            return square_dispatch(dst, src, alloc);
+        }
+    }
+    return multiply_dispatch(dst, src, src, alloc);
+}
+
+// Scratch limbs build_power_table_for_chunks carves for the chain slots:
+// slot j holds 2^j limbs, so a chain covering chunk_count chunks costs
+// bit_ceil(chunk_count) - 1 limbs in total.
+[[nodiscard]] constexpr std::size_t power_table_storage_size(const std::size_t chunk_count) noexcept {
+    return chunk_count <= 1 ? 0 : std::bit_ceil(chunk_count) - 1;
+}
+
+// Fills the table header and carves the 1-limb slot for P_0 = big_base.
+// Returns the initial trailing-zero bit offset for append_squared_power.
+[[nodiscard]] constexpr std::size_t
+init_power_table(base_power_table& table, const int base, scratch_allocator_base& scratch) {
+    table.base            = base;
+    table.chars_per_chunk = limb_max_input_digits(base);
+    table.big_base        = limb_max_power(base);
+    table.levels          = 1;
+
+    const std::span<uint_multiprecision_t> slot0 = scratch.allocate(1);
+    slot0[0]                                     = table.big_base;
+    table.entry[0]                               = {std::span<const uint_multiprecision_t>{slot0}, 0};
+    return static_cast<std::size_t>(std::countr_zero(table.big_base));
+}
+
+// ---------------------------------------------------------------------------
+// Squares entry[level - 1] into a fresh slot of `slot_limbs` limbs (>= twice
+// the stored value) and appends it as entry[level]. `r` is the in-limb
+// trailing-zero bit offset of the stored value: P_j carries z * 2^j trailing
+// zero bits (z = countr_zero(big_base)) of which whole limbs are trimmed
+// away, and doubling r tells whether this squaring completes one more
+// trimmable limb beyond the doubled trim - overflow-free, unlike tracking
+// z * 2^j itself.
+// ---------------------------------------------------------------------------
+template <class Allocator>
+constexpr void append_squared_power(base_power_table&       table,
+                                    const std::size_t       level,
+                                    const std::size_t       slot_limbs,
+                                    std::size_t&            r,
+                                    scratch_allocator_base& scratch,
+                                    Allocator&              alloc) {
+    constexpr std::size_t limb_bits = width_v<uint_multiprecision_t>;
+
+    const base_power_entry&                prev = table.entry[level - 1];
+    BEMAN_BIG_INT_DEBUG_ASSERT(slot_limbs >= 2 * prev.value.size());
+    const std::span<uint_multiprecision_t> slot = scratch.allocate(slot_limbs);
+    std::ranges::fill(slot, uint_multiprecision_t{0});
+    std::size_t size = square_into(slot, prev.value, alloc);
+
+    const std::size_t drop = 2 * r >= limb_bits ? 1 : 0;
+    r                      = 2 * r - drop * limb_bits;
+    if (drop != 0) {
+        BEMAN_BIG_INT_DEBUG_ASSERT(slot[0] == 0);
+        std::ranges::copy(slot.subspan(1, size - 1), slot.begin());
+        --size;
+    }
+    table.entry[level] = {std::span<const uint_multiprecision_t>{slot.data(), size}, 2 * prev.low_zero_limbs + drop};
+    table.levels       = level + 1;
+}
+
+// ---------------------------------------------------------------------------
+// Builds the chain P_0 .. P_{levels-1} with levels = ceil(log2(chunk_count)),
+// exactly the powers Algorithm 1.25's ladder consumes for chunk_count leaf
+// chunks. Slots are carved from `scratch` (power_table_storage_size limbs in
+// total) and stay live until the caller rewinds them (LIFO).
+// ---------------------------------------------------------------------------
+template <class Allocator>
+constexpr void build_power_table_for_chunks(base_power_table&       table,
+                                            const std::size_t       chunk_count,
+                                            const int               base,
+                                            scratch_allocator_base& scratch,
+                                            Allocator&              alloc) {
+    BEMAN_BIG_INT_DEBUG_ASSERT(is_fast_conversion_base(base));
+    BEMAN_BIG_INT_DEBUG_ASSERT(chunk_count >= 2);
+
+    const std::size_t target = static_cast<std::size_t>(std::bit_width(chunk_count - 1));
+    std::size_t       r      = init_power_table(table, base, scratch);
+    for (std::size_t j = 1; j < target; ++j) {
+        append_squared_power(table, j, std::size_t{1} << j, r, scratch, alloc);
+    }
+}
+
+// Leaf group size: the tuned threshold, or the passed override rounded down
+// to a power of two (the test-only deep-recursion escape hatch).
+[[nodiscard]] constexpr std::size_t fast_input_group_size(const std::size_t basecase_override) noexcept {
+    return basecase_override == 0 ? fast_input_basecase_chunks : std::bit_floor(basecase_override);
+}
+
+// Scratch upper bound for digits_to_limbs: the basecase accumulator when the
+// input stays below two leaf groups, otherwise two ping-pong combine arenas
+// of bit_ceil(chunks) limbs each plus the power chain slots. Exact, and
+// locked by the peak() probes in base_conversion_input.test.cpp. The
+// multiplication tiers size and own their own workspace through the
+// allocator's heap hooks.
+[[nodiscard]] constexpr std::size_t digits_to_limbs_storage_size(const std::size_t digit_count,
+                                                                 const int         base,
+                                                                 const std::size_t basecase_override = 0) noexcept {
+    const std::size_t chunks = base_conversion_chunk_count(digit_count, base);
+    return chunks < 2 * fast_input_group_size(basecase_override) ? chunks : 3 * std::bit_ceil(chunks) - 1;
+}
+
+// ---------------------------------------------------------------------------
+// One Algorithm 1.25 ladder level: next[p] = cur[2p] + P * cur[2p+1] over
+// fixed strides (level elements occupy `stride` limbs and are below P, the
+// destination stride is twice that, and the combined value stays below P^2).
+// A lone top element passes through unmultiplied. Returns ceil(k / 2).
+// ---------------------------------------------------------------------------
+template <class Allocator>
+constexpr std::size_t combine_level(const std::span<uint_multiprecision_t>       next,
+                                    const std::span<const uint_multiprecision_t> cur,
+                                    const std::size_t                            k,
+                                    const std::size_t                            stride,
+                                    const base_power_entry&                      power,
+                                    Allocator&                                   alloc) {
+    const std::size_t out_stride = 2 * stride;
+    const std::size_t pairs      = k / 2;
+    for (std::size_t p = 0; p < pairs; ++p) {
+        const std::span<const uint_multiprecision_t> lo  = cur.subspan(2 * p * stride, stride);
+        const std::span<const uint_multiprecision_t> hi  = cur.subspan((2 * p + 1) * stride, stride);
+        const std::span<uint_multiprecision_t>       dst = next.subspan(p * out_stride, out_stride);
+        std::ranges::fill(dst, uint_multiprecision_t{0});
+        if (is_span_zero(hi)) {
+            std::ranges::copy(lo, dst.begin());
+            continue;
+        }
+        // P * hi lands B^low_zero_limbs up; the trimmed product fits the rest
+        // of the stride exactly: |value| + |hi| <= (stride - low) + stride.
+        BEMAN_BIG_INT_DEBUG_ASSERT(power.value.size() + power.low_zero_limbs <= stride);
+        multiply_dispatch(dst.subspan(power.low_zero_limbs), power.value, hi.first(trimmed_size_span(hi)), alloc);
+        [[maybe_unused]] const bool carry = add_unsigned_spans(dst, dst, lo);
+        BEMAN_BIG_INT_DEBUG_ASSERT(!carry);
+    }
+    if (k % 2 == 1) {
+        const std::span<const uint_multiprecision_t> top = cur.subspan((k - 1) * stride, stride);
+        const std::span<uint_multiprecision_t>       dst = next.subspan(pairs * out_stride, out_stride);
+        std::ranges::copy(top, dst.begin());
+        std::ranges::fill(dst.subspan(stride), uint_multiprecision_t{0});
+    }
+    return pairs + (k % 2);
+}
+
+// ---------------------------------------------------------------------------
+// MCA Algorithm 1.25 FastIntegerInput at chunk granularity: leaf groups of
+// fast_input_basecase_chunks chunks are evaluated by the fused Horner
+// basecase straight into their ladder stride, then adjacent pairs combine
+// bottom-up with the squared power chain until one value remains.
+// `digits` holds MSD-first digit values, each below `base`, non-empty
+// (leading zeros allowed). `result` must hold at least
+// base_conversion_limb_bound(digits.size(), base) limbs; it is fully written
+// (zero above the significant limbs). Returns the trimmed limb count (>= 1;
+// a zero value yields 1 with result[0] == 0).
+// `scratch` must provide digits_to_limbs_storage_size(...) limbs for the
+// same `basecase_override`; the override forces a smaller leaf group
+// (rounded down to a power of two) so tests recurse deeply on small inputs.
+// ---------------------------------------------------------------------------
+template <class Allocator>
+constexpr std::size_t digits_to_limbs(const std::span<uint_multiprecision_t> result,
+                                      const std::span<const unsigned char>   digits,
+                                      const int                              base,
+                                      scratch_allocator_base&                scratch,
+                                      Allocator&                             alloc,
+                                      const std::size_t                      basecase_override = 0) {
+    BEMAN_BIG_INT_DEBUG_ASSERT(!digits.empty());
+    BEMAN_BIG_INT_DEBUG_ASSERT(is_fast_conversion_base(base));
+    BEMAN_BIG_INT_DEBUG_ASSERT(result.size() >= base_conversion_limb_bound(digits.size(), base));
+
+    const std::size_t chunks = base_conversion_chunk_count(digits.size(), base);
+    const std::size_t group  = fast_input_group_size(basecase_override);
+    const auto        cpl    = static_cast<std::size_t>(limb_max_input_digits(base));
+
+    // The ladder only starts once it can form two full leaf groups: a split
+    // into (group, runt) pays for the whole power chain to combine a sliver,
+    // which measures well below the straight basecase on both architectures.
+    if (chunks < 2 * group) {
+        const std::span<uint_multiprecision_t> acc  = scratch.allocate(chunks);
+        const std::size_t                      size = basecase_digits_to_limbs(acc, digits, base);
+        std::ranges::copy(acc.first(size), result.begin());
+        std::ranges::fill(result.subspan(size), uint_multiprecision_t{0});
+        scratch.deallocate(chunks);
+        return size;
+    }
+
+    const std::size_t                      arena_limbs = std::bit_ceil(chunks);
+    const std::span<uint_multiprecision_t> arena_a     = scratch.allocate(arena_limbs);
+    const std::span<uint_multiprecision_t> arena_b     = scratch.allocate(arena_limbs);
+
+    base_power_table table{};
+    build_power_table_for_chunks(table, chunks, base, scratch, alloc);
+
+    // Leaf groups are LSD-aligned like the chunks themselves (only the top
+    // group is short), each packed into its own stride of `group` limbs.
+    const std::size_t groups = div_to_pos_inf(chunks, group);
+    std::ranges::fill(arena_a.first(groups * group), uint_multiprecision_t{0});
+    for (std::size_t g = 0; g < groups; ++g) {
+        const std::size_t end   = digits.size() - g * group * cpl;
+        const std::size_t span  = group * cpl;
+        const std::size_t start = end > span ? end - span : 0;
+        [[maybe_unused]] const std::size_t size =
+            basecase_digits_to_limbs(arena_a.subspan(g * group, group), digits.subspan(start, end - start), base);
+    }
+
+    std::span<uint_multiprecision_t> cur   = arena_a;
+    std::span<uint_multiprecision_t> next  = arena_b;
+    std::size_t                      k     = groups;
+    std::size_t                      level = static_cast<std::size_t>(std::countr_zero(group));
+    while (k > 1) {
+        k = combine_level(next, cur, k, std::size_t{1} << level, table.entry[level], alloc);
+        std::swap(cur, next);
+        ++level;
+    }
+    BEMAN_BIG_INT_DEBUG_ASSERT((std::size_t{1} << level) == arena_limbs);
+
+    const std::span<const uint_multiprecision_t> final_value{cur.data(), arena_limbs};
+    const std::size_t                            size = trimmed_size_span(final_value);
+    std::ranges::copy(final_value.first(size), result.begin());
+    std::ranges::fill(result.subspan(size), uint_multiprecision_t{0});
+
+    scratch.deallocate(2 * arena_limbs + power_table_storage_size(chunks));
+    return size;
+}
+
+// Convenience overload owning the scratch workspace (the house dual-entry
+// pattern, cf. divide_burnikel_ziegler).
+template <class Allocator>
+    requires(!std::is_base_of_v<scratch_allocator_base, Allocator>)
+constexpr std::size_t digits_to_limbs(const std::span<uint_multiprecision_t> result,
+                                      const std::span<const unsigned char>   digits,
+                                      const int                              base,
+                                      Allocator&                             alloc,
+                                      const std::size_t                      basecase_override = 0) {
+    scratch_allocator<Allocator> scratch(digits_to_limbs_storage_size(digits.size(), base, basecase_override), alloc);
+    return digits_to_limbs(
+        result, digits, base, static_cast<scratch_allocator_base&>(scratch), alloc, basecase_override);
+}
+
+// ===========================================================================
+// FastIntegerOutput (MCA Algorithm 1.26)
+// ===========================================================================
+
+// Whether a recursive field keeps its full zero padding (interior fields are
+// exactly as wide as their power, the classic correctness trap) or trims
+// leading zeros (the leftmost spine and the public boundary).
+enum class digit_padding : unsigned char {
+    keep_leading_zeros,
+    trim_leading_zeros,
+};
+
+// Below this many chunks limbs_to_digits extracts a field with the repeated
+// short-division basecase instead of splitting by a power. Power of two
+// (fields tile the po2 chain) and at least 2 (split divisors must be
+// P_j, j >= 1, and the recursion steps down one level).
+//
+// Tuned with the base_conversion_bench output crossover sweep
+// (RelWithDebInfo, min-of-reps / median-of-samples, M4-class AArch64 +
+// i9-11900K x86-64, 2026-06-12): both architectures agree - the basecase
+// wins 16-chunk inputs by 10-18%, splitting wins 32-chunk inputs by 6-9%
+// and grows from there (the division basecase is far costlier than the
+// input direction's mul_1 Horner, so the ladder pays much earlier and no
+// per-arch split is warranted).
+inline constexpr std::size_t fast_output_basecase_chunks = 16;
+
+static_assert(std::has_single_bit(fast_output_basecase_chunks) && fast_output_basecase_chunks >= 2,
+              "output fields must tile the power-of-two chain and leave room to recurse");
+
+// Output field size: the tuned threshold, or the override clamped to a power
+// of two no smaller than 2 (the test-only deep-recursion escape hatch).
+[[nodiscard]] constexpr std::size_t fast_output_group_size(const std::size_t basecase_override) noexcept {
+    return basecase_override == 0 ? fast_output_basecase_chunks
+                                  : std::max<std::size_t>(std::bit_floor(basecase_override), 2);
+}
+
+// Powers at least this many limbs get a precomputed reciprocal and take the
+// invariant-divisor Barrett march instead of divide_dispatch. The tree's
+// divisions are balanced (dividend ~ twice the power), exactly the shapes
+// divide_dispatch routes to Barrett from barrett_balanced_cutoff dividend
+// limbs up - there the precomputed reciprocal is a pure saving. Below the
+// gate Burnikel-Ziegler wins those shapes even with the reciprocal free: a
+// 32768-limb gate measured 9-14% SLOWER whole-conversion at 3M-10M digits
+// on an M4-class machine (2026-06-12) by preempting B-Z at 32k-131k-limb
+// levels. Deriving from the dispatch gate keeps it per-arch and
+// NTT-configuration aware.
+inline constexpr std::size_t fast_output_preinv_min_limbs = barrett_balanced_cutoff / 2;
+
+// Bit width of a little-endian value span (0 for the value zero).
+[[nodiscard]] constexpr std::size_t value_bit_width(const std::span<const uint_multiprecision_t> v) noexcept {
+    BEMAN_BIG_INT_DEBUG_ASSERT(!v.empty());
+    BEMAN_BIG_INT_DEBUG_ASSERT(v.size() == 1 || v.back() != 0);
+    return (v.size() - 1) * width_v<uint_multiprecision_t> + static_cast<std::size_t>(std::bit_width(v.back()));
+}
+
+// Upper bound on the digits an n-limb value needs in `base` (the
+// to_basic_string sizing formula; overestimates by at most one digit).
+[[nodiscard]] constexpr std::size_t base_conversion_digit_bound(const std::span<const uint_multiprecision_t> value,
+                                                                const int                                     base) {
+    const std::size_t width = value_bit_width(value.first(trimmed_size_span(value)));
+    return width <= 1 ? std::size_t{1} : approximate_ceil_div_log2(width - 1, base) + 1;
+}
+
+// True when value(v) >= P (the entry's power, value * B^low_zero_limbs).
+// Decided by bit widths except in the equal-width band, where the stored
+// limbs are compared against the value's matching window.
+[[nodiscard]] constexpr bool value_reaches_power(const std::span<const uint_multiprecision_t> v,
+                                                 const base_power_entry&                      power) noexcept {
+    constexpr std::size_t limb_bits = width_v<uint_multiprecision_t>;
+
+    const std::size_t power_bits =
+        (power.low_zero_limbs + power.value.size() - 1) * limb_bits +
+        static_cast<std::size_t>(std::bit_width(power.value.back()));
+    const std::size_t value_bits = value_bit_width(v);
+    if (value_bits != power_bits) {
+        return value_bits > power_bits;
+    }
+    // Equal widths: v = v_hi * B^low + v_lo with v_hi the same width as the
+    // stored value, so v >= P exactly when v_hi >= value (v_lo only breaks
+    // the tie upward).
+    return compare_unsigned_spans(v.subspan(power.low_zero_limbs), power.value) != std::strong_ordering::less;
+}
+
+// ---------------------------------------------------------------------------
+// Builds the chain until the next square would certainly exceed `value`
+// (bit-width test: bits(P^2) >= 2 bits(P) - 1), so the top entry satisfies
+// P_top^2 > value - the emit invariant - at the cost of at most one level
+// whose power exceeds the value (the recursion descends through it for
+// free). Slots are tight (twice the previous stored size), unlike the
+// stride-sized slots of the chunk-count builder.
+// ---------------------------------------------------------------------------
+template <class Allocator>
+constexpr void build_power_table_for_value(base_power_table&                            table,
+                                           const std::span<const uint_multiprecision_t> value,
+                                           const int                                    base,
+                                           scratch_allocator_base&                      scratch,
+                                           Allocator&                                   alloc) {
+    BEMAN_BIG_INT_DEBUG_ASSERT(is_fast_conversion_base(base));
+
+    const std::size_t value_bits = value_bit_width(value);
+
+    std::size_t r = init_power_table(table, base, scratch);
+    while (true) {
+        const base_power_entry& top = table.entry[table.levels - 1];
+        const std::size_t       top_bits =
+            top.low_zero_limbs * width_v<uint_multiprecision_t> + value_bit_width(top.value);
+        if (2 * top_bits - 1 > value_bits) {
+            return;
+        }
+        append_squared_power(table, table.levels, 2 * top.value.size(), r, scratch, alloc);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Precomputed single-limb divisor for the output basecase loops. The chunk
+// peel calls divide_unsigned_short's algorithm with the reciprocal hoisted
+// out (recomputing it per chunk is a measurable share at basecase sizes),
+// and the digit expansion replaces `% base` / `/ base` outright - a runtime
+// base defeats the compiler's divide-by-constant strength reduction, leaving
+// a hardware divide per digit.
+// ---------------------------------------------------------------------------
+struct short_divisor {
+    uint_multiprecision_t norm  = 0; // divisor << shift, top bit set
+    uint_multiprecision_t recip = 0; // reciprocal_word(norm)
+    std::size_t           shift = 0;
+};
+
+[[nodiscard]] constexpr short_divisor make_short_divisor(const uint_multiprecision_t divisor) noexcept {
+    BEMAN_BIG_INT_DEBUG_ASSERT(divisor >= 2);
+    const auto                  shift = static_cast<std::size_t>(std::countl_zero(divisor));
+    const uint_multiprecision_t norm  = divisor << shift;
+    return {norm, reciprocal_word(norm), shift};
+}
+
+// In-place s.first(size) /= divisor; returns the remainder. The normalized
+// funnel of divide_unsigned_short with the reciprocal hoisted.
+[[nodiscard]] constexpr uint_multiprecision_t divide_short_preinv_in_place(const std::span<uint_multiprecision_t> s,
+                                                                           const std::size_t                      size,
+                                                                           const short_divisor& divisor) noexcept {
+    constexpr std::size_t limb_bits = width_v<uint_multiprecision_t>;
+    BEMAN_BIG_INT_DEBUG_ASSERT(size >= 1 && size <= s.size());
+
+    if (divisor.shift == 0) {
+        uint_multiprecision_t r = 0;
+        for (std::size_t i = size; i-- > 0;) {
+            const auto qr = div_2by1_preinv(
+                wide<uint_multiprecision_t>{.low_bits = s[i], .high_bits = r}, divisor.norm, divisor.recip);
+            s[i] = qr.quotient;
+            r    = qr.remainder;
+        }
+        return r;
+    }
+
+    uint_multiprecision_t cur = s[size - 1];
+    uint_multiprecision_t r   = cur >> (limb_bits - divisor.shift);
+    for (std::size_t i = size - 1; i > 0; --i) {
+        const uint_multiprecision_t next = s[i - 1];
+        const uint_multiprecision_t u    = funnel_shl(wide<uint_multiprecision_t>{.low_bits = next, .high_bits = cur},
+                                                   static_cast<unsigned>(divisor.shift));
+        const auto qr =
+            div_2by1_preinv(wide<uint_multiprecision_t>{.low_bits = u, .high_bits = r}, divisor.norm, divisor.recip);
+        s[i] = qr.quotient;
+        r    = qr.remainder;
+        cur  = next;
+    }
+    const auto qr = div_2by1_preinv(
+        wide<uint_multiprecision_t>{.low_bits = cur << divisor.shift, .high_bits = r}, divisor.norm, divisor.recip);
+    s[0] = qr.quotient;
+    return qr.remainder >> divisor.shift;
+}
+
+// ---------------------------------------------------------------------------
+// Attaches normalized values and reciprocal_span inverses to chain entries
+// of at least fast_output_preinv_min_limbs limbs (runtime only:
+// reciprocal_span and the Barrett march are compiled tiers). One reciprocal
+// per level then serves all of that level's balanced divisions. Entries
+// wider than half the value never see a balanced division (dividends by
+// P_j stay below P_j^2), so their reciprocal would be dead weight - the
+// root level often lands there when the chain stops close to the value.
+// Storage stays live in the caller's arena like the chain slots themselves.
+// ---------------------------------------------------------------------------
+inline void
+attach_power_reciprocals(base_power_table& table, const std::size_t value_limbs, scratch_allocator_base& scratch) {
+    constexpr std::size_t limb_bits = width_v<uint_multiprecision_t>;
+
+    for (std::size_t j = 1; j < table.levels; ++j) {
+        base_power_entry& entry = table.entry[j];
+        if (entry.value.size() < fast_output_preinv_min_limbs || 2 * entry.value.size() > value_limbs + 2) {
+            continue;
+        }
+        const std::size_t s     = entry.value.size();
+        const auto        shift = static_cast<std::size_t>(std::countl_zero(entry.value.back()));
+
+        std::span<const uint_multiprecision_t> norm = entry.value;
+        if (shift != 0) {
+            const std::span<uint_multiprecision_t> norm_slot = scratch.allocate(s);
+            std::ranges::copy(entry.value, norm_slot.begin());
+            const std::size_t norm_size = shift_left_n(norm_slot, s, static_cast<unsigned>(shift));
+            BEMAN_BIG_INT_DEBUG_ASSERT(norm_size == s);
+            norm = std::span<const uint_multiprecision_t>{norm_slot.data(), s};
+        }
+        BEMAN_BIG_INT_DEBUG_ASSERT(norm.back() >> (limb_bits - 1) == 1);
+
+        const std::span<uint_multiprecision_t> inv_slot = scratch.allocate(s);
+        reciprocal_span(inv_slot, norm, scratch);
+
+        entry.value_norm = norm;
+        entry.reciprocal = std::span<const uint_multiprecision_t>{inv_slot.data(), s};
+        entry.norm_shift = shift;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Digit expansion of a single chunk: plain hardware division. A
+// div_2by1_preinv replacement (the GMP fractional-limb lineage) was measured
+// and REJECTED on both architectures (2026-06-12): the M4-class hardware
+// divider beats the two-multiply chain by ~2 ns/digit, and on the i9-11900K
+// GCC fuses the % / pair into one divide, leaving plain expansion 3-13%
+// faster whole-conversion at 1k-30k digits.
+// ---------------------------------------------------------------------------
+
+// Writes `chunk` as exactly field.size() digit values, most significant
+// first (zero-padded).
+constexpr void write_chunk_digits(const std::span<unsigned char> field, uint_multiprecision_t chunk, const int base) {
+    const auto ubase = static_cast<uint_multiprecision_t>(base);
+    for (std::size_t d = field.size(); d-- > 0;) {
+        field[d] = static_cast<unsigned char>(chunk % ubase);
+        chunk /= ubase;
+    }
+    BEMAN_BIG_INT_DEBUG_ASSERT(chunk == 0);
+}
+
+// Writes `chunk` without leading zeros (value 0 -> one 0 digit); returns the
+// digit count.
+[[nodiscard]] constexpr std::size_t
+write_chunk_digits_trimmed(const std::span<unsigned char> out, uint_multiprecision_t chunk, const int base) {
+    const auto                    ubase = static_cast<uint_multiprecision_t>(base);
+    std::array<unsigned char, 64> reversed{};
+    std::size_t                   count = 0;
+    do {
+        BEMAN_BIG_INT_DEBUG_ASSERT(count < reversed.size());
+        reversed[count] = static_cast<unsigned char>(chunk % ubase);
+        chunk /= ubase;
+        ++count;
+    } while (chunk != 0);
+    for (std::size_t i = 0; i < count; ++i) {
+        out[i] = reversed[count - 1 - i];
+    }
+    return count;
+}
+
+// ---------------------------------------------------------------------------
+// Quadratic basecase: peels field_chunks chunks off a working copy of `v`
+// with repeated short divisions by big_base, then expands them MSD-first at
+// `pos`. keep_leading_zeros writes the field's full
+// field_chunks * chars_per_chunk digits; trim_leading_zeros writes only the
+// significant ones. Preconditions: `v` trimmed, value(v) < big_base ^
+// field_chunks; scratch holds field_chunks + v.size() limbs.
+// ---------------------------------------------------------------------------
+constexpr void basecase_limbs_to_digits(const std::span<unsigned char>               out,
+                                        std::size_t&                                 pos,
+                                        const std::span<const uint_multiprecision_t> v,
+                                        const std::size_t                            field_chunks,
+                                        const digit_padding                          padding,
+                                        const int                                    base,
+                                        scratch_allocator_base&                      scratch) {
+    const auto          cpl     = static_cast<std::size_t>(limb_max_input_digits(base));
+    const short_divisor big_div = make_short_divisor(limb_max_power(base));
+
+    const std::span<uint_multiprecision_t> staging = scratch.allocate(field_chunks);
+    const std::span<uint_multiprecision_t> work    = scratch.allocate(v.size());
+    std::ranges::copy(v, work.begin());
+
+    std::size_t size = v.size();
+    std::size_t top  = 0;
+    for (std::size_t i = 0; i < field_chunks; ++i) {
+        if (size == 1 && work[0] == 0) {
+            staging[i] = 0;
+            continue;
+        }
+        staging[i] = divide_short_preinv_in_place(work, size, big_div);
+        if (staging[i] != 0) {
+            top = i;
+        }
+        if (size > 1 && work[size - 1] == 0) {
+            --size;
+        }
+    }
+    BEMAN_BIG_INT_DEBUG_ASSERT(size == 1 && work[0] == 0);
+
+    if (padding == digit_padding::keep_leading_zeros) {
+        write_chunk_digits(out.subspan(pos, cpl), staging[field_chunks - 1], base);
+        pos += cpl;
+        for (std::size_t i = field_chunks - 1; i-- > 0;) {
+            write_chunk_digits(out.subspan(pos, cpl), staging[i], base);
+            pos += cpl;
+        }
+    } else {
+        pos += write_chunk_digits_trimmed(out.subspan(pos), staging[top], base);
+        for (std::size_t i = top; i-- > 0;) {
+            write_chunk_digits(out.subspan(pos, cpl), staging[i], base);
+            pos += cpl;
+        }
+    }
+    scratch.deallocate(field_chunks + v.size());
+}
+
+// ---------------------------------------------------------------------------
+// One MCA 1.26 node: a field of 2^(level + 1) chunks holding value(v) <
+// P_level^2. Fields at or below the leaf size take the basecase; a value
+// below P_level descends with the high half's zeros written (or skipped
+// under trim); otherwise DivRem by P_level = value * B^w via the nested
+// floor identity - only v >> w is divided by the trimmed power, and the
+// remainder is its remainder concatenated above the low w limbs. The
+// quotient spine inherits `padding`; the remainder field is emitted at
+// exactly 2^level chunks.
+// ---------------------------------------------------------------------------
+template <class Allocator>
+constexpr void emit_digits(const std::span<unsigned char>               out,
+                           std::size_t&                                 pos,
+                           const std::span<const uint_multiprecision_t> v,
+                           const std::size_t                            level,
+                           const digit_padding                          padding,
+                           const base_power_table&                      table,
+                           const std::size_t                            group,
+                           scratch_allocator_base&                      scratch,
+                           Allocator&                                   alloc) {
+    const std::size_t field = std::size_t{1} << (level + 1);
+    if (field <= group) {
+        basecase_limbs_to_digits(out, pos, v, field, padding, table.base, scratch);
+        return;
+    }
+
+    BEMAN_BIG_INT_DEBUG_ASSERT(level >= 1 && level < table.levels);
+    const base_power_entry& power = table.entry[level];
+
+    if (!value_reaches_power(v, power)) {
+        if (padding == digit_padding::keep_leading_zeros) {
+            const std::size_t zeros = (field / 2) * static_cast<std::size_t>(table.chars_per_chunk);
+            std::ranges::fill(out.subspan(pos, zeros), static_cast<unsigned char>(0));
+            pos += zeros;
+        }
+        emit_digits(out, pos, v, level - 1, padding, table, group, scratch, alloc);
+        return;
+    }
+
+    const std::size_t w    = power.low_zero_limbs;
+    const std::size_t m    = v.size();
+    const auto        v_hi = v.subspan(w);
+    BEMAN_BIG_INT_DEBUG_ASSERT(v_hi.size() >= power.value.size());
+
+    const std::size_t                      q_limbs = v_hi.size() - power.value.size() + 1;
+    const std::span<uint_multiprecision_t> q_buf   = scratch.allocate(q_limbs);
+    const std::span<uint_multiprecision_t> r_buf   = scratch.allocate(m + 1);
+    std::ranges::fill(q_buf, uint_multiprecision_t{0});
+    std::ranges::fill(r_buf, uint_multiprecision_t{0});
+    std::ranges::copy(v.first(w), r_buf.begin());
+
+    if (power.value.size() == 1) {
+        // Heavily trimmed even-base powers can collapse to one limb.
+        r_buf[w] = divide_unsigned_short(
+            q_buf.first(v_hi.size()), std::span<const uint_multiprecision_t>{v_hi}, power.value[0]);
+    } else if BEMAN_BIG_INT_IS_NOT_CONSTEVAL {
+        // The precomputed reciprocal only replaces divisions divide_dispatch
+        // would route to Barrett anyway (the balanced shape rule) - there it
+        // is a pure saving. Short-quotient nodes (the root when the chain
+        // lands close to the value) stay with the dispatch ladder: a forced
+        // 2-block march costs two full-width products no matter how small
+        // the quotient is, measured +16% whole-conversion at 3M-10M digits.
+        const bool balanced =
+            v_hi.size() >= barrett_balanced_cutoff && v_hi.size() - power.value.size() >= power.value.size();
+        if (!power.reciprocal.empty() && balanced) {
+            divide_barrett_preinv(q_buf,
+                                  r_buf.subspan(w),
+                                  v_hi,
+                                  power.value_norm,
+                                  static_cast<unsigned>(power.norm_shift),
+                                  power.reciprocal,
+                                  scratch);
+        } else {
+            divide_dispatch(q_buf, r_buf.subspan(w), v_hi, power.value, scratch, alloc);
+        }
+    } else {
+        divide_dispatch(q_buf, r_buf.subspan(w), v_hi, power.value, scratch, alloc);
+    }
+
+    const auto q_view = std::span<const uint_multiprecision_t>{q_buf}.first(
+        trimmed_size_span(std::span<const uint_multiprecision_t>{q_buf}));
+    const auto r_view = std::span<const uint_multiprecision_t>{r_buf}.first(
+        trimmed_size_span(std::span<const uint_multiprecision_t>{r_buf}));
+
+    emit_digits(out, pos, q_view, level - 1, padding, table, group, scratch, alloc);
+    emit_digits(out, pos, r_view, level - 1, digit_padding::keep_leading_zeros, table, group, scratch, alloc);
+
+    scratch.deallocate(q_limbs + m + 1);
+}
+
+// Scratch upper bound for limbs_to_digits over n limbs: the tight power
+// chain (< 4n), the per-level quotient/remainder path (geometric, < 4n plus
+// a few limbs per level), one schoolbook division transient (< 2n), and the
+// basecase staging + working copy - bounded by the leaf field size, itself
+// never beyond the value's own chunk capacity (~1.06n for the worst base).
+// Values large enough for the preinv tier additionally hold the normalized
+// powers and inverses (< 4(n + 2)), the reciprocal_span transient, and the
+// Barrett march workspace of the top-level division. Conservative, not
+// exact - node sizes depend on the value - and locked from above by the
+// peak() probes in base_conversion_output.test.cpp.
+[[nodiscard]] constexpr std::size_t limbs_to_digits_storage_size(const std::size_t limb_count,
+                                                                 const int         base,
+                                                                 const std::size_t basecase_override = 0) noexcept {
+    BEMAN_BIG_INT_DEBUG_ASSERT(is_fast_conversion_base(base));
+    const std::size_t staging =
+        std::min(fast_output_group_size(basecase_override), limb_count + limb_count / 8 + 4);
+    std::size_t total = 10 * limb_count + 2 * staging + 256;
+    if (limb_count >= fast_output_preinv_min_limbs) {
+        total += 4 * (limb_count + 2) + reciprocal_span_storage_size(limb_count + 2, reciprocal_span_cutoff) +
+                 barrett_preinv_storage_size(limb_count / 2 + 2, 4);
+    }
+    return total;
+}
+
+// ---------------------------------------------------------------------------
+// MCA Algorithm 1.26 FastIntegerOutput at chunk granularity: build the
+// squared power chain up to the value, then split top-down with DivRem,
+// remainder fields zero-padded to exactly their power's width and the
+// leftmost spine trimmed.
+// `value` holds little-endian limbs (untrimmed tolerated, not empty). `out`
+// must hold base_conversion_digit_bound(value, base) digits; out[0..count)
+// receives MSD-first digit values with no leading zeros (value 0 -> one 0
+// digit). Returns the exact digit count.
+// `scratch` must provide limbs_to_digits_storage_size(...) limbs for the
+// same `basecase_override`; the override forces a smaller leaf field
+// (clamped to a power of two >= 2) so tests recurse deeply on small inputs.
+// ---------------------------------------------------------------------------
+template <class Allocator>
+constexpr std::size_t limbs_to_digits(const std::span<unsigned char>               out,
+                                      const std::span<const uint_multiprecision_t> value,
+                                      const int                                    base,
+                                      scratch_allocator_base&                      scratch,
+                                      Allocator&                                   alloc,
+                                      const std::size_t                            basecase_override = 0) {
+    BEMAN_BIG_INT_DEBUG_ASSERT(!value.empty());
+    BEMAN_BIG_INT_DEBUG_ASSERT(is_fast_conversion_base(base));
+    BEMAN_BIG_INT_DEBUG_ASSERT(out.size() >= base_conversion_digit_bound(value, base));
+
+    const auto v     = value.first(trimmed_size_span(value));
+    const auto group = fast_output_group_size(basecase_override);
+    const auto cpl   = static_cast<std::size_t>(limb_max_input_digits(base));
+
+    std::size_t pos = 0;
+
+    const std::size_t chunk_bound = div_to_pos_inf(base_conversion_digit_bound(v, base), cpl);
+    if (chunk_bound <= group) {
+        basecase_limbs_to_digits(out, pos, v, chunk_bound, digit_padding::trim_leading_zeros, base, scratch);
+        return pos;
+    }
+
+    const std::size_t table_mark = scratch.m_offset;
+    base_power_table  table{};
+    build_power_table_for_value(table, v, base, scratch, alloc);
+    if BEMAN_BIG_INT_IS_NOT_CONSTEVAL {
+        if (v.size() >= 2 * fast_output_preinv_min_limbs) {
+            attach_power_reciprocals(table, v.size(), scratch);
+        }
+    }
+
+    emit_digits(out, pos, v, table.levels - 1, digit_padding::trim_leading_zeros, table, group, scratch, alloc);
+
+    scratch.deallocate(scratch.m_offset - table_mark);
+    return pos;
+}
+
+// Convenience overload owning the scratch workspace.
+template <class Allocator>
+    requires(!std::is_base_of_v<scratch_allocator_base, Allocator>)
+constexpr std::size_t limbs_to_digits(const std::span<unsigned char>               out,
+                                      const std::span<const uint_multiprecision_t> value,
+                                      const int                                    base,
+                                      Allocator&                                   alloc,
+                                      const std::size_t                            basecase_override = 0) {
+    scratch_allocator<Allocator> scratch(
+        limbs_to_digits_storage_size(trimmed_size_span(value), base, basecase_override), alloc);
+    return limbs_to_digits(out, value, base, static_cast<scratch_allocator_base&>(scratch), alloc, basecase_override);
+}
+
+} // namespace beman::big_int::detail
+
+#endif // BEMAN_BIG_INT_BASE_CONVERSION_HPP

--- a/include/beman/big_int/detail/base_conversion.hpp
+++ b/include/beman/big_int/detail/base_conversion.hpp
@@ -15,6 +15,7 @@
 #include <array>
 #include <bit>
 #include <cstddef>
+#include <memory>
 #include <span>
 #include <type_traits>
 
@@ -481,6 +482,79 @@ inline constexpr std::size_t fast_output_preinv_min_limbs = barrett_balanced_cut
     const std::size_t width = value_bit_width(value.first(trimmed_size_span(value)));
     return width <= 1 ? std::size_t{1} : approximate_ceil_div_log2(width - 1, base) + 1;
 }
+
+// ---------------------------------------------------------------------------
+// charconv integration glue. from_chars / to_chars route non-power-of-two bases
+// through the kernels above a per-direction size gate; below it the fixed cost
+// of a temporary digit-value buffer plus the kernel's owned scratch arena
+// outweighs the win, so small (common) inputs keep the inline path. The gates
+// are tuned at the whole-conversion crossover (the ASCII transcode included) --
+// the single tunable surface for the integration.
+// ---------------------------------------------------------------------------
+
+// from_chars routes to the kernel once the input reaches this many chunks. The
+// kernel's fused-Horner basecase already beats the charconv inline multiply-add
+// loop from ~3-4 chunks up -- far below the kernel's OWN ladder gate
+// (2 * fast_input_basecase_chunks) -- so the whole-conversion crossover (temp
+// buffer + scratch arena + ASCII transcode included) sits much earlier. Tuned
+// with the base_conversion_bench InputXover sweep (RelWithDebInfo, M4-class
+// AArch64 + i9-11900K x86-64, 2026-06-15): both arches break even at 2-4 chunks
+// and the kernel wins >= 1.6x by 8 chunks, growing from there. 8 (~150 base-10
+// digits) keeps small-number parsing on the zero-allocation inline path with
+// margin above the noisy floor.
+inline constexpr std::size_t fast_input_charconv_min_chunks = 8;
+
+[[nodiscard]] constexpr bool fast_digits_to_limbs_profitable(const std::size_t digit_count, const int base) noexcept {
+    return is_fast_conversion_base(base) &&
+           base_conversion_chunk_count(digit_count, base) >= fast_input_charconv_min_chunks;
+}
+
+// limbs_to_digits takes the ladder when ceil(digit_bound / cpl) > fast_output_basecase_chunks.
+[[nodiscard]] constexpr bool fast_limbs_to_digits_profitable(const std::span<const uint_multiprecision_t> value,
+                                                             const int base) noexcept {
+    if (!is_fast_conversion_base(base)) {
+        return false;
+    }
+    const auto        cpl    = static_cast<std::size_t>(limb_max_input_digits(base));
+    const std::size_t chunks = div_to_pos_inf(base_conversion_digit_bound(value, base), cpl);
+    return chunks > fast_output_basecase_chunks;
+}
+
+// ---------------------------------------------------------------------------
+// Owning, constexpr-safe scratch array of digit VALUES (0..base-1) for the
+// charconv glue: from_chars transcodes the validated ASCII run into one before
+// calling digits_to_limbs, and to_chars receives the MSD-first digits from
+// limbs_to_digits into one before mapping them to ASCII. Allocated through a
+// rebind of the big_int's own allocator so stateful / pmr allocators carry
+// through. Bytes are value-initialized to begin their lifetimes during
+// constant evaluation; every byte that is read is written first.
+// ---------------------------------------------------------------------------
+template <class LimbAllocator>
+class digit_value_buffer {
+    using byte_allocator = typename std::allocator_traits<LimbAllocator>::template rebind_alloc<unsigned char>;
+    using traits         = std::allocator_traits<byte_allocator>;
+
+  public:
+    constexpr digit_value_buffer(const LimbAllocator& alloc, const std::size_t count)
+        : m_alloc(alloc), m_count(count), m_data(traits::allocate(m_alloc, count)) {
+        for (std::size_t i = 0; i < count; ++i) {
+            std::construct_at(m_data + i, static_cast<unsigned char>(0));
+        }
+    }
+    constexpr ~digit_value_buffer() {
+        std::destroy_n(m_data, m_count);
+        traits::deallocate(m_alloc, m_data, m_count);
+    }
+    digit_value_buffer(const digit_value_buffer&)            = delete;
+    digit_value_buffer& operator=(const digit_value_buffer&) = delete;
+
+    [[nodiscard]] constexpr std::span<unsigned char> span() const noexcept { return {m_data, m_count}; }
+
+  private:
+    BEMAN_BIG_INT_NO_UNIQUE_ADDRESS byte_allocator m_alloc;
+    std::size_t                                    m_count;
+    unsigned char*                                 m_data;
+};
 
 // True when value(v) >= P (the entry's power, value * B^low_zero_limbs).
 // Decided by bit widths except in the equal-width band, where the stored

--- a/include/beman/big_int/detail/base_tables.hpp
+++ b/include/beman/big_int/detail/base_tables.hpp
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: BSL-1.0
+
+#ifndef BEMAN_BIG_INT_BASE_TABLES_HPP
+#define BEMAN_BIG_INT_BASE_TABLES_HPP
+
+#include <beman/big_int/detail/config.hpp>
+#include <beman/big_int/detail/wide_ops.hpp>
+#include <array>
+#include <bit>
+#include <cstddef>
+
+namespace beman::big_int::detail {
+
+[[nodiscard]] consteval unsigned char limb_max_input_digits_naive(const int base) {
+    BEMAN_BIG_INT_ASSERT(base >= 2);
+    const auto ubase = static_cast<uint_multiprecision_t>(base);
+    if (std::has_single_bit(ubase)) {
+        return detail::width_v<uint_multiprecision_t> / static_cast<unsigned char>(std::countr_zero(ubase));
+    }
+
+    uint_multiprecision_t x      = 1;
+    int                   result = 0;
+    while (true) {
+        const auto [product, overflow] = overflowing_mul(x, ubase);
+        if (overflow) {
+            return static_cast<unsigned char>(product == 0 ? result + 1 : result);
+        }
+        x = product;
+        ++result;
+        BEMAN_BIG_INT_ASSERT(product != 0);
+    }
+}
+
+inline constexpr auto limb_max_input_digits_table = []() consteval {
+    std::array<unsigned char, 37> result{};
+    for (std::size_t i = 2; i < result.size(); ++i) {
+        result[i] = limb_max_input_digits_naive(static_cast<int>(i));
+    }
+    return result;
+}();
+
+// Returns the amount of digits that `uint_multiprecision_t` can represent in the given base.
+// Mathematically, this is `floor(log(pow(2, width_v<uint_multiprecision_t>)) / log(base))`.
+[[nodiscard]] constexpr int limb_max_input_digits(const int base) {
+    BEMAN_BIG_INT_DEBUG_ASSERT(base >= 2 && base <= 36);
+    return limb_max_input_digits_table[std::size_t(base)];
+}
+
+[[nodiscard]] consteval uint_multiprecision_t limb_pow_naive(const uint_multiprecision_t x, const int y) {
+    uint_multiprecision_t result = 1;
+    for (int i = 0; i < y; ++i) {
+        result *= x;
+    }
+    return result;
+}
+
+inline constexpr auto limb_max_power_table = []() consteval {
+    std::array<uint_multiprecision_t, 37> result{};
+    for (std::size_t i = 2; i < result.size(); ++i) {
+        const int max_exponent = limb_max_input_digits(static_cast<int>(i));
+        result[i]              = limb_pow_naive(i, max_exponent);
+    }
+    return result;
+}();
+
+// Returns the greatest power of `base` representable in `uint_multiprecision_t`,
+// or zero if the next greater power is exactly `pow(2, width_v<uint_multiprecision_t>)`.
+//
+// A result of zero essentially communicates that no bit of `std::uint64_t` is wasted,
+// such as in the base-2 or base-16 case.
+[[nodiscard]] constexpr uint_multiprecision_t limb_max_power(const int base) {
+    BEMAN_BIG_INT_DEBUG_ASSERT(base >= 2 && base <= 36);
+    return limb_max_power_table[std::size_t(base)];
+}
+
+// Fixed-point ceil(log2(base)) coefficients in Q7.4 format.
+// Each entry stores ceil(log2(base) * 16), i.e. ceil(log2(base)) represented with 4 fractional bits.
+inline constexpr std::array<unsigned short, 37> approximate_ceil_mul_log2_q7_4_table{
+    0x00, 0x00, 0x10, 0x1A, 0x20, 0x26, 0x2A, 0x2D, 0x30, 0x33, 0x36, 0x38, 0x3A, 0x3C, 0x3D, 0x3F, 0x40, 0x42, 0x43,
+    0x44, 0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4D, 0x4E, 0x4F, 0x50, 0x50, 0x51, 0x52, 0x53, 0x53,
+};
+
+// Computes a fast approximation of the amount of bits
+// required to represent an integer in base `base` with `digit_count` digits.
+// Mathematically, this is `ceil(digit_count * log2(base))`.
+// For powers of two, the exact result is returned.
+[[nodiscard]] constexpr std::size_t approximate_ceil_mul_log2(const std::size_t digit_count, const int base) {
+    BEMAN_BIG_INT_DEBUG_ASSERT(base >= 2 && base <= 36);
+    constexpr std::size_t fractional_bits = 4;
+    constexpr std::size_t fractional_mask = (std::size_t{1} << fractional_bits) - 1;
+
+    const auto        coeff = static_cast<std::size_t>(approximate_ceil_mul_log2_q7_4_table[std::size_t(base)]);
+    const std::size_t scaled_result = digit_count * coeff;
+    return (scaled_result >> fractional_bits) + static_cast<std::size_t>((scaled_result & fractional_mask) != 0);
+}
+
+// Fixed-point ceil(1/log2(base)) coefficients in Q0.8 format.
+// Each entry stores ceil(256 / log2(base)) as an unsigned char.
+// Indices 0, 1, and 2 are unused; base 2 is handled separately in approximate_ceil_div_log2.
+inline constexpr std::array<unsigned char, 37> approximate_ceil_div_log2_q0_8_table{
+    0x00, 0x00, 0x00, 0xA2, 0x80, 0x6F, 0x64, 0x5C, 0x56, 0x51, 0x4E, 0x4B, 0x48, 0x46, 0x44, 0x42, 0x40, 0x3F, 0x3E,
+    0x3D, 0x3C, 0x3B, 0x3A, 0x39, 0x38, 0x38, 0x37, 0x36, 0x36, 0x35, 0x35, 0x34, 0x34, 0x33, 0x33, 0x32, 0x32,
+};
+
+// Computes a fast approximation of `ceil(x / log2(base))`.
+// For base 2, the exact result is returned.
+[[nodiscard]] constexpr std::size_t approximate_ceil_div_log2(const std::size_t x, const int base) {
+    BEMAN_BIG_INT_DEBUG_ASSERT(base >= 2 && base <= 36);
+    constexpr std::size_t fractional_bits = 8;
+    constexpr std::size_t fractional_mask = (std::size_t{1} << fractional_bits) - 1;
+
+    if (base == 2) {
+        return x;
+    }
+    const auto coeff = static_cast<std::size_t>(approximate_ceil_div_log2_q0_8_table[static_cast<std::size_t>(base)]);
+    const std::size_t scaled_result = x * coeff;
+    return (scaled_result >> fractional_bits) + static_cast<std::size_t>((scaled_result & fractional_mask) != 0);
+}
+
+} // namespace beman::big_int::detail
+
+#endif // BEMAN_BIG_INT_BASE_TABLES_HPP

--- a/include/beman/big_int/detail/div_impl.hpp
+++ b/include/beman/big_int/detail/div_impl.hpp
@@ -855,6 +855,33 @@ void divide_barrett(const std::span<uint_multiprecision_t>       quotient,
         quotient, remainder, dividend, divisor, static_cast<scratch_allocator_base&>(scratch), invert_override);
 }
 
+// Scratch upper bound for divide_barrett_preinv: barrett_storage_size minus
+// the divisor/reciprocal slots and the reciprocal computation arm - the
+// caller holds those once per invariant divisor.
+[[nodiscard]] constexpr std::size_t barrett_preinv_storage_size(const std::size_t block_limbs,
+                                                                const std::size_t blocks) noexcept {
+    const std::size_t w = multiply_mod_bnm1_next_size(block_limbs + 1, multiply_mod_bnm1_cutoff);
+    return (2 * blocks - 1) * block_limbs + 2 * block_limbs + 2 * w + multiply_mod_bnm1_storage_size(w) + 8;
+}
+
+// ---------------------------------------------------------------------------
+// Invariant-divisor Barrett division (the radix-conversion entry the
+// reciprocal_span notes anticipate): same outer contract as divide_barrett,
+// but the divisor arrives pre-normalized (`d_norm`, top bit set; the
+// original divisor is d_norm >> shift) with its exact scaled reciprocal
+// precomputed by reciprocal_span(inv, d_norm, ...). One reciprocal then
+// serves any number of divisions by the same divisor. Fully rewinds its
+// scratch (barrett_preinv_storage_size(d_norm.size(), barrett_blocks(...))
+// limbs) before returning, so repeated calls share one arena.
+// ---------------------------------------------------------------------------
+void divide_barrett_preinv(std::span<uint_multiprecision_t>       quotient,
+                           std::span<uint_multiprecision_t>       remainder,
+                           std::span<const uint_multiprecision_t> dividend,
+                           std::span<const uint_multiprecision_t> d_norm,
+                           unsigned                               shift,
+                           std::span<const uint_multiprecision_t> inv,
+                           scratch_allocator_base&                scratch);
+
 // ---------------------------------------------------------------------------
 // Top-level division dispatcher (counterpart of multiply_dispatch): the
 // divide-and-conquer path needs both a large divisor and a long quotient to

--- a/src/divide.cpp
+++ b/src/divide.cpp
@@ -870,9 +870,8 @@ void divide_barrett_preinv(const std::span<uint_multiprecision_t>       quotient
 
     // The block count of barrett_blocks on the unshifted divisor: its
     // leading-zero count is exactly `shift`.
-    const std::size_t dividend_bits =
-        (m - 1) * limb_bits + static_cast<std::size_t>(std::bit_width(dividend.back()));
-    const std::size_t t = std::max<std::size_t>(2, (dividend_bits + shift) / (n * limb_bits) + 1);
+    const std::size_t dividend_bits = (m - 1) * limb_bits + static_cast<std::size_t>(std::bit_width(dividend.back()));
+    const std::size_t t             = std::max<std::size_t>(2, (dividend_bits + shift) / (n * limb_bits) + 1);
 
     const std::span<uint_multiprecision_t> w = scratch.allocate(t * n);
     std::ranges::fill(w, uint_multiprecision_t{0});

--- a/src/divide.cpp
+++ b/src/divide.cpp
@@ -696,52 +696,29 @@ void reciprocal_span(const std::span<uint_multiprecision_t>       inverse,
 // X > B^2n/d - 1. The correction loop adds d back accordingly.
 // `invert_override` forwards to reciprocal_span (test-only escape hatch).
 // ---------------------------------------------------------------------------
-void divide_barrett(const std::span<uint_multiprecision_t>       quotient,
-                    const std::span<uint_multiprecision_t>       remainder,
-                    const std::span<const uint_multiprecision_t> dividend,
-                    const std::span<const uint_multiprecision_t> divisor,
-                    scratch_allocator_base&                      scratch,
-                    const std::size_t                            invert_override) {
-    BEMAN_BIG_INT_DEBUG_ASSERT(divisor.size() >= 2);
-    BEMAN_BIG_INT_DEBUG_ASSERT(divisor.back() != 0);
-    BEMAN_BIG_INT_DEBUG_ASSERT(!dividend.empty());
-    BEMAN_BIG_INT_DEBUG_ASSERT(dividend.back() != 0);
-    BEMAN_BIG_INT_DEBUG_ASSERT(dividend.size() >= divisor.size());
-    BEMAN_BIG_INT_DEBUG_ASSERT(quotient.size() >= dividend.size() - divisor.size() + 1);
-    BEMAN_BIG_INT_DEBUG_ASSERT(remainder.size() >= dividend.size() + 1);
+// ---------------------------------------------------------------------------
+// Shared block march of the Barrett drivers: the dividend arrives pre-shifted
+// into t = w.size() / d.size() blocks (`w`), the divisor pre-normalized
+// (`d`, top bit set) with its exact scaled reciprocal (`inv`), and `shift`
+// is the normalization undone on the final remainder window. Allocates only
+// the march products (rewound before returning); `w` holds the remainder
+// chain and `q_work` the concatenated quotient blocks.
+// ---------------------------------------------------------------------------
+namespace {
 
-    const std::size_t n = divisor.size();
-    const std::size_t m = dividend.size();
-    const std::size_t t = barrett_blocks(dividend, divisor);
-
-    const unsigned shift = static_cast<unsigned>(std::countl_zero(divisor.back()));
-
-    // Normalized divisor view (top bit set).
-    std::span<const uint_multiprecision_t> d = divisor;
-    if (shift != 0) {
-        const std::span<uint_multiprecision_t> d_norm = scratch.allocate(n);
-        std::ranges::copy(divisor, d_norm.begin());
-        const std::size_t d_size = shift_left_n(d_norm, n, shift);
-        BEMAN_BIG_INT_DEBUG_ASSERT(d_size == n);
-        d = d_norm.first(d_size);
-    }
-
-    // w = dividend << shift, zero-extended to t blocks of n limbs.
-    const std::span<uint_multiprecision_t> w = scratch.allocate(t * n);
-    std::ranges::fill(w, uint_multiprecision_t{0});
-    std::ranges::copy(dividend, w.begin());
-    if (shift != 0) {
-        const std::size_t w_size = shift_left_n(w, m, shift);
-        BEMAN_BIG_INT_DEBUG_ASSERT(w_size <= t * n);
-    }
-
-    const std::span<uint_multiprecision_t> q_work = scratch.allocate((t - 1) * n);
-
-    // The exact reciprocal of the normalized divisor; its computation scratch
-    // rewinds before the standing block products below are allocated.
-    const std::span<uint_multiprecision_t> inv = scratch.allocate(n);
-    reciprocal_span(inv, d, scratch, invert_override);
-    const auto inv_view = std::span<const uint_multiprecision_t>{inv.data(), inv.size()};
+void barrett_march(const std::span<uint_multiprecision_t>       quotient,
+                   const std::span<uint_multiprecision_t>       remainder,
+                   const std::span<uint_multiprecision_t>       w,
+                   const std::span<uint_multiprecision_t>       q_work,
+                   const std::span<const uint_multiprecision_t> d,
+                   const std::span<const uint_multiprecision_t> inv,
+                   const unsigned                               shift,
+                   scratch_allocator_base&                      scratch) {
+    const std::size_t n = d.size();
+    const std::size_t t = w.size() / n;
+    BEMAN_BIG_INT_DEBUG_ASSERT(w.size() == t * n);
+    BEMAN_BIG_INT_DEBUG_ASSERT(q_work.size() == (t - 1) * n);
+    BEMAN_BIG_INT_DEBUG_ASSERT(inv.size() == n);
 
     // The estimate product stays full (its high half is needed exactly); the
     // q_hat * d_hat subtrahend only matters mod B^wrap - 1 because the true
@@ -761,7 +738,7 @@ void divide_barrett(const std::span<uint_multiprecision_t>       quotient,
 
         // q_hat = U_hi + high_half(U_hi * X) where X = B^n + I.
         std::ranges::fill(p, uint_multiprecision_t{0});
-        multiply_runtime_any(p, u_hi, inv_view, scratch.heap());
+        multiply_runtime_any(p, u_hi, inv, scratch.heap());
         const bool q_carry =
             add_unsigned_spans(q_block, u_hi, std::span<const uint_multiprecision_t>{p.data() + n, n});
         BEMAN_BIG_INT_DEBUG_ASSERT(!q_carry);
@@ -817,6 +794,102 @@ void divide_barrett(const std::span<uint_multiprecision_t>       quotient,
     }
     std::ranges::copy(w.first(n), remainder.begin());
     std::ranges::fill(remainder.subspan(n), uint_multiprecision_t{0});
+}
+
+} // namespace
+
+void divide_barrett(const std::span<uint_multiprecision_t>       quotient,
+                    const std::span<uint_multiprecision_t>       remainder,
+                    const std::span<const uint_multiprecision_t> dividend,
+                    const std::span<const uint_multiprecision_t> divisor,
+                    scratch_allocator_base&                      scratch,
+                    const std::size_t                            invert_override) {
+    BEMAN_BIG_INT_DEBUG_ASSERT(divisor.size() >= 2);
+    BEMAN_BIG_INT_DEBUG_ASSERT(divisor.back() != 0);
+    BEMAN_BIG_INT_DEBUG_ASSERT(!dividend.empty());
+    BEMAN_BIG_INT_DEBUG_ASSERT(dividend.back() != 0);
+    BEMAN_BIG_INT_DEBUG_ASSERT(dividend.size() >= divisor.size());
+    BEMAN_BIG_INT_DEBUG_ASSERT(quotient.size() >= dividend.size() - divisor.size() + 1);
+    BEMAN_BIG_INT_DEBUG_ASSERT(remainder.size() >= dividend.size() + 1);
+
+    const std::size_t n = divisor.size();
+    const std::size_t m = dividend.size();
+    const std::size_t t = barrett_blocks(dividend, divisor);
+
+    const unsigned shift = static_cast<unsigned>(std::countl_zero(divisor.back()));
+
+    // Normalized divisor view (top bit set).
+    std::span<const uint_multiprecision_t> d = divisor;
+    if (shift != 0) {
+        const std::span<uint_multiprecision_t> d_norm = scratch.allocate(n);
+        std::ranges::copy(divisor, d_norm.begin());
+        const std::size_t d_size = shift_left_n(d_norm, n, shift);
+        BEMAN_BIG_INT_DEBUG_ASSERT(d_size == n);
+        d = d_norm.first(d_size);
+    }
+
+    // w = dividend << shift, zero-extended to t blocks of n limbs.
+    const std::span<uint_multiprecision_t> w = scratch.allocate(t * n);
+    std::ranges::fill(w, uint_multiprecision_t{0});
+    std::ranges::copy(dividend, w.begin());
+    if (shift != 0) {
+        const std::size_t w_size = shift_left_n(w, m, shift);
+        BEMAN_BIG_INT_DEBUG_ASSERT(w_size <= t * n);
+    }
+
+    const std::span<uint_multiprecision_t> q_work = scratch.allocate((t - 1) * n);
+
+    // The exact reciprocal of the normalized divisor; its computation scratch
+    // rewinds before the standing block products below are allocated.
+    const std::span<uint_multiprecision_t> inv = scratch.allocate(n);
+    reciprocal_span(inv, d, scratch, invert_override);
+
+    barrett_march(quotient, remainder, w, q_work, d, std::span<const uint_multiprecision_t>{inv}, shift, scratch);
+}
+
+void divide_barrett_preinv(const std::span<uint_multiprecision_t>       quotient,
+                           const std::span<uint_multiprecision_t>       remainder,
+                           const std::span<const uint_multiprecision_t> dividend,
+                           const std::span<const uint_multiprecision_t> d_norm,
+                           const unsigned                               shift,
+                           const std::span<const uint_multiprecision_t> inv,
+                           scratch_allocator_base&                      scratch) {
+    constexpr std::size_t limb_bits = width_v<uint_multiprecision_t>;
+    BEMAN_BIG_INT_DEBUG_ASSERT(d_norm.size() >= 2);
+    BEMAN_BIG_INT_DEBUG_ASSERT(d_norm.back() >> (limb_bits - 1) == 1);
+    BEMAN_BIG_INT_DEBUG_ASSERT(inv.size() == d_norm.size());
+    BEMAN_BIG_INT_DEBUG_ASSERT(shift < limb_bits);
+    BEMAN_BIG_INT_DEBUG_ASSERT(!dividend.empty());
+    BEMAN_BIG_INT_DEBUG_ASSERT(dividend.back() != 0);
+    BEMAN_BIG_INT_DEBUG_ASSERT(dividend.size() >= d_norm.size());
+    BEMAN_BIG_INT_DEBUG_ASSERT(quotient.size() >= dividend.size() - d_norm.size() + 1);
+    BEMAN_BIG_INT_DEBUG_ASSERT(remainder.size() >= dividend.size() + 1);
+
+    const std::size_t n = d_norm.size();
+    const std::size_t m = dividend.size();
+
+    // The block count of barrett_blocks on the unshifted divisor: its
+    // leading-zero count is exactly `shift`.
+    const std::size_t dividend_bits =
+        (m - 1) * limb_bits + static_cast<std::size_t>(std::bit_width(dividend.back()));
+    const std::size_t t = std::max<std::size_t>(2, (dividend_bits + shift) / (n * limb_bits) + 1);
+
+    const std::span<uint_multiprecision_t> w = scratch.allocate(t * n);
+    std::ranges::fill(w, uint_multiprecision_t{0});
+    std::ranges::copy(dividend, w.begin());
+    if (shift != 0) {
+        const std::size_t w_size = shift_left_n(w, m, shift);
+        BEMAN_BIG_INT_DEBUG_ASSERT(w_size <= t * n);
+    }
+
+    const std::span<uint_multiprecision_t> q_work = scratch.allocate((t - 1) * n);
+
+    barrett_march(quotient, remainder, w, q_work, d_norm, inv, shift, scratch);
+
+    // Fully rewind: unlike divide_barrett (one shot per owned workspace),
+    // this entry runs many times against one long-lived scratch.
+    scratch.deallocate((t - 1) * n);
+    scratch.deallocate(t * n);
 }
 
 // Convenience overload: sizes and owns the workspace, then forwards to the

--- a/tests/beman/big_int/base_conversion_bench.test.cpp
+++ b/tests/beman/big_int/base_conversion_bench.test.cpp
@@ -51,9 +51,9 @@
 
 namespace local {
 
-namespace detail  = ::beman::big_int::detail;
-using uint_t      = ::beman::big_int::uint_multiprecision_t;
-using stopwatch   = ::beman::big_int::benchmark_testing::stopwatch;
+namespace detail = ::beman::big_int::detail;
+using uint_t     = ::beman::big_int::uint_multiprecision_t;
+using stopwatch  = ::beman::big_int::benchmark_testing::stopwatch;
 
 inline constexpr unsigned reps_per_point    = 5;
 inline constexpr unsigned samples_per_point = 3;
@@ -139,7 +139,7 @@ double run_from_chars_at(const std::size_t len, const int base) {
     return measure_ns(len, base, [&](const std::vector<unsigned char>& digits) {
         auto text = std::make_shared<std::string>(ascii_of(digits));
         return [text, &base]() {
-            ::beman::big_int::big_int value;
+            ::beman::big_int::big_int                     value;
             [[maybe_unused]] const std::from_chars_result result =
                 ::beman::big_int::from_chars(text->data(), text->data() + text->size(), value, base);
         };
@@ -161,8 +161,8 @@ double run_fast_out_at(const std::size_t len, const int base, const std::size_t 
 
 double run_to_chars_at(const std::size_t len, const int base) {
     return measure_ns(len, base, [&](const std::vector<unsigned char>& digits) {
-        auto value = std::make_shared<::beman::big_int::big_int>();
-        const auto text = ascii_of(digits);
+        auto                                          value = std::make_shared<::beman::big_int::big_int>();
+        const auto                                    text  = ascii_of(digits);
         [[maybe_unused]] const std::from_chars_result parsed =
             ::beman::big_int::from_chars(text.data(), text.data() + text.size(), *value, base);
         auto out = std::make_shared<std::vector<char>>(digits.size() + 8, '\0');
@@ -201,8 +201,14 @@ void run_sweep() {
     }
 
     // Crossover: pure basecase vs one and two ladder levels at the same size.
-    for (const std::size_t group : {std::size_t{8}, std::size_t{16}, std::size_t{32}, std::size_t{64},
-                                    std::size_t{128}, std::size_t{256}, std::size_t{512}, std::size_t{1024}}) {
+    for (const std::size_t group : {std::size_t{8},
+                                    std::size_t{16},
+                                    std::size_t{32},
+                                    std::size_t{64},
+                                    std::size_t{128},
+                                    std::size_t{256},
+                                    std::size_t{512},
+                                    std::size_t{1024}}) {
         for (const std::size_t mult : {std::size_t{2}, std::size_t{4}}) {
             const std::size_t chunks = mult * group;
             const std::size_t len    = chunks * cpl;
@@ -213,9 +219,15 @@ void run_sweep() {
     }
 
     // Headline curves.
-    for (const std::size_t len : {std::size_t{1000}, std::size_t{3000}, std::size_t{10000}, std::size_t{30000},
-                                  std::size_t{100000}, std::size_t{300000}, std::size_t{1000000},
-                                  std::size_t{3000000}, std::size_t{10000000}}) {
+    for (const std::size_t len : {std::size_t{1000},
+                                  std::size_t{3000},
+                                  std::size_t{10000},
+                                  std::size_t{30000},
+                                  std::size_t{100000},
+                                  std::size_t{300000},
+                                  std::size_t{1000000},
+                                  std::size_t{3000000},
+                                  std::size_t{10000000}}) {
         emit("input_fast", base, len, run_fast_at(len, base, 0));
         if (len <= 300000) {
             emit("input_basecase", base, len, run_fast_at(len, base, std::size_t{1} << 30));
@@ -251,8 +263,13 @@ void run_sweep() {
 
     // Output crossover: pure short-division basecase vs one and two split
     // levels at the same size (tunes fast_output_basecase_chunks).
-    for (const std::size_t group : {std::size_t{4}, std::size_t{8}, std::size_t{16}, std::size_t{32},
-                                    std::size_t{64}, std::size_t{128}, std::size_t{256}}) {
+    for (const std::size_t group : {std::size_t{4},
+                                    std::size_t{8},
+                                    std::size_t{16},
+                                    std::size_t{32},
+                                    std::size_t{64},
+                                    std::size_t{128},
+                                    std::size_t{256}}) {
         for (const std::size_t mult : {std::size_t{2}, std::size_t{4}}) {
             const std::size_t chunks = mult * group;
             const std::size_t len    = chunks * cpl;
@@ -267,9 +284,15 @@ void run_sweep() {
 
     // Output headline curves (compare with the input rows above for the
     // div-vs-mul ratio).
-    for (const std::size_t len : {std::size_t{1000}, std::size_t{3000}, std::size_t{10000}, std::size_t{30000},
-                                  std::size_t{100000}, std::size_t{300000}, std::size_t{1000000},
-                                  std::size_t{3000000}, std::size_t{10000000}}) {
+    for (const std::size_t len : {std::size_t{1000},
+                                  std::size_t{3000},
+                                  std::size_t{10000},
+                                  std::size_t{30000},
+                                  std::size_t{100000},
+                                  std::size_t{300000},
+                                  std::size_t{1000000},
+                                  std::size_t{3000000},
+                                  std::size_t{10000000}}) {
         emit("output_fast", base, len, run_fast_out_at(len, base, 0));
         if (len <= 100000) {
             emit("output_basecase", base, len, run_fast_out_at(len, base, std::size_t{1} << 30));
@@ -290,9 +313,18 @@ void run_sweep() {
 void run_input_xover() {
     std::cout << "kernel,base,digits,chunks,ns_per_op\n";
     const int base = 10;
-    for (const std::size_t len : {std::size_t{19}, std::size_t{38}, std::size_t{57}, std::size_t{76},
-                                  std::size_t{95}, std::size_t{133}, std::size_t{190}, std::size_t{285},
-                                  std::size_t{500}, std::size_t{1000}, std::size_t{2000}, std::size_t{5000}}) {
+    for (const std::size_t len : {std::size_t{19},
+                                  std::size_t{38},
+                                  std::size_t{57},
+                                  std::size_t{76},
+                                  std::size_t{95},
+                                  std::size_t{133},
+                                  std::size_t{190},
+                                  std::size_t{285},
+                                  std::size_t{500},
+                                  std::size_t{1000},
+                                  std::size_t{2000},
+                                  std::size_t{5000}}) {
         emit("xover_from_chars", base, len, run_from_chars_at(len, base));
         emit("xover_fast", base, len, run_fast_at(len, base, 0));
         std::cout.flush();
@@ -309,8 +341,11 @@ void run_input_xover() {
 void run_po2_sweep() {
     std::cout << "kernel,base,digits,chunks,ns_per_op\n";
     for (const int base : {2, 8, 16, 32}) {
-        for (const std::size_t len : {std::size_t{1000}, std::size_t{10000}, std::size_t{100000},
-                                      std::size_t{1000000}, std::size_t{10000000}}) {
+        for (const std::size_t len : {std::size_t{1000},
+                                      std::size_t{10000},
+                                      std::size_t{100000},
+                                      std::size_t{1000000},
+                                      std::size_t{10000000}}) {
             emit("po2_from_chars", base, len, run_from_chars_at(len, base));
             emit("po2_to_chars", base, len, run_to_chars_at(len, base));
             std::cout.flush();

--- a/tests/beman/big_int/base_conversion_bench.test.cpp
+++ b/tests/beman/big_int/base_conversion_bench.test.cpp
@@ -55,7 +55,7 @@ namespace detail  = ::beman::big_int::detail;
 using uint_t      = ::beman::big_int::uint_multiprecision_t;
 using stopwatch   = ::beman::big_int::benchmark_testing::stopwatch;
 
-inline constexpr unsigned reps_per_point   = 5;
+inline constexpr unsigned reps_per_point    = 5;
 inline constexpr unsigned samples_per_point = 3;
 
 // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp)
@@ -220,7 +220,7 @@ void run_sweep() {
         if (len <= 300000) {
             emit("input_basecase", base, len, run_fast_at(len, base, std::size_t{1} << 30));
         }
-        if (len <= 1000000) {
+        if (len <= 10000000) {
             emit("input_from_chars", base, len, run_from_chars_at(len, base));
         }
         std::cout.flush();
@@ -234,12 +234,19 @@ void run_sweep() {
         std::cout.flush();
     }
 
-    // Base spread: even bases (trimmed powers) vs odd controls.
+    // Base spread: even bases (trimmed powers) vs odd controls. For the
+    // before/after charconv-integration sweep we emit both kernel directions
+    // and the public from_chars/to_chars at moderate sizes so the speedup
+    // table spans bases, not just base 10. (1M is the long pole for the naive
+    // output baseline; per-base stops there -- base 10 carries 3M/10M.)
     for (const int spot_base : {3, 7, 10, 26, 36}) {
-        for (const std::size_t len : {std::size_t{10000}, std::size_t{1000000}}) {
+        for (const std::size_t len : {std::size_t{10000}, std::size_t{100000}, std::size_t{1000000}}) {
             emit("input_fast", spot_base, len, run_fast_at(len, spot_base, 0));
+            emit("output_fast", spot_base, len, run_fast_out_at(len, spot_base, 0));
+            emit("input_from_chars", spot_base, len, run_from_chars_at(len, spot_base));
+            emit("output_to_chars", spot_base, len, run_to_chars_at(len, spot_base));
+            std::cout.flush();
         }
-        std::cout.flush();
     }
 
     // Output crossover: pure short-division basecase vs one and two split
@@ -267,9 +274,27 @@ void run_sweep() {
         if (len <= 100000) {
             emit("output_basecase", base, len, run_fast_out_at(len, base, std::size_t{1} << 30));
         }
-        if (len <= 1000000) {
+        if (len <= 3000000) {
             emit("output_to_chars", base, len, run_to_chars_at(len, base));
         }
+        std::cout.flush();
+    }
+}
+
+// Input-gate crossover probe (run in isolation: --gtest_filter=*InputXover*).
+// from_chars under the compiled gate vs the kernel-only ceiling at fine sizes
+// spanning the sub-gate band. Build with
+// -DBEMAN_BIG_INT_INPUT_CHARCONV_MIN_CHUNKS=2 (forces kernel+glue) and with a
+// huge value (forces the inline baseline), then compare xover_from_chars across
+// the two runs to find where the whole conversion first beats the inline loop.
+void run_input_xover() {
+    std::cout << "kernel,base,digits,chunks,ns_per_op\n";
+    const int base = 10;
+    for (const std::size_t len : {std::size_t{19}, std::size_t{38}, std::size_t{57}, std::size_t{76},
+                                  std::size_t{95}, std::size_t{133}, std::size_t{190}, std::size_t{285},
+                                  std::size_t{500}, std::size_t{1000}, std::size_t{2000}, std::size_t{5000}}) {
+        emit("xover_from_chars", base, len, run_from_chars_at(len, base));
+        emit("xover_fast", base, len, run_fast_at(len, base, 0));
         std::cout.flush();
     }
 }
@@ -279,6 +304,15 @@ void run_sweep() {
 TEST(BaseConversion, InputBench) {
 #ifdef BEMAN_BIG_INT_RUN_BENCHMARKS
     local::run_sweep();
+    SUCCEED();
+#else
+    GTEST_SKIP() << "Benchmarks not run (define BEMAN_BIG_INT_RUN_BENCHMARKS to enable)";
+#endif
+}
+
+TEST(BaseConversion, InputXover) {
+#ifdef BEMAN_BIG_INT_RUN_BENCHMARKS
+    local::run_input_xover();
     SUCCEED();
 #else
     GTEST_SKIP() << "Benchmarks not run (define BEMAN_BIG_INT_RUN_BENCHMARKS to enable)";

--- a/tests/beman/big_int/base_conversion_bench.test.cpp
+++ b/tests/beman/big_int/base_conversion_bench.test.cpp
@@ -299,6 +299,25 @@ void run_input_xover() {
     }
 }
 
+// Power-of-two coverage (run in isolation: --gtest_filter=*Po2Bench*). po2 bases
+// never touch the sub-quadratic kernels; from_chars/to_chars handle them with
+// O(n) bit-oriented chunk loops. Bases 2 and 16 exercise the max_pow == 0 path
+// (one digit block maps to exactly one limb), 8 and 32 the general is_pow_2 path
+// (funnel-shift writes). to_chars emits digits with direct shift/mask; from_chars
+// currently parses each chunk with std::from_chars -- this sweep measures whether
+// that costs against the bit-aligned ideal.
+void run_po2_sweep() {
+    std::cout << "kernel,base,digits,chunks,ns_per_op\n";
+    for (const int base : {2, 8, 16, 32}) {
+        for (const std::size_t len : {std::size_t{1000}, std::size_t{10000}, std::size_t{100000},
+                                      std::size_t{1000000}, std::size_t{10000000}}) {
+            emit("po2_from_chars", base, len, run_from_chars_at(len, base));
+            emit("po2_to_chars", base, len, run_to_chars_at(len, base));
+            std::cout.flush();
+        }
+    }
+}
+
 } // namespace local
 
 TEST(BaseConversion, InputBench) {
@@ -313,6 +332,15 @@ TEST(BaseConversion, InputBench) {
 TEST(BaseConversion, InputXover) {
 #ifdef BEMAN_BIG_INT_RUN_BENCHMARKS
     local::run_input_xover();
+    SUCCEED();
+#else
+    GTEST_SKIP() << "Benchmarks not run (define BEMAN_BIG_INT_RUN_BENCHMARKS to enable)";
+#endif
+}
+
+TEST(BaseConversion, Po2Bench) {
+#ifdef BEMAN_BIG_INT_RUN_BENCHMARKS
+    local::run_po2_sweep();
     SUCCEED();
 #else
     GTEST_SKIP() << "Benchmarks not run (define BEMAN_BIG_INT_RUN_BENCHMARKS to enable)";

--- a/tests/beman/big_int/base_conversion_bench.test.cpp
+++ b/tests/beman/big_int/base_conversion_bench.test.cpp
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: BSL-1.0
+//
+// Benchmark for tuning fast_input_basecase_chunks (and, in a later phase, the
+// FastIntegerOutput thresholds). Three sweeps:
+//   crossover  - at 2G and 4G chunks, the pure fused-Horner basecase
+//                (override = whole input) against the ladder splitting at G
+//                (override = G). The threshold is the first G where splitting
+//                wins; crossovers are sawtoothed (recursion-depth
+//                boundaries), so points report the MIN over repetitions.
+//   curve      - digits_to_limbs with tuned defaults vs the pure basecase vs
+//                the public from_chars, log-spaced base-10 sizes.
+//   lone-top   - 2^k vs 2^k + 1 chunks: the cost of Algorithm 1.25's
+//                unmultiplied lone top element (balanced-splitting probe).
+//   bases      - spot bases: even bases ride the trimmed-power trick, odd
+//                bases are the control.
+//
+// Output-vs-input ratio (2026-06-12, tuned configs): 2.7x on the M4-class
+// box and 2.3x on the i9-11900K at 10M digits - the y-cruncher
+// two-products-per-level expectation. A Bouvier-Zimmermann scaled remainder
+// tree (division-free output, MCA exercise 1.35) is the known next step if
+// that ratio ever matters: their integer-conversion crossover was ~250k
+// limbs, so prototype the middle-product level (multiply_mod_bnm1 wraparound
+// machinery) against the preinv Barrett march before committing.
+//
+// Disabled by default. To run:
+//   cmake --preset appleclang-release (build dir carries
+//     CMAKE_CXX_FLAGS=-DBEMAN_BIG_INT_RUN_BENCHMARKS=1)
+//   cmake --build build/appleclang-release
+//   ./build/appleclang-release/tests/beman/big_int/beman.big_int.tests.base_conversion_bench
+//
+// Output is CSV on stdout: kernel,base,digits,chunks,ns_per_op.
+
+#include <beman/big_int/big_int.hpp>
+#include <beman/big_int/detail/base_conversion.hpp>
+
+#include <gtest/gtest.h>
+
+#include "benchmark_testing.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <random>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace local {
+
+namespace detail  = ::beman::big_int::detail;
+using uint_t      = ::beman::big_int::uint_multiprecision_t;
+using stopwatch   = ::beman::big_int::benchmark_testing::stopwatch;
+
+inline constexpr unsigned reps_per_point   = 5;
+inline constexpr unsigned samples_per_point = 3;
+
+// NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp)
+static std::mt19937_64 rng{0xBA5EULL};
+
+std::vector<unsigned char> random_digits(const std::size_t len, const int base) {
+    std::uniform_int_distribution<int> dist(0, base - 1);
+    std::vector<unsigned char>         digits(len);
+    for (auto& d : digits) {
+        d = static_cast<unsigned char>(dist(rng));
+    }
+    if (digits[0] == 0) {
+        digits[0] = 1;
+    }
+    return digits;
+}
+
+// Per digit sample: `make(digits)` builds the timed closure (untimed
+// per-sample setup such as string or limb conversion), then the minimum over
+// reps_per_point repetitions of `iters` calls is taken; across samples: the
+// median. `iters` self-scales off a warmup shot so every repetition lands in
+// the low milliseconds.
+template <class MakeFn>
+double measure_ns(const std::size_t len, const int base, MakeFn make) {
+    std::array<double, samples_per_point> sample_ns{};
+    for (unsigned sample = 0; sample < samples_per_point; ++sample) {
+        const auto digits = random_digits(len, base);
+        auto       fn     = make(digits);
+
+        const stopwatch warmup{};
+        fn();
+        const double   shot  = std::max(stopwatch::elapsed_time<double>(warmup), 1.0e-9);
+        const unsigned iters = static_cast<unsigned>(std::clamp(0.005 / shot, 1.0, 5000.0));
+
+        double best = 1.0e300;
+        for (unsigned rep = 0; rep < reps_per_point; ++rep) {
+            const stopwatch sw{};
+            for (unsigned i = 0; i < iters; ++i) {
+                fn();
+            }
+            best = std::min(best, stopwatch::elapsed_time<double>(sw) / iters);
+        }
+        sample_ns[sample] = best;
+    }
+    std::ranges::sort(sample_ns);
+    return sample_ns[samples_per_point / 2] * 1.0e9;
+}
+
+std::string ascii_of(const std::vector<unsigned char>& digits) {
+    std::string text(digits.size(), '0');
+    for (std::size_t i = 0; i < digits.size(); ++i) {
+        const auto d = digits[i];
+        text[i]      = static_cast<char>(d < 10 ? '0' + d : 'a' + (d - 10));
+    }
+    return text;
+}
+
+// Output benches run on the value of the random digit string so input and
+// output rows at the same (base, digits) describe the same number.
+std::vector<uint_t> value_of_digits(const std::vector<unsigned char>& digits, const int base) {
+    std::vector<uint_t>    limbs(detail::base_conversion_limb_bound(digits.size(), base), 0);
+    std::allocator<uint_t> alloc;
+    const std::size_t      count =
+        detail::digits_to_limbs(std::span<uint_t>{limbs}, std::span<const unsigned char>{digits}, base, alloc);
+    limbs.resize(count);
+    return limbs;
+}
+
+double run_fast_at(const std::size_t len, const int base, const std::size_t basecase_override) {
+    return measure_ns(len, base, [&](const std::vector<unsigned char>& digits) {
+        auto out = std::make_shared<std::vector<uint_t>>(detail::base_conversion_limb_bound(len, base), 0);
+        return [&digits, &base, &basecase_override, out]() {
+            std::allocator<uint_t> alloc;
+            detail::digits_to_limbs(
+                std::span<uint_t>{*out}, std::span<const unsigned char>{digits}, base, alloc, basecase_override);
+        };
+    });
+}
+
+double run_from_chars_at(const std::size_t len, const int base) {
+    return measure_ns(len, base, [&](const std::vector<unsigned char>& digits) {
+        auto text = std::make_shared<std::string>(ascii_of(digits));
+        return [text, &base]() {
+            ::beman::big_int::big_int value;
+            [[maybe_unused]] const std::from_chars_result result =
+                ::beman::big_int::from_chars(text->data(), text->data() + text->size(), value, base);
+        };
+    });
+}
+
+double run_fast_out_at(const std::size_t len, const int base, const std::size_t basecase_override) {
+    return measure_ns(len, base, [&](const std::vector<unsigned char>& digits) {
+        auto value = std::make_shared<std::vector<uint_t>>(value_of_digits(digits, base));
+        auto out   = std::make_shared<std::vector<unsigned char>>(
+            detail::base_conversion_digit_bound(std::span<const uint_t>{*value}, base), 0);
+        return [value, out, &base, &basecase_override]() {
+            std::allocator<uint_t>             alloc;
+            [[maybe_unused]] const std::size_t count = detail::limbs_to_digits(
+                std::span<unsigned char>{*out}, std::span<const uint_t>{*value}, base, alloc, basecase_override);
+        };
+    });
+}
+
+double run_to_chars_at(const std::size_t len, const int base) {
+    return measure_ns(len, base, [&](const std::vector<unsigned char>& digits) {
+        auto value = std::make_shared<::beman::big_int::big_int>();
+        const auto text = ascii_of(digits);
+        [[maybe_unused]] const std::from_chars_result parsed =
+            ::beman::big_int::from_chars(text.data(), text.data() + text.size(), *value, base);
+        auto out = std::make_shared<std::vector<char>>(digits.size() + 8, '\0');
+        return [value, out, &base]() {
+            [[maybe_unused]] const std::to_chars_result result =
+                ::beman::big_int::to_chars(out->data(), out->data() + out->size(), *value, base);
+        };
+    });
+}
+
+void emit(const char* kernel, const int base, const std::size_t len, const double ns) {
+    const std::size_t chunks = detail::base_conversion_chunk_count(len, base);
+    std::cout << kernel << ',' << base << ',' << len << ',' << chunks << ',' << std::fixed << std::setprecision(1)
+              << ns << '\n';
+}
+
+void run_sweep() {
+    std::cout << "kernel,base,digits,chunks,ns_per_op\n";
+    const int  base = 10;
+    const auto cpl  = static_cast<std::size_t>(detail::limb_max_input_digits(base));
+
+    // One large round-trip guards the preinv Barrett tier, which only
+    // engages at bench scales: digits -> limbs -> digits must be identity.
+    {
+        const auto                 digits = random_digits(3000000, base);
+        const auto                 value  = value_of_digits(digits, base);
+        std::vector<unsigned char> out(detail::base_conversion_digit_bound(std::span<const uint_t>{value}, base), 0);
+        std::allocator<uint_t>     alloc;
+        const std::size_t          count =
+            detail::limbs_to_digits(std::span<unsigned char>{out}, std::span<const uint_t>{value}, base, alloc);
+        out.resize(count);
+        if (out != digits) {
+            std::cout << "FATAL: 3M-digit round-trip mismatch\n";
+            std::abort();
+        }
+    }
+
+    // Crossover: pure basecase vs one and two ladder levels at the same size.
+    for (const std::size_t group : {std::size_t{8}, std::size_t{16}, std::size_t{32}, std::size_t{64},
+                                    std::size_t{128}, std::size_t{256}, std::size_t{512}, std::size_t{1024}}) {
+        for (const std::size_t mult : {std::size_t{2}, std::size_t{4}}) {
+            const std::size_t chunks = mult * group;
+            const std::size_t len    = chunks * cpl;
+            emit(mult == 2 ? "basecase_2g" : "basecase_4g", base, len, run_fast_at(len, base, chunks));
+            emit(mult == 2 ? "split_2g" : "split_4g", base, len, run_fast_at(len, base, group));
+            std::cout.flush();
+        }
+    }
+
+    // Headline curves.
+    for (const std::size_t len : {std::size_t{1000}, std::size_t{3000}, std::size_t{10000}, std::size_t{30000},
+                                  std::size_t{100000}, std::size_t{300000}, std::size_t{1000000},
+                                  std::size_t{3000000}, std::size_t{10000000}}) {
+        emit("input_fast", base, len, run_fast_at(len, base, 0));
+        if (len <= 300000) {
+            emit("input_basecase", base, len, run_fast_at(len, base, std::size_t{1} << 30));
+        }
+        if (len <= 1000000) {
+            emit("input_from_chars", base, len, run_from_chars_at(len, base));
+        }
+        std::cout.flush();
+    }
+
+    // Lone-top probe: the odd element passes through every level unmultiplied.
+    for (const std::size_t k : {std::size_t{10}, std::size_t{12}}) {
+        const std::size_t pow2 = std::size_t{1} << k;
+        emit("lone_top_even", base, pow2 * cpl, run_fast_at(pow2 * cpl, base, 0));
+        emit("lone_top_odd", base, (pow2 + 1) * cpl, run_fast_at((pow2 + 1) * cpl, base, 0));
+        std::cout.flush();
+    }
+
+    // Base spread: even bases (trimmed powers) vs odd controls.
+    for (const int spot_base : {3, 7, 10, 26, 36}) {
+        for (const std::size_t len : {std::size_t{10000}, std::size_t{1000000}}) {
+            emit("input_fast", spot_base, len, run_fast_at(len, spot_base, 0));
+        }
+        std::cout.flush();
+    }
+
+    // Output crossover: pure short-division basecase vs one and two split
+    // levels at the same size (tunes fast_output_basecase_chunks).
+    for (const std::size_t group : {std::size_t{4}, std::size_t{8}, std::size_t{16}, std::size_t{32},
+                                    std::size_t{64}, std::size_t{128}, std::size_t{256}}) {
+        for (const std::size_t mult : {std::size_t{2}, std::size_t{4}}) {
+            const std::size_t chunks = mult * group;
+            const std::size_t len    = chunks * cpl;
+            emit(mult == 2 ? "out_basecase_2g" : "out_basecase_4g",
+                 base,
+                 len,
+                 run_fast_out_at(len, base, std::size_t{1} << 30));
+            emit(mult == 2 ? "out_split_2g" : "out_split_4g", base, len, run_fast_out_at(len, base, group));
+            std::cout.flush();
+        }
+    }
+
+    // Output headline curves (compare with the input rows above for the
+    // div-vs-mul ratio).
+    for (const std::size_t len : {std::size_t{1000}, std::size_t{3000}, std::size_t{10000}, std::size_t{30000},
+                                  std::size_t{100000}, std::size_t{300000}, std::size_t{1000000},
+                                  std::size_t{3000000}, std::size_t{10000000}}) {
+        emit("output_fast", base, len, run_fast_out_at(len, base, 0));
+        if (len <= 100000) {
+            emit("output_basecase", base, len, run_fast_out_at(len, base, std::size_t{1} << 30));
+        }
+        if (len <= 1000000) {
+            emit("output_to_chars", base, len, run_to_chars_at(len, base));
+        }
+        std::cout.flush();
+    }
+}
+
+} // namespace local
+
+TEST(BaseConversion, InputBench) {
+#ifdef BEMAN_BIG_INT_RUN_BENCHMARKS
+    local::run_sweep();
+    SUCCEED();
+#else
+    GTEST_SKIP() << "Benchmarks not run (define BEMAN_BIG_INT_RUN_BENCHMARKS to enable)";
+#endif
+}

--- a/tests/beman/big_int/base_conversion_input.test.cpp
+++ b/tests/beman/big_int/base_conversion_input.test.cpp
@@ -1,0 +1,397 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: BSL-1.0
+//
+// Exercises digits_to_limbs (MCA Algorithm 1.25 FastIntegerInput) directly at
+// the span level. Results are cross-checked against a per-digit Horner
+// reference built from span primitives, a chunk-level Horner reference for
+// large inputs, and Boost cpp_int as an independent third opinion. The edge
+// matrix covers chunk boundaries, big_base^k +- 1 carry chains, odd/even
+// element counts at every ladder level, and the fully-written contract.
+
+#include <beman/big_int/detail/base_conversion.hpp>
+#include <beman/big_int/detail/span_ops.hpp>
+
+#include <gtest/gtest.h>
+
+#include <boost/multiprecision/cpp_int.hpp>
+
+#include <array>
+#include <cstddef>
+#include <iterator>
+#include <memory>
+#include <random>
+#include <span>
+#include <vector>
+
+namespace {
+
+namespace detail = beman::big_int::detail;
+using uint_t     = beman::big_int::uint_multiprecision_t;
+
+// Per-digit Horner reference using only span primitives: value = value * base + d.
+// Independent of the chunking scheme; quadratic, so reserved for short inputs.
+std::vector<uint_t> horner_ref(const std::span<const unsigned char> digits, const int base) {
+    std::vector<uint_t> value{0};
+    std::vector<uint_t> product;
+    for (const unsigned char d : digits) {
+        product.assign(value.size() + 1, 0);
+        [[maybe_unused]] const std::size_t product_size = detail::multiply_single_limb(
+            std::span<uint_t>{product}, std::span<const uint_t>{value}, static_cast<uint_t>(base));
+        const uint_t                addend[1] = {static_cast<uint_t>(d)};
+        [[maybe_unused]] const bool carry     = detail::add_unsigned_spans(
+            std::span<uint_t>{product}, std::span<const uint_t>{product}, std::span<const uint_t>{addend});
+        product.resize(detail::trimmed_size_span(std::span<const uint_t>{product}));
+        value = product;
+    }
+    return value;
+}
+
+// Chunk-level Horner reference: packs limb_max_input_digits(base) digits per
+// chunk (top chunk short) and folds value = value * big_base + chunk. Still
+// independent of the divide-and-conquer ladder, but only O(chunks^2).
+std::vector<uint_t> chunk_horner_ref(const std::span<const unsigned char> digits, const int base) {
+    const auto   cpl      = static_cast<std::size_t>(detail::limb_max_input_digits(base));
+    const uint_t big_base = detail::limb_max_power(base);
+
+    const std::size_t top_width = digits.size() % cpl == 0 ? cpl : digits.size() % cpl;
+
+    const auto pack = [&](const std::size_t pos, const std::size_t width) {
+        uint_t chunk = 0;
+        for (std::size_t i = 0; i < width; ++i) {
+            chunk = chunk * static_cast<uint_t>(base) + static_cast<uint_t>(digits[pos + i]);
+        }
+        return chunk;
+    };
+
+    std::vector<uint_t> value{pack(0, top_width)};
+    std::vector<uint_t> product;
+    for (std::size_t pos = top_width; pos < digits.size(); pos += cpl) {
+        product.assign(value.size() + 1, 0);
+        [[maybe_unused]] const std::size_t product_size =
+            detail::multiply_single_limb(std::span<uint_t>{product}, std::span<const uint_t>{value}, big_base);
+        const uint_t                addend[1] = {pack(pos, cpl)};
+        [[maybe_unused]] const bool carry     = detail::add_unsigned_spans(
+            std::span<uint_t>{product}, std::span<const uint_t>{product}, std::span<const uint_t>{addend});
+        product.resize(detail::trimmed_size_span(std::span<const uint_t>{product}));
+        value = product;
+    }
+    return value;
+}
+
+// Boost cpp_int reference, exported to little-endian limbs.
+std::vector<uint_t> cpp_int_ref(const std::span<const unsigned char> digits, const int base) {
+    boost::multiprecision::cpp_int acc = 0;
+    for (const unsigned char d : digits) {
+        acc *= base;
+        acc += d;
+    }
+    std::vector<uint_t> limbs;
+    boost::multiprecision::export_bits(acc, std::back_inserter(limbs), detail::width_v<uint_t>, false);
+    if (limbs.empty()) {
+        limbs.push_back(0);
+    }
+    return limbs;
+}
+
+// Runs the fast path and checks the fully-written contract: the buffer is
+// poisoned beforehand, the count is in [1, bound], and everything above the
+// count is zero. Returns the trimmed limbs.
+std::vector<uint_t>
+run_fast(const std::span<const unsigned char> digits, const int base, const std::size_t basecase_override = 0) {
+    const std::size_t   bound = detail::base_conversion_limb_bound(digits.size(), base);
+    std::vector<uint_t> out(bound, static_cast<uint_t>(0xfefefefe));
+
+    std::allocator<uint_t> alloc;
+    const std::size_t      count = detail::digits_to_limbs(
+        std::span<uint_t>{out}, std::span<const unsigned char>{digits}, base, alloc, basecase_override);
+
+    EXPECT_GE(count, 1u);
+    EXPECT_LE(count, bound);
+    if (count > 0) {
+        EXPECT_TRUE(count == 1 || out[count - 1] != 0);
+    }
+    for (std::size_t i = count; i < out.size(); ++i) {
+        EXPECT_EQ(out[i], 0u) << "limb " << i << " above the count is not zero";
+    }
+    out.resize(count);
+    return out;
+}
+
+std::vector<unsigned char> random_digits(const std::size_t len, const int base, std::mt19937_64& rng) {
+    std::uniform_int_distribution<int> dist(0, base - 1);
+    std::vector<unsigned char>         digits(len);
+    for (auto& d : digits) {
+        d = static_cast<unsigned char>(dist(rng));
+    }
+    return digits;
+}
+
+constexpr std::array<int, 30> non_power_of_two_bases = {3,  5,  6,  7,  9,  10, 11, 12, 13, 14, 15, 17, 18, 19, 20,
+                                                        21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 33, 34, 35, 36};
+
+TEST(BaseConversionInput, ZeroValues) {
+    for (const int base : {3, 10, 36}) {
+        const auto cpl = static_cast<std::size_t>(detail::limb_max_input_digits(base));
+        for (const std::size_t len : {std::size_t{1}, cpl, cpl + 1, 4 * cpl}) {
+            const std::vector<unsigned char> digits(len, 0);
+            const std::vector<uint_t>        expected{0};
+            EXPECT_EQ(run_fast(digits, base), expected) << "base " << base << " len " << len;
+        }
+    }
+}
+
+TEST(BaseConversionInput, SingleChunkValues) {
+    std::mt19937_64 rng{0xba5e1};
+    for (const int base : {3, 10, 36}) {
+        const auto cpl = static_cast<std::size_t>(detail::limb_max_input_digits(base));
+        for (std::size_t len = 1; len <= cpl; ++len) {
+            const auto digits = random_digits(len, base, rng);
+            EXPECT_EQ(run_fast(digits, base), horner_ref(digits, base)) << "base " << base << " len " << len;
+        }
+    }
+}
+
+TEST(BaseConversionInput, ChunkCountsExhaustive) {
+    std::mt19937_64 rng{0xba5e2};
+    for (const int base : {3, 10, 36}) {
+        const auto cpl = static_cast<std::size_t>(detail::limb_max_input_digits(base));
+        for (std::size_t chunks = 1; chunks <= 65; ++chunks) {
+            // Full top chunk and a one-digit top chunk per count.
+            for (const std::size_t len : {chunks * cpl, (chunks - 1) * cpl + 1}) {
+                const auto digits = random_digits(len, base, rng);
+                const auto fast   = run_fast(digits, base);
+                EXPECT_EQ(fast, chunk_horner_ref(digits, base)) << "base " << base << " len " << len;
+                // Forced leaf-group sizes drive the ladder deep on these
+                // small inputs so every level shape is hit cheaply.
+                for (const std::size_t override_group : {std::size_t{1}, std::size_t{2}, std::size_t{8}}) {
+                    EXPECT_EQ(run_fast(digits, base, override_group), fast)
+                        << "base " << base << " len " << len << " group " << override_group;
+                }
+                if (chunks <= 8) {
+                    EXPECT_EQ(fast, horner_ref(digits, base)) << "base " << base << " len " << len;
+                    EXPECT_EQ(fast, cpp_int_ref(digits, base)) << "base " << base << " len " << len;
+                }
+            }
+        }
+    }
+}
+
+TEST(BaseConversionInput, PowerBoundaryValues) {
+    for (const int base : {3, 10, 36}) {
+        const auto cpl = static_cast<std::size_t>(detail::limb_max_input_digits(base));
+        for (const std::size_t k : {std::size_t{1}, std::size_t{2}, std::size_t{3}, std::size_t{7}, std::size_t{8},
+                                    std::size_t{15}, std::size_t{16}, std::size_t{31}, std::size_t{32},
+                                    std::size_t{33}, std::size_t{64}}) {
+            // big_base^k: "1" followed by k * cpl zeros.
+            std::vector<unsigned char> digits(k * cpl + 1, 0);
+            digits[0] = 1;
+            EXPECT_EQ(run_fast(digits, base), chunk_horner_ref(digits, base)) << "base " << base << " k " << k;
+
+            // big_base^k + 1: "1", zeros, trailing "1".
+            digits.back() = 1;
+            EXPECT_EQ(run_fast(digits, base), chunk_horner_ref(digits, base)) << "base " << base << " k " << k;
+
+            // big_base^k - 1: (base - 1) repeated k * cpl times. Maximal carry chains.
+            const std::vector<unsigned char> nines(k * cpl, static_cast<unsigned char>(base - 1));
+            EXPECT_EQ(run_fast(nines, base), chunk_horner_ref(nines, base)) << "base " << base << " k " << k;
+        }
+    }
+}
+
+TEST(BaseConversionInput, InteriorZeroRuns) {
+    std::mt19937_64 rng{0xba5e3};
+    const int       base = 10;
+    const auto      cpl  = static_cast<std::size_t>(detail::limb_max_input_digits(base));
+
+    for (const std::size_t zero_chunks : {std::size_t{1}, std::size_t{5}, std::size_t{40}}) {
+        const auto                 prefix = random_digits(5, base, rng);
+        const auto                 suffix = random_digits(5, base, rng);
+        std::vector<unsigned char> digits;
+        digits.insert(digits.end(), prefix.begin(), prefix.end());
+        digits.insert(digits.end(), zero_chunks * cpl, static_cast<unsigned char>(0));
+        digits.insert(digits.end(), suffix.begin(), suffix.end());
+        EXPECT_EQ(run_fast(digits, base), chunk_horner_ref(digits, base)) << "zero chunks " << zero_chunks;
+    }
+}
+
+TEST(BaseConversionInput, OddEvenLevelCounts) {
+    std::mt19937_64 rng{0xba5e4};
+    const int       base = 10;
+    const auto      cpl  = static_cast<std::size_t>(detail::limb_max_input_digits(base));
+
+    for (std::size_t k = 1; k <= 10; ++k) {
+        const std::size_t pow2 = std::size_t{1} << k;
+        for (const std::size_t chunks : {pow2 - 1, pow2, pow2 + 1, 3 * pow2 + 1}) {
+            const auto digits = random_digits(chunks * cpl, base, rng);
+            EXPECT_EQ(run_fast(digits, base), chunk_horner_ref(digits, base)) << "chunks " << chunks;
+        }
+    }
+}
+
+TEST(BaseConversionInput, AllBasesSampled) {
+    std::mt19937_64 rng{0xba5e5};
+    for (const int base : non_power_of_two_bases) {
+        for (const std::size_t len : {std::size_t{1}, std::size_t{7}, std::size_t{100}, std::size_t{1000},
+                                      std::size_t{5000}}) {
+            const auto digits = random_digits(len, base, rng);
+            const auto fast   = run_fast(digits, base);
+            EXPECT_EQ(fast, chunk_horner_ref(digits, base)) << "base " << base << " len " << len;
+            if (len <= 100) {
+                EXPECT_EQ(fast, cpp_int_ref(digits, base)) << "base " << base << " len " << len;
+            }
+        }
+    }
+}
+
+TEST(BaseConversionInput, Base10Dense) {
+    std::mt19937_64 rng{0xba5e6};
+    const int       base = 10;
+
+    for (std::size_t len = 1; len <= 200; ++len) {
+        const auto digits = random_digits(len, base, rng);
+        const auto fast   = run_fast(digits, base);
+        EXPECT_EQ(fast, horner_ref(digits, base)) << "len " << len;
+        EXPECT_EQ(fast, cpp_int_ref(digits, base)) << "len " << len;
+    }
+    for (const std::size_t len :
+         {std::size_t{500}, std::size_t{1000}, std::size_t{2000}, std::size_t{5000}, std::size_t{20000},
+          std::size_t{50000}}) {
+        const auto digits = random_digits(len, base, rng);
+        EXPECT_EQ(run_fast(digits, base), chunk_horner_ref(digits, base)) << "len " << len;
+    }
+
+    // A huge override forces the pure fused-Horner basecase at a size the
+    // ladder would normally own.
+    const auto digits = random_digits(5000, base, rng);
+    EXPECT_EQ(run_fast(digits, base, std::size_t{1} << 20), chunk_horner_ref(digits, base));
+}
+
+TEST(BaseConversionInput, LeadingZeros) {
+    std::mt19937_64 rng{0xba5e7};
+    for (const int base : {3, 10, 36}) {
+        const auto cpl   = static_cast<std::size_t>(detail::limb_max_input_digits(base));
+        const auto value = random_digits(3 * cpl + 2, base, rng);
+
+        const auto expected = run_fast(value, base);
+        for (const std::size_t zeros : {std::size_t{1}, cpl, 3 * cpl}) {
+            std::vector<unsigned char> digits(zeros, 0);
+            digits.insert(digits.end(), value.begin(), value.end());
+            EXPECT_EQ(run_fast(digits, base), expected) << "base " << base << " zeros " << zeros;
+        }
+    }
+}
+
+TEST(BaseConversionInput, ScratchPeakWithinBound) {
+    std::mt19937_64 rng{0xba5e8};
+    for (const int base : {3, 10}) {
+        const auto cpl = static_cast<std::size_t>(detail::limb_max_input_digits(base));
+        for (const std::size_t chunks :
+             {std::size_t{2}, std::size_t{3}, std::size_t{5}, std::size_t{8}, std::size_t{33}, std::size_t{1024}}) {
+            // Default leaf group plus forced sizes covering the pure-ladder
+            // and mixed shapes.
+            for (const std::size_t override_group : {std::size_t{0}, std::size_t{1}, std::size_t{4}}) {
+                const std::size_t len    = chunks * cpl - 1;
+                const auto        digits = random_digits(len, base, rng);
+
+                const std::size_t      storage = detail::digits_to_limbs_storage_size(len, base, override_group);
+                std::allocator<uint_t> alloc;
+                detail::scratch_allocator<std::allocator<uint_t>> scratch(storage, alloc);
+
+                std::vector<uint_t> out(detail::base_conversion_limb_bound(len, base), 0);
+                const std::size_t   count =
+                    detail::digits_to_limbs(std::span<uint_t>{out},
+                                            std::span<const unsigned char>{digits},
+                                            base,
+                                            static_cast<detail::scratch_allocator_base&>(scratch),
+                                            alloc,
+                                            override_group);
+
+                EXPECT_EQ(scratch.peak(), storage)
+                    << "the storage model is exact; base " << base << " chunks " << chunks << " group "
+                    << override_group;
+
+                out.resize(count);
+                EXPECT_EQ(out, chunk_horner_ref(digits, base)) << "base " << base << " chunks " << chunks;
+            }
+        }
+    }
+}
+
+TEST(BaseConversionInput, FusedKernelMatchesMultiplyAdd) {
+    std::mt19937_64 rng{0xba5e9};
+    for (const std::size_t size : {std::size_t{1}, std::size_t{2}, std::size_t{3}, std::size_t{17}}) {
+        for (int rep = 0; rep < 50; ++rep) {
+            std::vector<uint_t> value(size);
+            for (auto& limb : value) {
+                limb = static_cast<uint_t>(rng());
+            }
+            const auto mul = static_cast<uint_t>(rng() | 1);
+            const auto add = static_cast<uint_t>(rng());
+
+            std::vector<uint_t> expected(size + 1, 0);
+            [[maybe_unused]] const std::size_t product_size = detail::multiply_single_limb(
+                std::span<uint_t>{expected}, std::span<const uint_t>{value}, mul);
+            const uint_t                addend[1] = {add};
+            [[maybe_unused]] const bool carry     = detail::add_unsigned_spans(
+                std::span<uint_t>{expected}, std::span<const uint_t>{expected}, std::span<const uint_t>{addend});
+            expected.resize(detail::trimmed_size_span(std::span<const uint_t>{expected}));
+
+            std::vector<uint_t> fused = value;
+            fused.push_back(static_cast<uint_t>(0xfefefefe));
+            const std::size_t fused_size =
+                detail::mul_add_single_limb_in_place(std::span<uint_t>{fused}, size, mul, add);
+
+            ASSERT_LE(fused_size, fused.size());
+            fused.resize(fused_size);
+            EXPECT_EQ(fused, expected) << "size " << size;
+        }
+    }
+}
+
+// Constant-evaluation smoke test against an inline per-digit Horner,
+// limb-width agnostic. Group 0 takes the tuned leaf size (the fused Horner
+// basecase at this length); group 1 forces the full ladder (packing, power
+// chain, combines) at compile time.
+consteval bool input_consteval_smoke(const std::size_t basecase_override) {
+    constexpr std::size_t                  digit_count = 47;
+    std::array<unsigned char, digit_count> digits{};
+    for (std::size_t i = 0; i < digit_count; ++i) {
+        digits[i] = static_cast<unsigned char>((i * 7 + 3) % 10);
+    }
+
+    std::array<uint_t, 8>  out{};
+    std::allocator<uint_t> alloc;
+    const std::size_t      count = detail::digits_to_limbs(
+        std::span<uint_t>{out}, std::span<const unsigned char>{digits}, 10, alloc, basecase_override);
+
+    std::array<uint_t, 8> ref{};
+    std::size_t           ref_size = 1;
+    for (std::size_t i = 0; i < digit_count; ++i) {
+        uint_t carry = static_cast<uint_t>(digits[i]);
+        for (std::size_t j = 0; j < ref_size; ++j) {
+            const auto [lo, hi] = detail::widening_mul(ref[j], uint_t{10});
+            const uint_t next   = lo + carry;
+            carry               = hi + static_cast<uint_t>(next < lo);
+            ref[j]              = next;
+        }
+        if (carry != 0) {
+            ref[ref_size] = carry;
+            ++ref_size;
+        }
+    }
+
+    if (count != ref_size) {
+        return false;
+    }
+    for (std::size_t j = 0; j < out.size(); ++j) {
+        if (out[j] != (j < ref_size ? ref[j] : uint_t{0})) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static_assert(input_consteval_smoke(0));
+static_assert(input_consteval_smoke(1));
+
+} // namespace

--- a/tests/beman/big_int/base_conversion_input.test.cpp
+++ b/tests/beman/big_int/base_conversion_input.test.cpp
@@ -8,6 +8,16 @@
 // matrix covers chunk boundaries, big_base^k +- 1 carry chains, odd/even
 // element counts at every ladder level, and the fully-written contract.
 
+#include <beman/big_int/detail/config.hpp>
+
+// Boost.Multiprecision cpp_int (the independent reference below) trips GCC's
+// -Warray-bounds / stringop checks through its small-buffer optimization under
+// fortify + optimization; these are false positives (cf. conversion_bench).
+BEMAN_BIG_INT_DIAGNOSTIC_PUSH()
+BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Warray-bounds")
+BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Wstringop-overflow")
+BEMAN_BIG_INT_DIAGNOSTIC_IGNORED_GCC("-Wstringop-overread")
+
 #include <beman/big_int/detail/base_conversion.hpp>
 #include <beman/big_int/detail/span_ops.hpp>
 
@@ -405,3 +415,5 @@ static_assert(input_consteval_smoke(0));
 static_assert(input_consteval_smoke(1));
 
 } // namespace
+
+BEMAN_BIG_INT_DIAGNOSTIC_POP()

--- a/tests/beman/big_int/base_conversion_input.test.cpp
+++ b/tests/beman/big_int/base_conversion_input.test.cpp
@@ -179,9 +179,17 @@ TEST(BaseConversionInput, ChunkCountsExhaustive) {
 TEST(BaseConversionInput, PowerBoundaryValues) {
     for (const int base : {3, 10, 36}) {
         const auto cpl = static_cast<std::size_t>(detail::limb_max_input_digits(base));
-        for (const std::size_t k : {std::size_t{1}, std::size_t{2}, std::size_t{3}, std::size_t{7}, std::size_t{8},
-                                    std::size_t{15}, std::size_t{16}, std::size_t{31}, std::size_t{32},
-                                    std::size_t{33}, std::size_t{64}}) {
+        for (const std::size_t k : {std::size_t{1},
+                                    std::size_t{2},
+                                    std::size_t{3},
+                                    std::size_t{7},
+                                    std::size_t{8},
+                                    std::size_t{15},
+                                    std::size_t{16},
+                                    std::size_t{31},
+                                    std::size_t{32},
+                                    std::size_t{33},
+                                    std::size_t{64}}) {
             // big_base^k: "1" followed by k * cpl zeros.
             std::vector<unsigned char> digits(k * cpl + 1, 0);
             digits[0] = 1;
@@ -231,8 +239,8 @@ TEST(BaseConversionInput, OddEvenLevelCounts) {
 TEST(BaseConversionInput, AllBasesSampled) {
     std::mt19937_64 rng{0xba5e5};
     for (const int base : non_power_of_two_bases) {
-        for (const std::size_t len : {std::size_t{1}, std::size_t{7}, std::size_t{100}, std::size_t{1000},
-                                      std::size_t{5000}}) {
+        for (const std::size_t len :
+             {std::size_t{1}, std::size_t{7}, std::size_t{100}, std::size_t{1000}, std::size_t{5000}}) {
             const auto digits = random_digits(len, base, rng);
             const auto fast   = run_fast(digits, base);
             EXPECT_EQ(fast, chunk_horner_ref(digits, base)) << "base " << base << " len " << len;
@@ -253,9 +261,12 @@ TEST(BaseConversionInput, Base10Dense) {
         EXPECT_EQ(fast, horner_ref(digits, base)) << "len " << len;
         EXPECT_EQ(fast, cpp_int_ref(digits, base)) << "len " << len;
     }
-    for (const std::size_t len :
-         {std::size_t{500}, std::size_t{1000}, std::size_t{2000}, std::size_t{5000}, std::size_t{20000},
-          std::size_t{50000}}) {
+    for (const std::size_t len : {std::size_t{500},
+                                  std::size_t{1000},
+                                  std::size_t{2000},
+                                  std::size_t{5000},
+                                  std::size_t{20000},
+                                  std::size_t{50000}}) {
         const auto digits = random_digits(len, base, rng);
         EXPECT_EQ(run_fast(digits, base), chunk_horner_ref(digits, base)) << "len " << len;
     }
@@ -306,9 +317,8 @@ TEST(BaseConversionInput, ScratchPeakWithinBound) {
                                             alloc,
                                             override_group);
 
-                EXPECT_EQ(scratch.peak(), storage)
-                    << "the storage model is exact; base " << base << " chunks " << chunks << " group "
-                    << override_group;
+                EXPECT_EQ(scratch.peak(), storage) << "the storage model is exact; base " << base << " chunks "
+                                                   << chunks << " group " << override_group;
 
                 out.resize(count);
                 EXPECT_EQ(out, chunk_horner_ref(digits, base)) << "base " << base << " chunks " << chunks;
@@ -328,9 +338,9 @@ TEST(BaseConversionInput, FusedKernelMatchesMultiplyAdd) {
             const auto mul = static_cast<uint_t>(rng() | 1);
             const auto add = static_cast<uint_t>(rng());
 
-            std::vector<uint_t> expected(size + 1, 0);
-            [[maybe_unused]] const std::size_t product_size = detail::multiply_single_limb(
-                std::span<uint_t>{expected}, std::span<const uint_t>{value}, mul);
+            std::vector<uint_t>                expected(size + 1, 0);
+            [[maybe_unused]] const std::size_t product_size =
+                detail::multiply_single_limb(std::span<uint_t>{expected}, std::span<const uint_t>{value}, mul);
             const uint_t                addend[1] = {add};
             [[maybe_unused]] const bool carry     = detail::add_unsigned_spans(
                 std::span<uint_t>{expected}, std::span<const uint_t>{expected}, std::span<const uint_t>{addend});

--- a/tests/beman/big_int/base_conversion_output.test.cpp
+++ b/tests/beman/big_int/base_conversion_output.test.cpp
@@ -153,8 +153,13 @@ constexpr std::array<int, 30> non_power_of_two_bases = {3,  5,  6,  7,  9,  10, 
 TEST(BaseConversionOutput, ZeroAndSmallValues) {
     for (const int base : {3, 10, 12, 36}) {
         const uint_t big_base = detail::limb_max_power(base);
-        for (const uint_t value : {uint_t{0}, uint_t{1}, static_cast<uint_t>(base - 1), static_cast<uint_t>(base),
-                                   big_base - 1, big_base, big_base + 1}) {
+        for (const uint_t value : {uint_t{0},
+                                   uint_t{1},
+                                   static_cast<uint_t>(base - 1),
+                                   static_cast<uint_t>(base),
+                                   big_base - 1,
+                                   big_base,
+                                   big_base + 1}) {
             const uint_t                  limbs[1] = {value};
             const std::span<const uint_t> v{limbs};
             EXPECT_EQ(run_fast_out(v, base), digit_ref(v, base)) << "base " << base << " value " << value;
@@ -165,8 +170,14 @@ TEST(BaseConversionOutput, ZeroAndSmallValues) {
 TEST(BaseConversionOutput, RoundTripRandom) {
     std::mt19937_64 rng{0x07b1};
     for (const int base : {3, 10, 12, 36}) {
-        for (const std::size_t limbs : {std::size_t{1}, std::size_t{2}, std::size_t{3}, std::size_t{7},
-                                        std::size_t{16}, std::size_t{33}, std::size_t{100}, std::size_t{257}}) {
+        for (const std::size_t limbs : {std::size_t{1},
+                                        std::size_t{2},
+                                        std::size_t{3},
+                                        std::size_t{7},
+                                        std::size_t{16},
+                                        std::size_t{33},
+                                        std::size_t{100},
+                                        std::size_t{257}}) {
             for (const std::size_t override_group : {std::size_t{0}, std::size_t{2}, std::size_t{4}}) {
                 const auto value  = random_value(limbs, rng);
                 const auto digits = run_fast_out(value, base, override_group);
@@ -259,7 +270,7 @@ TEST(BaseConversionOutput, UntrimmedInputTolerated) {
     padded.insert(padded.end(), 5, uint_t{0});
     EXPECT_EQ(run_fast_out(padded, 10), run_fast_out(value, 10));
 
-    const std::vector<uint_t> zeros(7, uint_t{0});
+    const std::vector<uint_t>        zeros(7, uint_t{0});
     const std::vector<unsigned char> zero_digits{0};
     EXPECT_EQ(run_fast_out(zeros, 10), zero_digits);
 }
@@ -272,7 +283,7 @@ TEST(BaseConversionOutput, ScratchPeakWithinBound) {
             for (const std::size_t override_group : {std::size_t{0}, std::size_t{2}}) {
                 const auto value = random_value(limbs, rng);
 
-                const std::size_t storage = detail::limbs_to_digits_storage_size(limbs, base, override_group);
+                const std::size_t      storage = detail::limbs_to_digits_storage_size(limbs, base, override_group);
                 std::allocator<uint_t> alloc;
                 detail::scratch_allocator<std::allocator<uint_t>> scratch(storage, alloc);
 
@@ -316,18 +327,17 @@ TEST(BaseConversionOutput, BarrettPreinvMatchesBarrett) {
                                    alloc);
 
             // Normalize and invert once, as the conversion table does.
-            const auto          shift = static_cast<unsigned>(std::countl_zero(divisor.back()));
+            const auto          shift  = static_cast<unsigned>(std::countl_zero(divisor.back()));
             std::vector<uint_t> d_norm = divisor;
             if (shift != 0) {
                 [[maybe_unused]] const std::size_t norm_size =
                     detail::shift_left_n(std::span<uint_t>{d_norm}, s, shift);
             }
 
-            const std::size_t blocks = detail::barrett_blocks(std::span<const uint_t>{dividend},
-                                                              std::span<const uint_t>{divisor});
-            const std::size_t storage =
-                detail::reciprocal_span_storage_size(s, detail::reciprocal_span_cutoff) +
-                detail::barrett_preinv_storage_size(s, blocks) + s;
+            const std::size_t blocks =
+                detail::barrett_blocks(std::span<const uint_t>{dividend}, std::span<const uint_t>{divisor});
+            const std::size_t storage = detail::reciprocal_span_storage_size(s, detail::reciprocal_span_cutoff) +
+                                        detail::barrett_preinv_storage_size(s, blocks) + s;
             detail::scratch_allocator<std::allocator<uint_t>> scratch(storage, alloc);
 
             const std::span<uint_t> inv = scratch.allocate(s);
@@ -367,12 +377,11 @@ consteval bool output_consteval_smoke(const std::size_t basecase_override) {
         detail::digits_to_limbs(std::span<uint_t>{limbs}, std::span<const unsigned char>{digits}, 10, alloc);
 
     std::array<unsigned char, digit_count + 1> out{};
-    const std::size_t                          count =
-        detail::limbs_to_digits(std::span<unsigned char>{out},
-                                std::span<const uint_t>{limbs.data(), limb_count},
-                                10,
-                                alloc,
-                                basecase_override);
+    const std::size_t count = detail::limbs_to_digits(std::span<unsigned char>{out},
+                                                      std::span<const uint_t>{limbs.data(), limb_count},
+                                                      10,
+                                                      alloc,
+                                                      basecase_override);
 
     if (count != digit_count) {
         return false;

--- a/tests/beman/big_int/base_conversion_output.test.cpp
+++ b/tests/beman/big_int/base_conversion_output.test.cpp
@@ -1,0 +1,391 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: BSL-1.0
+//
+// Exercises limbs_to_digits (MCA Algorithm 1.26 FastIntegerOutput) directly
+// at the span level. Cross-checks: a per-digit short-division reference, a
+// chunk-level reference, round-trips through digits_to_limbs (validated by
+// base_conversion_input.test.cpp), and digit-string identities for power
+// boundaries - in particular remainder fields with leading zeros, the
+// classic divide-and-conquer output bug.
+
+#include <beman/big_int/detail/base_conversion.hpp>
+#include <beman/big_int/detail/span_ops.hpp>
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <random>
+#include <span>
+#include <vector>
+
+namespace {
+
+namespace detail = beman::big_int::detail;
+using uint_t     = beman::big_int::uint_multiprecision_t;
+
+// Per-digit reference: repeated short division by `base` itself. Quadratic
+// with a large constant; reserved for short values.
+std::vector<unsigned char> digit_ref(const std::span<const uint_t> value, const int base) {
+    std::vector<uint_t> work(value.begin(), value.end());
+    work.resize(detail::trimmed_size_span(std::span<const uint_t>{work}));
+
+    std::vector<unsigned char> reversed;
+    std::size_t                size = work.size();
+    do {
+        const uint_t r = detail::divide_unsigned_short(std::span<uint_t>{work.data(), size},
+                                                       std::span<const uint_t>{work.data(), size},
+                                                       static_cast<uint_t>(base));
+        reversed.push_back(static_cast<unsigned char>(r));
+        if (size > 1 && work[size - 1] == 0) {
+            --size;
+        }
+    } while (size > 1 || work[0] != 0);
+    return {reversed.rbegin(), reversed.rend()};
+}
+
+// Chunk-level reference: repeated short division by big_base, chunks
+// expanded digit by digit. Independent of the divide-and-conquer ladder.
+std::vector<unsigned char> chunk_ref(const std::span<const uint_t> value, const int base) {
+    const auto   cpl      = static_cast<std::size_t>(detail::limb_max_input_digits(base));
+    const uint_t big_base = detail::limb_max_power(base);
+
+    std::vector<uint_t> work(value.begin(), value.end());
+    work.resize(detail::trimmed_size_span(std::span<const uint_t>{work}));
+
+    std::vector<uint_t> chunks;
+    std::size_t         size = work.size();
+    do {
+        chunks.push_back(detail::divide_unsigned_short(
+            std::span<uint_t>{work.data(), size}, std::span<const uint_t>{work.data(), size}, big_base));
+        if (size > 1 && work[size - 1] == 0) {
+            --size;
+        }
+    } while (size > 1 || work[0] != 0);
+
+    std::vector<unsigned char> digits;
+    for (std::size_t i = chunks.size(); i-- > 0;) {
+        uint_t                        chunk = chunks[i];
+        std::array<unsigned char, 64> tmp{};
+        std::size_t                   count = 0;
+        do {
+            tmp[count] = static_cast<unsigned char>(chunk % static_cast<uint_t>(base));
+            chunk /= static_cast<uint_t>(base);
+            ++count;
+        } while (chunk != 0);
+        const bool top = i + 1 == chunks.size();
+        if (!top) {
+            for (std::size_t pad = count; pad < cpl; ++pad) {
+                digits.push_back(0);
+            }
+        }
+        for (std::size_t d = count; d-- > 0;) {
+            digits.push_back(tmp[d]);
+        }
+    }
+    return digits;
+}
+
+// Runs the fast output path with contract checks: poisoned buffer, count in
+// [1, bound], all digit values below the base, no leading zero unless the
+// value is zero.
+std::vector<unsigned char>
+run_fast_out(const std::span<const uint_t> value, const int base, const std::size_t basecase_override = 0) {
+    const std::size_t          bound = detail::base_conversion_digit_bound(value, base);
+    std::vector<unsigned char> out(bound, static_cast<unsigned char>(0xAB));
+
+    std::allocator<uint_t> alloc;
+    const std::size_t      count =
+        detail::limbs_to_digits(std::span<unsigned char>{out}, value, base, alloc, basecase_override);
+
+    EXPECT_GE(count, 1u);
+    EXPECT_LE(count, bound);
+    // The Q0.8 reciprocal-log coefficient overshoots by < 1/256 per bit, so
+    // the bound's slack stays proportionally small.
+    EXPECT_LE(bound - count, bound / 32 + 2) << "digit bound slack grew beyond the Q0.8 error model";
+    for (std::size_t i = 0; i < count; ++i) {
+        EXPECT_LT(static_cast<int>(out[i]), base) << "digit " << i;
+    }
+    if (count > 1) {
+        EXPECT_NE(out[0], 0u) << "leading zero digit";
+    }
+    out.resize(count);
+    return out;
+}
+
+// Builds a value from MSD-first digit values via digits_to_limbs (validated
+// in base_conversion_input.test.cpp).
+std::vector<uint_t> value_of(const std::span<const unsigned char> digits, const int base) {
+    std::vector<uint_t>    limbs(detail::base_conversion_limb_bound(digits.size(), base), 0);
+    std::allocator<uint_t> alloc;
+    const std::size_t      count = detail::digits_to_limbs(std::span<uint_t>{limbs}, digits, base, alloc);
+    limbs.resize(count);
+    return limbs;
+}
+
+std::vector<uint_t> random_value(const std::size_t limbs, std::mt19937_64& rng) {
+    std::vector<uint_t> v(limbs);
+    for (auto& limb : v) {
+        limb = static_cast<uint_t>(rng());
+    }
+    if (v.back() == 0) {
+        v.back() = 1;
+    }
+    return v;
+}
+
+std::vector<unsigned char> random_digits(const std::size_t len, const int base, std::mt19937_64& rng) {
+    std::uniform_int_distribution<int> dist(0, base - 1);
+    std::vector<unsigned char>         digits(len);
+    for (auto& d : digits) {
+        d = static_cast<unsigned char>(dist(rng));
+    }
+    if (digits[0] == 0) {
+        digits[0] = 1;
+    }
+    return digits;
+}
+
+constexpr std::array<int, 30> non_power_of_two_bases = {3,  5,  6,  7,  9,  10, 11, 12, 13, 14, 15, 17, 18, 19, 20,
+                                                        21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 33, 34, 35, 36};
+
+TEST(BaseConversionOutput, ZeroAndSmallValues) {
+    for (const int base : {3, 10, 12, 36}) {
+        const uint_t big_base = detail::limb_max_power(base);
+        for (const uint_t value : {uint_t{0}, uint_t{1}, static_cast<uint_t>(base - 1), static_cast<uint_t>(base),
+                                   big_base - 1, big_base, big_base + 1}) {
+            const uint_t                  limbs[1] = {value};
+            const std::span<const uint_t> v{limbs};
+            EXPECT_EQ(run_fast_out(v, base), digit_ref(v, base)) << "base " << base << " value " << value;
+        }
+    }
+}
+
+TEST(BaseConversionOutput, RoundTripRandom) {
+    std::mt19937_64 rng{0x07b1};
+    for (const int base : {3, 10, 12, 36}) {
+        for (const std::size_t limbs : {std::size_t{1}, std::size_t{2}, std::size_t{3}, std::size_t{7},
+                                        std::size_t{16}, std::size_t{33}, std::size_t{100}, std::size_t{257}}) {
+            for (const std::size_t override_group : {std::size_t{0}, std::size_t{2}, std::size_t{4}}) {
+                const auto value  = random_value(limbs, rng);
+                const auto digits = run_fast_out(value, base, override_group);
+                EXPECT_EQ(value_of(digits, base), value)
+                    << "base " << base << " limbs " << limbs << " group " << override_group;
+                if (limbs <= 33) {
+                    EXPECT_EQ(digits, chunk_ref(value, base))
+                        << "base " << base << " limbs " << limbs << " group " << override_group;
+                }
+            }
+        }
+    }
+}
+
+// Digit-string identities around the power chain: values built from digit
+// strings convert back to exactly those strings. Remainder fields full of
+// zeros (Q * P_j) and nearly full of zeros (Q * P_j + tiny) are the classic
+// bug shapes.
+TEST(BaseConversionOutput, PowerBoundaryStrings) {
+    std::mt19937_64 rng{0x07b2};
+    for (const int base : {3, 10, 36}) {
+        const auto cpl = static_cast<std::size_t>(detail::limb_max_input_digits(base));
+        for (const std::size_t k :
+             {std::size_t{1}, std::size_t{2}, std::size_t{4}, std::size_t{8}, std::size_t{16}, std::size_t{32}}) {
+            // big_base^k = "1" followed by k * cpl zeros.
+            std::vector<unsigned char> digits(k * cpl + 1, 0);
+            digits[0] = 1;
+            EXPECT_EQ(run_fast_out(value_of(digits, base), base), digits) << "base " << base << " k " << k;
+
+            // big_base^k + 1.
+            digits.back() = 1;
+            EXPECT_EQ(run_fast_out(value_of(digits, base), base), digits) << "base " << base << " k " << k;
+
+            // big_base^k - 1: all (base - 1), maximal borrow/carry chains.
+            const std::vector<unsigned char> nines(k * cpl, static_cast<unsigned char>(base - 1));
+            EXPECT_EQ(run_fast_out(value_of(nines, base), base), nines) << "base " << base << " k " << k;
+
+            // Q * big_base^k and Q * big_base^k + tiny for random Q: the
+            // remainder field is all (or nearly all) leading zeros.
+            const auto                 q = random_digits(3 * cpl, base, rng);
+            std::vector<unsigned char> padded(q.begin(), q.end());
+            padded.insert(padded.end(), k * cpl, static_cast<unsigned char>(0));
+            EXPECT_EQ(run_fast_out(value_of(padded, base), base), padded) << "base " << base << " k " << k;
+
+            padded.back() = static_cast<unsigned char>(base - 1);
+            EXPECT_EQ(run_fast_out(value_of(padded, base), base), padded) << "base " << base << " k " << k;
+        }
+    }
+}
+
+TEST(BaseConversionOutput, AllBasesSampled) {
+    std::mt19937_64 rng{0x07b3};
+    for (const int base : non_power_of_two_bases) {
+        for (const std::size_t limbs :
+             {std::size_t{1}, std::size_t{2}, std::size_t{5}, std::size_t{20}, std::size_t{100}, std::size_t{500}}) {
+            const auto value  = random_value(limbs, rng);
+            const auto digits = run_fast_out(value, base);
+            EXPECT_EQ(value_of(digits, base), value) << "base " << base << " limbs " << limbs;
+            if (limbs <= 20) {
+                EXPECT_EQ(digits, chunk_ref(value, base)) << "base " << base << " limbs " << limbs;
+            }
+        }
+    }
+}
+
+TEST(BaseConversionOutput, Base10DenseLimbCounts) {
+    std::mt19937_64 rng{0x07b4};
+    const int       base = 10;
+    for (std::size_t limbs = 1; limbs <= 100; ++limbs) {
+        const auto value  = random_value(limbs, rng);
+        const auto digits = run_fast_out(value, base);
+        EXPECT_EQ(value_of(digits, base), value) << "limbs " << limbs;
+        EXPECT_EQ(digits, chunk_ref(value, base)) << "limbs " << limbs;
+    }
+    for (const std::size_t limbs : {std::size_t{500}, std::size_t{2000}, std::size_t{10000}}) {
+        const auto value  = random_value(limbs, rng);
+        const auto digits = run_fast_out(value, base);
+        EXPECT_EQ(value_of(digits, base), value) << "limbs " << limbs;
+        if (limbs <= 2000) {
+            EXPECT_EQ(digits, chunk_ref(value, base)) << "limbs " << limbs;
+        }
+    }
+}
+
+TEST(BaseConversionOutput, UntrimmedInputTolerated) {
+    std::mt19937_64 rng{0x07b5};
+    const auto      value = random_value(9, rng);
+
+    std::vector<uint_t> padded = value;
+    padded.insert(padded.end(), 5, uint_t{0});
+    EXPECT_EQ(run_fast_out(padded, 10), run_fast_out(value, 10));
+
+    const std::vector<uint_t> zeros(7, uint_t{0});
+    const std::vector<unsigned char> zero_digits{0};
+    EXPECT_EQ(run_fast_out(zeros, 10), zero_digits);
+}
+
+TEST(BaseConversionOutput, ScratchPeakWithinBound) {
+    std::mt19937_64 rng{0x07b6};
+    for (const int base : {3, 10, 12}) {
+        for (const std::size_t limbs :
+             {std::size_t{1}, std::size_t{3}, std::size_t{17}, std::size_t{64}, std::size_t{300}, std::size_t{1500}}) {
+            for (const std::size_t override_group : {std::size_t{0}, std::size_t{2}}) {
+                const auto value = random_value(limbs, rng);
+
+                const std::size_t storage = detail::limbs_to_digits_storage_size(limbs, base, override_group);
+                std::allocator<uint_t> alloc;
+                detail::scratch_allocator<std::allocator<uint_t>> scratch(storage, alloc);
+
+                std::vector<unsigned char> out(detail::base_conversion_digit_bound(value, base), 0);
+                const std::size_t          count =
+                    detail::limbs_to_digits(std::span<unsigned char>{out},
+                                            std::span<const uint_t>{value},
+                                            base,
+                                            static_cast<detail::scratch_allocator_base&>(scratch),
+                                            alloc,
+                                            override_group);
+
+                EXPECT_LE(scratch.peak(), storage)
+                    << "base " << base << " limbs " << limbs << " group " << override_group;
+
+                out.resize(count);
+                EXPECT_EQ(value_of(out, base), value) << "base " << base << " limbs " << limbs;
+            }
+        }
+    }
+}
+
+// The invariant-divisor Barrett entry against the self-contained driver on
+// random shapes: identical quotient/remainder, peak within its storage
+// model, and the scratch fully rewound (the conversion tree reuses one
+// arena across many calls).
+TEST(BaseConversionOutput, BarrettPreinvMatchesBarrett) {
+    std::mt19937_64 rng{0x07b7};
+    for (const std::size_t s : {std::size_t{2}, std::size_t{5}, std::size_t{16}, std::size_t{64}, std::size_t{300}}) {
+        for (const std::size_t m : {2 * s, 3 * s + 1, 16 * s}) {
+            const auto dividend = random_value(m, rng);
+            auto       divisor  = random_value(s, rng);
+
+            std::allocator<uint_t> alloc;
+            std::vector<uint_t>    q_ref(m - s + 1, 0);
+            std::vector<uint_t>    r_ref(m + 1, 0);
+            detail::divide_barrett(std::span<uint_t>{q_ref},
+                                   std::span<uint_t>{r_ref},
+                                   std::span<const uint_t>{dividend},
+                                   std::span<const uint_t>{divisor},
+                                   alloc);
+
+            // Normalize and invert once, as the conversion table does.
+            const auto          shift = static_cast<unsigned>(std::countl_zero(divisor.back()));
+            std::vector<uint_t> d_norm = divisor;
+            if (shift != 0) {
+                [[maybe_unused]] const std::size_t norm_size =
+                    detail::shift_left_n(std::span<uint_t>{d_norm}, s, shift);
+            }
+
+            const std::size_t blocks = detail::barrett_blocks(std::span<const uint_t>{dividend},
+                                                              std::span<const uint_t>{divisor});
+            const std::size_t storage =
+                detail::reciprocal_span_storage_size(s, detail::reciprocal_span_cutoff) +
+                detail::barrett_preinv_storage_size(s, blocks) + s;
+            detail::scratch_allocator<std::allocator<uint_t>> scratch(storage, alloc);
+
+            const std::span<uint_t> inv = scratch.allocate(s);
+            detail::reciprocal_span(inv, std::span<const uint_t>{d_norm}, scratch);
+            const std::size_t mark = scratch.m_offset;
+
+            std::vector<uint_t> q(m - s + 1, 0);
+            std::vector<uint_t> r(m + 1, 0);
+            detail::divide_barrett_preinv(std::span<uint_t>{q},
+                                          std::span<uint_t>{r},
+                                          std::span<const uint_t>{dividend},
+                                          std::span<const uint_t>{d_norm},
+                                          shift,
+                                          std::span<const uint_t>{inv},
+                                          scratch);
+
+            EXPECT_EQ(q, q_ref) << "m " << m << " s " << s;
+            EXPECT_EQ(r, r_ref) << "m " << m << " s " << s;
+            EXPECT_EQ(scratch.m_offset, mark) << "preinv must rewind fully";
+            EXPECT_LE(scratch.peak(), storage) << "m " << m << " s " << s;
+        }
+    }
+}
+
+// Constant-evaluation smoke test: digits -> limbs -> digits is the identity,
+// once with the tuned leaf size and once forcing the divide ladder.
+consteval bool output_consteval_smoke(const std::size_t basecase_override) {
+    constexpr std::size_t                  digit_count = 47;
+    std::array<unsigned char, digit_count> digits{};
+    for (std::size_t i = 0; i < digit_count; ++i) {
+        digits[i] = static_cast<unsigned char>(i % 9 + (i == 0 ? 1 : 0));
+    }
+
+    std::array<uint_t, 8>  limbs{};
+    std::allocator<uint_t> alloc;
+    const std::size_t      limb_count =
+        detail::digits_to_limbs(std::span<uint_t>{limbs}, std::span<const unsigned char>{digits}, 10, alloc);
+
+    std::array<unsigned char, digit_count + 1> out{};
+    const std::size_t                          count =
+        detail::limbs_to_digits(std::span<unsigned char>{out},
+                                std::span<const uint_t>{limbs.data(), limb_count},
+                                10,
+                                alloc,
+                                basecase_override);
+
+    if (count != digit_count) {
+        return false;
+    }
+    for (std::size_t i = 0; i < digit_count; ++i) {
+        if (out[i] != digits[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static_assert(output_consteval_smoke(0));
+static_assert(output_consteval_smoke(2));
+
+} // namespace

--- a/tests/beman/big_int/charconv.test.cpp
+++ b/tests/beman/big_int/charconv.test.cpp
@@ -1210,6 +1210,23 @@ TEST(Charconv, FastPathRoundTrip) {
     }
 }
 
+// Large power-of-two round-trips: the fixed-value tests above top out at ~200
+// digits, so this exercises the multi-limb bit-packing chunk loops in both po2
+// from_chars branches (2/16 = max_pow==0, 8/32 = general is_pow_2) plus the
+// short top block, against the direct-shift to_chars side.
+TEST(Charconv, Po2RoundTrip) {
+    for (const int base : {2, 8, 16, 32}) {
+        for (const std::size_t len : {std::size_t{200}, std::size_t{5000}, std::size_t{100000}}) {
+            const std::uint64_t seed = static_cast<std::uint64_t>(base) * 7919u + static_cast<std::uint64_t>(len);
+            const std::string   s    = random_digit_string(len, base, seed);
+
+            EXPECT_EQ(to_string(parse(s, base), base), s) << "base=" << base << " len=" << len;
+            const std::string ns = "-" + s;
+            EXPECT_EQ(to_string(parse(ns, base), base), ns) << "negative base=" << base << " len=" << len;
+        }
+    }
+}
+
 TEST(FromChars, FastPathStopsAtInvalidCharacter) {
     constexpr int     base   = 10;
     const std::string digits = random_digit_string(25000, base, 0xABCDEFull);

--- a/tests/beman/big_int/charconv.test.cpp
+++ b/tests/beman/big_int/charconv.test.cpp
@@ -1232,7 +1232,7 @@ TEST(FromChars, FastPathStopsAtInvalidCharacter) {
     const std::string digits = random_digit_string(25000, base, 0xABCDEFull);
     const std::string text   = digits + "!not a digit";
 
-    big_int    v;
+    big_int v;
     const auto [p, ec] = from_chars(text.data(), text.data() + text.size(), v, base);
     EXPECT_EQ(ec, std::errc{});
     EXPECT_EQ(p, text.data() + digits.size());

--- a/tests/beman/big_int/charconv.test.cpp
+++ b/tests/beman/big_int/charconv.test.cpp
@@ -1,5 +1,7 @@
 #include <string_view>
 #include <cmath>
+#include <random>
+#include <string>
 
 #include <gtest/gtest.h>
 
@@ -1168,6 +1170,67 @@ TEST(ToChars, HugeValueTooLarge) {
         const auto [p, ec] = to_chars(range, std::end(range), value, base);
         EXPECT_EQ(ec, std::errc::value_too_large);
     }
+}
+
+// ---------------------------------------------------------------------------
+// Large-input coverage for the sub-quadratic from_chars / to_chars path. The
+// fast kernel only engages above the per-arch gate (~1216 base-10 digits on
+// AArch64, ~19456 on x86-64), so all the fixed-value tests above exercise only
+// the inline fallback. These round-trips push past both gates across several
+// non-power-of-two bases, validating the ASCII<->digit-value transcode, the
+// result/scratch sizing, sign handling, and the value_too_large path.
+// ---------------------------------------------------------------------------
+[[nodiscard]] std::string random_digit_string(const std::size_t len, const int base, const std::uint64_t seed) {
+    static constexpr char              alphabet[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+    std::mt19937_64                    rng{seed};
+    std::uniform_int_distribution<int> dist(0, base - 1);
+    std::string                        s(len, '0');
+    for (char& c : s) {
+        c = alphabet[dist(rng)];
+    }
+    if (s.front() == '0') {
+        s.front() = alphabet[1]; // no leading zero, so to_string round-trips the string exactly
+    }
+    return s;
+}
+
+TEST(Charconv, FastPathRoundTrip) {
+    for (const int base : {3, 7, 10, 26, 36}) {
+        for (const std::size_t len : {std::size_t{2000}, std::size_t{25000}, std::size_t{60000}}) {
+            const std::uint64_t seed = static_cast<std::uint64_t>(base) * 1000003u + static_cast<std::uint64_t>(len);
+            const std::string   s    = random_digit_string(len, base, seed);
+
+            const big_int v = parse(s, base);
+            EXPECT_EQ(to_string(v, base), s) << "base=" << base << " len=" << len;
+
+            const std::string ns = "-" + s;
+            const big_int     nv = parse(ns, base);
+            EXPECT_EQ(to_string(nv, base), ns) << "negative base=" << base << " len=" << len;
+        }
+    }
+}
+
+TEST(FromChars, FastPathStopsAtInvalidCharacter) {
+    constexpr int     base   = 10;
+    const std::string digits = random_digit_string(25000, base, 0xABCDEFull);
+    const std::string text   = digits + "!not a digit";
+
+    big_int    v;
+    const auto [p, ec] = from_chars(text.data(), text.data() + text.size(), v, base);
+    EXPECT_EQ(ec, std::errc{});
+    EXPECT_EQ(p, text.data() + digits.size());
+    EXPECT_EQ(to_string(v, base), digits);
+}
+
+TEST(ToChars, FastPathValueTooLarge) {
+    constexpr int     base   = 10;
+    const std::string digits = random_digit_string(25000, base, 0x5555ull);
+    const big_int     v      = parse(digits, base);
+
+    std::string buf(digits.size() - 1, '\0'); // one char short of the digit count
+    const auto [p, ec] = to_chars(buf.data(), buf.data() + buf.size(), v, base);
+    EXPECT_EQ(ec, std::errc::value_too_large);
+    EXPECT_EQ(p, buf.data() + buf.size());
 }
 
 } // namespace


### PR DESCRIPTION
Implements algorithms for fast digits to limbs and vice versa as described in "Modern Computer Arithmetic". Once implemented and tested for correctness, they have generally replaced the non-power of 2 base handling for `to_chars`, and `from_chars`. Also benchmarked the powers-of-two case and found that libstdc++ does handle that case properly, whereas libc++ handles it naively. Replace with our own proper handling of powers of two which yielded ~1.2x speedup with libstdc++ on Ubuntu x64, and ~6.5x speedup with libc++ on ARM Mac.

Here is a quick summary of results:

# Mac (AArch64, M4-class)

| base | digits | from_chars speedup | to_chars speedup |
|-----:|-------:|-------------------:|-----------------:|
|    3 |  10000 |               2.4x |             2.9x |
|    3 | 100000 |               4.9x |             7.1x |
|    3 | 1000000 |              21.8x |            23.2x |
|    7 |  10000 |               3.0x |             4.1x |
|    7 | 100000 |               6.5x |             9.6x |
|    7 | 1000000 |              31.8x |            34.1x |
|   10 |  10000 |               3.5x |             4.6x |
|   10 | 100000 |               8.9x |            13.6x |
|   10 | 1000000 |              39.5x |            43.6x |
|   26 |  10000 |               4.4x |             5.8x |
|   26 | 100000 |              12.8x |            15.1x |
|   26 | 1000000 |              48.9x |            53.0x |
|   36 |  10000 |               5.6x |             6.7x |
|   36 | 100000 |              11.1x |            16.8x |
|   36 | 1000000 |              54.2x |            60.3x |

# x86-64 (i9-11900K, AVX-512+IFMA)

| base | digits | from_chars speedup | to_chars speedup |
|-----:|-------:|-------------------:|-----------------:|
|    3 |  10000 |               2.1x |             2.2x |
|    3 | 100000 |               3.2x |             4.7x |
|    3 | 1000000 |              11.2x |            13.8x |
|    7 |  10000 |               2.4x |             2.8x |
|    7 | 100000 |               4.4x |             6.2x |
|    7 | 1000000 |              16.0x |            19.9x |
|   10 |  10000 |               2.4x |             3.4x |
|   10 | 100000 |               6.0x |             8.8x |
|   10 | 1000000 |              25.9x |            25.2x |
|   26 |  10000 |               2.4x |             4.2x |
|   26 | 100000 |               8.6x |            10.1x |
|   26 | 1000000 |              25.1x |            28.3x |
|   36 |  10000 |               2.4x |             5.3x |
|   36 | 100000 |               7.2x |            11.6x |
|   36 | 1000000 |              23.1x |            37.1x |

Full results were up to 200x with base-10 conversions of huge numbers (1M+ decimal digits).

Closes: #252 
Closes: #253 
Closes: #254 
