### PR TITLE
Add `LimbType` template parameter

### DIFF
--- a/doc/modules/ROOT/pages/big_int_type.adoc
+++ b/doc/modules/ROOT/pages/big_int_type.adoc
@@ -49,8 +49,8 @@ using big_int = basic_big_int<64, std::allocator<uint_multiprecision_t>>;
 namespace pmr {
 
 // Specialization parameterized on std::pmr::polymorphic_allocator.
-template <std::size_t b, class Limb = uint_multiprecision_t>
-using basic_big_int = beman::big_int::basic_big_int<b, std::pmr::polymorphic_allocator<Limb>, Limb>;
+template <std::size_t b, class LimbType = uint_multiprecision_t>
+using basic_big_int = beman::big_int::basic_big_int<b, std::pmr::polymorphic_allocator<LimbType>, LimbType>;
 
 using big_int = basic_big_int</* same in-place bits as the default big_int */>;
 

--- a/doc/modules/ROOT/pages/big_int_type.adoc
+++ b/doc/modules/ROOT/pages/big_int_type.adoc
@@ -37,7 +37,10 @@ using uint_multiprecision_t = unsigned long long;
 ----
 // min_inplace_bits is the number of bits of statically allocated storage that
 // the basic_big_int will have available for the small-object optimization.
-template <std::size_t min_inplace_bits, class Allocator = std::allocator<uint_multiprecision_t>>
+// LimbType names the limb type, and shall be uint_multiprecision_t.
+template <std::size_t min_inplace_bits,
+          class Allocator = std::allocator<uint_multiprecision_t>,
+          class LimbType  = uint_multiprecision_t>
 class basic_big_int;
 
 // Default specialization with a stateless allocator.
@@ -46,8 +49,8 @@ using big_int = basic_big_int<64, std::allocator<uint_multiprecision_t>>;
 namespace pmr {
 
 // Specialization parameterized on std::pmr::polymorphic_allocator.
-template <std::size_t b>
-using basic_big_int = beman::big_int::basic_big_int<b, std::pmr::polymorphic_allocator<uint_multiprecision_t>>;
+template <std::size_t b, class Limb = uint_multiprecision_t>
+using basic_big_int = beman::big_int::basic_big_int<b, std::pmr::polymorphic_allocator<Limb>, Limb>;
 
 using big_int = basic_big_int</* same in-place bits as the default big_int */>;
 
@@ -61,6 +64,12 @@ A `basic_big_int` stores its magnitude as a little-endian sequence of
 together with a separate sign. Values whose magnitude fits within
 `inplace_bits` bits are stored directly inside the object; larger values are
 stored in allocator-provided dynamic storage.
+
+The limb type is named by the `LimbType` template parameter rather than being fixed by the
+class, so that a future revision can change it without changing the signature of
+`basic_big_int`. `LimbType` shall be `uint_multiprecision_t`, and
+`Allocator::value_type` shall be `LimbType`; a program that instantiates
+`basic_big_int` with any other limb type is ill-formed.
 
 [#big_int_type_synopsis]
 == Synopsis
@@ -76,7 +85,9 @@ same specialization or a built-in signed or unsigned integer type.
 [#big_int_type_basic_big_int]
 [source,c++]
 ----
-template <std::size_t min_inplace_bits, class Allocator = std::allocator<uint_multiprecision_t>>
+template <std::size_t min_inplace_bits,
+          class Allocator = std::allocator<uint_multiprecision_t>,
+          class LimbType  = uint_multiprecision_t>
 class basic_big_int {
   public:
     // member types
@@ -88,7 +99,7 @@ class basic_big_int {
     // member constants
     static constexpr size_type inplace_capacity = /* number of in-place limbs */;
     static constexpr size_type inplace_bits =
-        inplace_capacity * std::numeric_limits<uint_multiprecision_t>::digits;
+        inplace_capacity * std::numeric_limits<LimbType>::digits;
 
     // [big.int.cons], construct/copy/destroy
     constexpr basic_big_int() noexcept(noexcept(Allocator()));
@@ -205,10 +216,10 @@ constexpr std::remove_cvref_t<T> operator>>(T&& x, S s);
 | `std::allocator_traits<Allocator>::const_pointer`.
 
 | `inplace_capacity`
-| The number of `uint_multiprecision_t` limbs available in the in-place (small-object) storage. It is at least large enough to hold `min_inplace_bits` bits, and never smaller than what fits in the object's pointer footprint.
+| The number of `LimbType` limbs available in the in-place (small-object) storage. It is at least large enough to hold `min_inplace_bits` bits, and never smaller than what fits in the object's pointer footprint.
 
 | `inplace_bits`
-| `inplace_capacity * std::numeric_limits<uint_multiprecision_t>::digits`; the number of bits of in-place storage. A value whose magnitude fits in `inplace_bits` bits is stored without allocating.
+| `inplace_capacity * std::numeric_limits<LimbType>::digits`; the number of bits of in-place storage. A value whose magnitude fits in `inplace_bits` bits is stored without allocating.
 |===
 
 [#big_int_type_construct]

--- a/doc/modules/ROOT/pages/charconv.adoc
+++ b/doc/modules/ROOT/pages/charconv.adoc
@@ -18,13 +18,13 @@ buffer of its own, never throws, and is usable in a constant expression.
 ----
 namespace beman::big_int {
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 constexpr std::to_chars_result
-to_chars(char* first, char* last, const basic_big_int<b, A>& value, int base = 10);
+to_chars(char* first, char* last, const basic_big_int<b, A, Limb>& value, int base = 10);
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 constexpr std::from_chars_result
-from_chars(const char* first, const char* last, basic_big_int<b, A>& value, int base = 10);
+from_chars(const char* first, const char* last, basic_big_int<b, A, Limb>& value, int base = 10);
 
 } // namespace beman::big_int
 ----
@@ -39,9 +39,9 @@ consumed, and no leading whitespace is skipped.
 
 [source,c++]
 ----
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 constexpr std::to_chars_result
-to_chars(char* first, char* last, const basic_big_int<b, A>& value, int base = 10);
+to_chars(char* first, char* last, const basic_big_int<b, A, Limb>& value, int base = 10);
 ----
 
 Writes the integer value of `value` into the character range `[first, last)`,
@@ -61,9 +61,9 @@ written with no sign. No null terminator is written.
 
 [source,c++]
 ----
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 constexpr std::from_chars_result
-from_chars(const char* first, const char* last, basic_big_int<b, A>& value, int base = 10);
+from_chars(const char* first, const char* last, basic_big_int<b, A, Limb>& value, int base = 10);
 ----
 
 Parses an integer from the longest prefix of `[first, last)` that forms a valid

--- a/doc/modules/ROOT/pages/charconv.adoc
+++ b/doc/modules/ROOT/pages/charconv.adoc
@@ -18,13 +18,13 @@ buffer of its own, never throws, and is usable in a constant expression.
 ----
 namespace beman::big_int {
 
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 constexpr std::to_chars_result
-to_chars(char* first, char* last, const basic_big_int<b, A, Limb>& value, int base = 10);
+to_chars(char* first, char* last, const basic_big_int<b, A, LimbType>& value, int base = 10);
 
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 constexpr std::from_chars_result
-from_chars(const char* first, const char* last, basic_big_int<b, A, Limb>& value, int base = 10);
+from_chars(const char* first, const char* last, basic_big_int<b, A, LimbType>& value, int base = 10);
 
 } // namespace beman::big_int
 ----
@@ -39,9 +39,9 @@ consumed, and no leading whitespace is skipped.
 
 [source,c++]
 ----
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 constexpr std::to_chars_result
-to_chars(char* first, char* last, const basic_big_int<b, A, Limb>& value, int base = 10);
+to_chars(char* first, char* last, const basic_big_int<b, A, LimbType>& value, int base = 10);
 ----
 
 Writes the integer value of `value` into the character range `[first, last)`,
@@ -61,9 +61,9 @@ written with no sign. No null terminator is written.
 
 [source,c++]
 ----
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 constexpr std::from_chars_result
-from_chars(const char* first, const char* last, basic_big_int<b, A, Limb>& value, int base = 10);
+from_chars(const char* first, const char* last, basic_big_int<b, A, LimbType>& value, int base = 10);
 ----
 
 Parses an integer from the longest prefix of `[first, last)` that forms a valid

--- a/doc/modules/ROOT/pages/numeric.adoc
+++ b/doc/modules/ROOT/pages/numeric.adoc
@@ -22,9 +22,9 @@ template <class T>
     requires /* T is a basic_big_int (after removing cv-qualifiers and references) */
 constexpr std::remove_cvref_t<T> abs(T&& x);
 
-template <class R, std::size_t b, class A, class Limb>
+template <class R, std::size_t b, class A, class LimbType>
     requires /* R is a signed or unsigned integer type */
-constexpr R saturating_cast(const basic_big_int<b, A, Limb>& x) noexcept;
+constexpr R saturating_cast(const basic_big_int<b, A, LimbType>& x) noexcept;
 
 } // namespace beman::big_int
 ----
@@ -57,9 +57,9 @@ unbounded, so the magnitude of every value is representable.
 
 [source,c++]
 ----
-template <class R, std::size_t b, class A, class Limb>
+template <class R, std::size_t b, class A, class LimbType>
     requires /* R is a signed or unsigned integer type */
-constexpr R saturating_cast(const basic_big_int<b, A, Limb>& x) noexcept;
+constexpr R saturating_cast(const basic_big_int<b, A, LimbType>& x) noexcept;
 ----
 
 Converts `x` to the integer type `R`, clamping the result to the range of `R`

--- a/doc/modules/ROOT/pages/numeric.adoc
+++ b/doc/modules/ROOT/pages/numeric.adoc
@@ -22,9 +22,9 @@ template <class T>
     requires /* T is a basic_big_int (after removing cv-qualifiers and references) */
 constexpr std::remove_cvref_t<T> abs(T&& x);
 
-template <class R, std::size_t b, class A>
+template <class R, std::size_t b, class A, class Limb>
     requires /* R is a signed or unsigned integer type */
-constexpr R saturating_cast(const basic_big_int<b, A>& x) noexcept;
+constexpr R saturating_cast(const basic_big_int<b, A, Limb>& x) noexcept;
 
 } // namespace beman::big_int
 ----
@@ -57,9 +57,9 @@ unbounded, so the magnitude of every value is representable.
 
 [source,c++]
 ----
-template <class R, std::size_t b, class A>
+template <class R, std::size_t b, class A, class Limb>
     requires /* R is a signed or unsigned integer type */
-constexpr R saturating_cast(const basic_big_int<b, A>& x) noexcept;
+constexpr R saturating_cast(const basic_big_int<b, A, Limb>& x) noexcept;
 ----
 
 Converts `x` to the integer type `R`, clamping the result to the range of `R`

--- a/doc/modules/ROOT/pages/string.adoc
+++ b/doc/modules/ROOT/pages/string.adoc
@@ -21,11 +21,11 @@ avoid allocating at all, use xref:charconv.adoc[`to_chars`] directly.
 ----
 namespace beman::big_int {
 
-template <std::size_t b, class A, class Limb>
-constexpr std::string to_string(const basic_big_int<b, A, Limb>& value, int base = 10);
+template <std::size_t b, class A, class LimbType>
+constexpr std::string to_string(const basic_big_int<b, A, LimbType>& value, int base = 10);
 
-template <std::size_t b, class A, class Limb>
-constexpr std::wstring to_wstring(const basic_big_int<b, A, Limb>& value, int base = 10);
+template <std::size_t b, class A, class LimbType>
+constexpr std::wstring to_wstring(const basic_big_int<b, A, LimbType>& value, int base = 10);
 
 } // namespace beman::big_int
 ----
@@ -42,8 +42,8 @@ values of ten or more use the lowercase letters `a`-`z`. No prefix (such as
 
 [source,c++]
 ----
-template <std::size_t b, class A, class Limb>
-constexpr std::string to_string(const basic_big_int<b, A, Limb>& value, int base = 10);
+template <std::size_t b, class A, class LimbType>
+constexpr std::string to_string(const basic_big_int<b, A, LimbType>& value, int base = 10);
 ----
 
 Returns a `std::string` holding `value` rendered in the given `base`.
@@ -58,8 +58,8 @@ Returns a `std::string` holding `value` rendered in the given `base`.
 
 [source,c++]
 ----
-template <std::size_t b, class A, class Limb>
-constexpr std::wstring to_wstring(const basic_big_int<b, A, Limb>& value, int base = 10);
+template <std::size_t b, class A, class LimbType>
+constexpr std::wstring to_wstring(const basic_big_int<b, A, LimbType>& value, int base = 10);
 ----
 
 Behaves exactly like `to_string`, but returns a `std::wstring`. The digit

--- a/doc/modules/ROOT/pages/string.adoc
+++ b/doc/modules/ROOT/pages/string.adoc
@@ -21,11 +21,11 @@ avoid allocating at all, use xref:charconv.adoc[`to_chars`] directly.
 ----
 namespace beman::big_int {
 
-template <std::size_t b, class A>
-constexpr std::string to_string(const basic_big_int<b, A>& value, int base = 10);
+template <std::size_t b, class A, class Limb>
+constexpr std::string to_string(const basic_big_int<b, A, Limb>& value, int base = 10);
 
-template <std::size_t b, class A>
-constexpr std::wstring to_wstring(const basic_big_int<b, A>& value, int base = 10);
+template <std::size_t b, class A, class Limb>
+constexpr std::wstring to_wstring(const basic_big_int<b, A, Limb>& value, int base = 10);
 
 } // namespace beman::big_int
 ----
@@ -42,8 +42,8 @@ values of ten or more use the lowercase letters `a`-`z`. No prefix (such as
 
 [source,c++]
 ----
-template <std::size_t b, class A>
-constexpr std::string to_string(const basic_big_int<b, A>& value, int base = 10);
+template <std::size_t b, class A, class Limb>
+constexpr std::string to_string(const basic_big_int<b, A, Limb>& value, int base = 10);
 ----
 
 Returns a `std::string` holding `value` rendered in the given `base`.
@@ -58,8 +58,8 @@ Returns a `std::string` holding `value` rendered in the given `base`.
 
 [source,c++]
 ----
-template <std::size_t b, class A>
-constexpr std::wstring to_wstring(const basic_big_int<b, A>& value, int base = 10);
+template <std::size_t b, class A, class Limb>
+constexpr std::wstring to_wstring(const basic_big_int<b, A, Limb>& value, int base = 10);
 ----
 
 Behaves exactly like `to_string`, but returns a `std::wstring`. The digit

--- a/extra/big_int_printer_gdb.py
+++ b/extra/big_int_printer_gdb.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # SPDX-License-Identifier: BSL-1.0
 #
-# Pretty printer for beman::big_int::basic_big_int<min_inplace_bits, Allocator>.
+# Pretty printer for beman::big_int::basic_big_int<min_inplace_bits, Allocator, LimbType>.
 #
 # Layout (see include/beman/big_int/big_int.hpp):
 #   class basic_big_int {

--- a/extra/big_int_printer_lldb.py
+++ b/extra/big_int_printer_lldb.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # SPDX-License-Identifier: BSL-1.0
 #
-# Pretty printer for beman::big_int::basic_big_int<min_inplace_bits, Allocator>.
+# Pretty printer for beman::big_int::basic_big_int<min_inplace_bits, Allocator, LimbType>.
 #
 # Layout (see include/beman/big_int/big_int.hpp):
 #   class basic_big_int {

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -47,19 +47,19 @@ template <std::size_t min_inplace_bits,
           class LimbType  = uint_multiprecision_t>
 class basic_big_int;
 
-template <std::size_t b, class A, class Limb>
-constexpr std::from_chars_result from_chars(const char*, const char*, basic_big_int<b, A, Limb>&, int = 10);
+template <std::size_t b, class A, class LimbType>
+constexpr std::from_chars_result from_chars(const char*, const char*, basic_big_int<b, A, LimbType>&, int = 10);
 
-template <std::size_t b, class A, class Limb>
-constexpr std::to_chars_result to_chars(char*, char*, const basic_big_int<b, A, Limb>&, int = 10);
+template <std::size_t b, class A, class LimbType>
+constexpr std::to_chars_result to_chars(char*, char*, const basic_big_int<b, A, LimbType>&, int = 10);
 
 namespace detail {
 
 template <class>
 struct is_basic_big_int : std::false_type {};
 
-template <std::size_t b, class A, class Limb>
-struct is_basic_big_int<basic_big_int<b, A, Limb>> : std::true_type {};
+template <std::size_t b, class A, class LimbType>
+struct is_basic_big_int<basic_big_int<b, A, LimbType>> : std::true_type {};
 
 template <class T>
 inline constexpr bool is_basic_big_int_v = is_basic_big_int<std::remove_cvref_t<T>>::value;
@@ -68,9 +68,9 @@ inline constexpr bool is_basic_big_int_v = is_basic_big_int<std::remove_cvref_t<
 template <class>
 struct limb_type_of {};
 
-template <std::size_t b, class A, class Limb>
-struct limb_type_of<basic_big_int<b, A, Limb>> {
-    using type = Limb;
+template <std::size_t b, class A, class LimbType>
+struct limb_type_of<basic_big_int<b, A, LimbType>> {
+    using type = LimbType;
 };
 
 template <class T>
@@ -112,10 +112,10 @@ inline constexpr bool no_alloc_constructible_from = []() {
     }
 }();
 
-template <std::size_t b, class A, class Limb, class T>
+template <std::size_t b, class A, class LimbType, class T>
 inline constexpr bool is_implicit_constructible_from =
     detail::signed_or_unsigned<std::remove_cvref_t<T>> ||
-    std::is_same_v<std::remove_cvref_t<T>, basic_big_int<b, A, Limb>>;
+    std::is_same_v<std::remove_cvref_t<T>, basic_big_int<b, A, LimbType>>;
 
 #if defined(__cpp_lib_allocate_at_least) && __cpp_lib_allocate_at_least >= 202302L
 using std::allocation_result;
@@ -294,11 +294,14 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     template <std::size_t, class, class>
     friend class basic_big_int;
 
-    template <std::size_t b, class A, class Limb>
-    friend constexpr std::from_chars_result from_chars(const char*, const char*, basic_big_int<b, A, Limb>&, int);
+    // These two spell the limb parameter `OtherLimbType` rather than `LimbType`: a member template
+    // may not redeclare a template parameter of the enclosing class ([temp.local]).
+    template <std::size_t b, class A, class OtherLimbType>
+    friend constexpr std::from_chars_result
+    from_chars(const char*, const char*, basic_big_int<b, A, OtherLimbType>&, int);
 
-    template <std::size_t b, class A, class Limb>
-    friend constexpr std::to_chars_result to_chars(char*, char*, const basic_big_int<b, A, Limb>&, int);
+    template <std::size_t b, class A, class OtherLimbType>
+    friend constexpr std::to_chars_result to_chars(char*, char*, const basic_big_int<b, A, OtherLimbType>&, int);
 
     friend struct ::std::hash<basic_big_int>;
 
@@ -910,34 +913,34 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
 
 // Internal accessors
 
-template <std::size_t b, class A, class Limb>
-constexpr bool basic_big_int<b, A, Limb>::is_representation_inplace() const noexcept {
+template <std::size_t b, class A, class LimbType>
+constexpr bool basic_big_int<b, A, LimbType>::is_representation_inplace() const noexcept {
     return m_capacity == 0;
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr std::uint32_t basic_big_int<b, A, Limb>::limb_count() const noexcept {
+template <std::size_t b, class A, class LimbType>
+constexpr std::uint32_t basic_big_int<b, A, LimbType>::limb_count() const noexcept {
     constexpr std::uint32_t negative_zero_size_and_sign = 0x8000'0000U;
     BEMAN_BIG_INT_DEBUG_ASSERT(m_size_and_sign != negative_zero_size_and_sign);
     return m_size_and_sign & 0x7FFF'FFFFU;
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr bool basic_big_int<b, A, Limb>::is_negative() const noexcept {
+template <std::size_t b, class A, class LimbType>
+constexpr bool basic_big_int<b, A, LimbType>::is_negative() const noexcept {
     constexpr std::uint32_t negative_zero_size_and_sign = 0x8000'0000U;
     BEMAN_BIG_INT_DEBUG_ASSERT(m_size_and_sign != negative_zero_size_and_sign);
     return (m_size_and_sign & 0x8000'0000U) != 0;
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr bool basic_big_int<b, A, Limb>::is_zero() const noexcept {
+template <std::size_t b, class A, class LimbType>
+constexpr bool basic_big_int<b, A, LimbType>::is_zero() const noexcept {
     // We have the invariant that the sign bit is never set for zero magnitude,
     // so negative numbers short-circuit here.
     return !is_negative() && unchecked_is_magnitude_zero();
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr bool basic_big_int<b, A, Limb>::unchecked_is_magnitude_zero() const noexcept {
+template <std::size_t b, class A, class LimbType>
+constexpr bool basic_big_int<b, A, LimbType>::unchecked_is_magnitude_zero() const noexcept {
     const std::uint32_t unchecked_limb_count = m_size_and_sign & 0x7FFF'FFFFU;
     const limb_type*    limbs                = limb_ptr();
     for (std::uint32_t i = 0; i < unchecked_limb_count; ++i) {
@@ -948,32 +951,32 @@ constexpr bool basic_big_int<b, A, Limb>::unchecked_is_magnitude_zero() const no
     return true;
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr void basic_big_int<b, A, Limb>::unchecked_set_limb_count(const std::uint32_t n) noexcept {
+template <std::size_t b, class A, class LimbType>
+constexpr void basic_big_int<b, A, LimbType>::unchecked_set_limb_count(const std::uint32_t n) noexcept {
     BEMAN_BIG_INT_DEBUG_ASSERT(n != 0);
     m_size_and_sign = (m_size_and_sign & 0x8000'0000U) | n;
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr void basic_big_int<b, A, Limb>::unchecked_set_sign(const bool s) noexcept {
+template <std::size_t b, class A, class LimbType>
+constexpr void basic_big_int<b, A, LimbType>::unchecked_set_sign(const bool s) noexcept {
     m_size_and_sign = (m_size_and_sign & 0x7FFF'FFFFU) | (static_cast<std::uint32_t>(s) << 31);
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr void basic_big_int<b, A, Limb>::negate() noexcept {
+template <std::size_t b, class A, class LimbType>
+constexpr void basic_big_int<b, A, LimbType>::negate() noexcept {
     if (!is_zero()) {
         m_size_and_sign ^= 0x8000'0000U;
     }
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr void basic_big_int<b, A, Limb>::set_zero() noexcept {
+template <std::size_t b, class A, class LimbType>
+constexpr void basic_big_int<b, A, LimbType>::set_zero() noexcept {
     limb_ptr()[0]   = 0;
     m_size_and_sign = 1;
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr void basic_big_int<b, A, Limb>::unchecked_trim_magnitude() noexcept {
+template <std::size_t b, class A, class LimbType>
+constexpr void basic_big_int<b, A, LimbType>::unchecked_trim_magnitude() noexcept {
     const limb_type* const limbs = limb_ptr();
     std::uint32_t          size  = m_size_and_sign & 0x7FFF'FFFFU;
     if (size > 1 && limbs[size - 1] == 0) {
@@ -986,25 +989,25 @@ constexpr void basic_big_int<b, A, Limb>::unchecked_trim_magnitude() noexcept {
     }
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr auto basic_big_int<b, A, Limb>::limb_ptr() noexcept -> limb_type* {
+template <std::size_t b, class A, class LimbType>
+constexpr auto basic_big_int<b, A, LimbType>::limb_ptr() noexcept -> limb_type* {
     return is_representation_inplace() ? m_storage.limbs : m_storage.data;
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr auto basic_big_int<b, A, Limb>::limb_ptr() const noexcept -> const limb_type* {
+template <std::size_t b, class A, class LimbType>
+constexpr auto basic_big_int<b, A, LimbType>::limb_ptr() const noexcept -> const limb_type* {
     return is_representation_inplace() ? m_storage.limbs : m_storage.data;
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr std::span<uint_multiprecision_t> basic_big_int<b, A, Limb>::limb_span() noexcept {
+template <std::size_t b, class A, class LimbType>
+constexpr std::span<uint_multiprecision_t> basic_big_int<b, A, LimbType>::limb_span() noexcept {
     return {limb_ptr(), limb_count()};
 }
 
 // [big.int.cons] — constructors
 
-template <std::size_t b, class A, class Limb>
-constexpr basic_big_int<b, A, Limb>::basic_big_int(const basic_big_int& x)
+template <std::size_t b, class A, class LimbType>
+constexpr basic_big_int<b, A, LimbType>::basic_big_int(const basic_big_int& x)
     : m_capacity{0}, m_size_and_sign{x.m_size_and_sign}, m_storage{}, m_alloc{x.m_alloc} {
     if (x.limb_count() <= inplace_capacity) {
         if (x.is_representation_inplace()) {
@@ -1029,8 +1032,8 @@ constexpr basic_big_int<b, A, Limb>::basic_big_int(const basic_big_int& x)
     }
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr basic_big_int<b, A, Limb>::basic_big_int(basic_big_int&& x) noexcept
+template <std::size_t b, class A, class LimbType>
+constexpr basic_big_int<b, A, LimbType>::basic_big_int(basic_big_int&& x) noexcept
     : m_capacity{x.m_capacity}, m_size_and_sign{x.m_size_and_sign}, m_storage{}, m_alloc{std::move(x.m_alloc)} {
     if (x.is_representation_inplace()) {
         for (size_type i = 0; i < inplace_capacity; ++i) {
@@ -1044,14 +1047,14 @@ constexpr basic_big_int<b, A, Limb>::basic_big_int(basic_big_int&& x) noexcept
     }
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr basic_big_int<b, A, Limb>& basic_big_int<b, A, Limb>::operator=(const basic_big_int& x) {
+template <std::size_t b, class A, class LimbType>
+constexpr basic_big_int<b, A, LimbType>& basic_big_int<b, A, LimbType>::operator=(const basic_big_int& x) {
     assign_value(x);
     return *this;
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr basic_big_int<b, A, Limb>& basic_big_int<b, A, Limb>::operator=(basic_big_int&& x) noexcept {
+template <std::size_t b, class A, class LimbType>
+constexpr basic_big_int<b, A, LimbType>& basic_big_int<b, A, LimbType>::operator=(basic_big_int&& x) noexcept {
     // Invariant: `assign_value` with `extra_space == 0` and an rvalue `src`
     // never allocates -- either `*this` already fits `x.limb_count()`, or we
     // steal `x`'s heap buffer, or `x` is inline and fits inline in `*this`.
@@ -1067,8 +1070,8 @@ constexpr basic_big_int<b, A, Limb>& basic_big_int<b, A, Limb>::operator=(basic_
 // heap operand's storage while the freed pointer is adopted by the other.
 // The allocator participates only when `propagate_on_container_swap` holds;
 // otherwise [container.reqmts] requires the two allocators to compare equal.
-template <std::size_t b, class A, class Limb>
-constexpr void basic_big_int<b, A, Limb>::swap(basic_big_int& x) noexcept(
+template <std::size_t b, class A, class LimbType>
+constexpr void basic_big_int<b, A, LimbType>::swap(basic_big_int& x) noexcept(
     std::allocator_traits<A>::propagate_on_container_swap::value || std::allocator_traits<A>::is_always_equal::value) {
     if (this == std::addressof(x)) {
         return;
@@ -1108,9 +1111,9 @@ constexpr void basic_big_int<b, A, Limb>::swap(basic_big_int& x) noexcept(
     }
 }
 
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <detail::arbitrary_arithmetic T>
-constexpr basic_big_int<b, A, Limb>::basic_big_int(const T& value, const allocator_type& a) noexcept(
+constexpr basic_big_int<b, A, LimbType>::basic_big_int(const T& value, const allocator_type& a) noexcept(
     detail::no_alloc_constructible_from<inplace_bits, T>)
     : m_capacity{0}, m_size_and_sign{1}, m_storage{}, m_alloc{a} {
     if constexpr (std::is_floating_point_v<std::remove_cvref_t<T>>) {
@@ -1135,10 +1138,10 @@ constexpr basic_big_int<b, A, Limb>::basic_big_int(const T& value, const allocat
     }
 }
 
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <std::input_iterator I, std::sentinel_for<I> S>
     requires detail::signed_or_unsigned<std::iter_value_t<I>>
-constexpr basic_big_int<b, A, Limb>::basic_big_int(I begin, S end, const allocator_type& a)
+constexpr basic_big_int<b, A, LimbType>::basic_big_int(I begin, S end, const allocator_type& a)
     : m_capacity{0}, m_size_and_sign{1}, m_storage{}, m_alloc{a} {
 
     if constexpr (std::ranges::sized_range<std::ranges::subrange<I, S>>) {
@@ -1164,16 +1167,16 @@ constexpr basic_big_int<b, A, Limb>::basic_big_int(I begin, S end, const allocat
     }
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr basic_big_int<b, A, Limb>::~basic_big_int() {
+template <std::size_t b, class A, class LimbType>
+constexpr basic_big_int<b, A, LimbType>::~basic_big_int() {
     free_storage();
 }
 
 // [big.int.modifiers]
 
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <detail::signed_or_unsigned S>
-constexpr auto basic_big_int<b, A, Limb>::operator>>=(const S s) -> basic_big_int& {
+constexpr auto basic_big_int<b, A, LimbType>::operator>>=(const S s) -> basic_big_int& {
     // If this pattern comes up more often, we should consider something like a `safe_cast` utility.
     // This would convert to another type and signal whether the result is exactly representable.
     if constexpr (std::is_signed_v<S>) {
@@ -1186,9 +1189,9 @@ constexpr auto basic_big_int<b, A, Limb>::operator>>=(const S s) -> basic_big_in
     return *this;
 }
 
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <detail::signed_or_unsigned S>
-constexpr auto basic_big_int<b, A, Limb>::operator<<=(const S s) -> basic_big_int& {
+constexpr auto basic_big_int<b, A, LimbType>::operator<<=(const S s) -> basic_big_int& {
     if constexpr (std::is_signed_v<S>) {
         BEMAN_BIG_INT_DEBUG_ASSERT(s >= 0);
         BEMAN_BIG_INT_DEBUG_ASSERT(static_cast<detail::make_unsigned_t<S>>(s) <= shift_max);
@@ -1199,8 +1202,8 @@ constexpr auto basic_big_int<b, A, Limb>::operator<<=(const S s) -> basic_big_in
     return *this;
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr bool basic_big_int<b, A, Limb>::unchecked_increment_magnitude() {
+template <std::size_t b, class A, class LimbType>
+constexpr bool basic_big_int<b, A, LimbType>::unchecked_increment_magnitude() {
     limb_type* const limbs    = limb_ptr();
     bool             carry_in = true;
     for (size_type i = 0; carry_in && i < limb_count(); ++i) {
@@ -1216,8 +1219,8 @@ constexpr bool basic_big_int<b, A, Limb>::unchecked_increment_magnitude() {
     return carry_in;
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr bool basic_big_int<b, A, Limb>::unchecked_decrement_magnitude() {
+template <std::size_t b, class A, class LimbType>
+constexpr bool basic_big_int<b, A, LimbType>::unchecked_decrement_magnitude() {
     limb_type* const limbs     = limb_ptr();
     bool             borrow_in = true;
     for (size_type i = 0; borrow_in && i < limb_count(); ++i) {
@@ -1236,8 +1239,8 @@ constexpr bool basic_big_int<b, A, Limb>::unchecked_decrement_magnitude() {
     return borrow_in;
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr void basic_big_int<b, A, Limb>::shift_left(const shift_type s) {
+template <std::size_t b, class A, class LimbType>
+constexpr void basic_big_int<b, A, LimbType>::shift_left(const shift_type s) {
     BEMAN_BIG_INT_DEBUG_ASSERT(s <= shift_max);
     if (s == 0) {
         return;
@@ -1279,8 +1282,8 @@ constexpr void basic_big_int<b, A, Limb>::shift_left(const shift_type s) {
     }
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr void basic_big_int<b, A, Limb>::shift_right(const shift_type s) {
+template <std::size_t b, class A, class LimbType>
+constexpr void basic_big_int<b, A, LimbType>::shift_right(const shift_type s) {
     BEMAN_BIG_INT_DEBUG_ASSERT(s <= shift_max);
     if (s == 0) {
         return;
@@ -1338,8 +1341,8 @@ constexpr void basic_big_int<b, A, Limb>::shift_right(const shift_type s) {
 
 // [big.int.ops]
 
-template <std::size_t b, class A, class Limb>
-constexpr std::size_t basic_big_int<b, A, Limb>::width_mag() const noexcept {
+template <std::size_t b, class A, class LimbType>
+constexpr std::size_t basic_big_int<b, A, LimbType>::width_mag() const noexcept {
     const auto count = limb_count();
     const auto top   = limb_ptr()[count - 1];
     if (top == 0) {
@@ -1348,28 +1351,28 @@ constexpr std::size_t basic_big_int<b, A, Limb>::width_mag() const noexcept {
     return (count - 1) * bits_per_limb + (bits_per_limb - static_cast<size_type>(std::countl_zero(top)));
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr std::span<const uint_multiprecision_t> basic_big_int<b, A, Limb>::representation() const noexcept {
+template <std::size_t b, class A, class LimbType>
+constexpr std::span<const uint_multiprecision_t> basic_big_int<b, A, LimbType>::representation() const noexcept {
     return {limb_ptr(), limb_count()};
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr std::size_t basic_big_int<b, A, Limb>::representation_size() const noexcept {
+template <std::size_t b, class A, class LimbType>
+constexpr std::size_t basic_big_int<b, A, LimbType>::representation_size() const noexcept {
     // Number of limbs spanned by the magnitude: a single limb for a zero value,
     // otherwise ceil(width_mag() / bits_per_limb). Equals representation().size().
     return is_zero() ? size_type{1} : detail::div_to_pos_inf(width_mag(), bits_per_limb);
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr typename basic_big_int<b, A, Limb>::allocator_type
-basic_big_int<b, A, Limb>::get_allocator() const noexcept {
+template <std::size_t b, class A, class LimbType>
+constexpr typename basic_big_int<b, A, LimbType>::allocator_type
+basic_big_int<b, A, LimbType>::get_allocator() const noexcept {
     return m_alloc;
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr std::size_t basic_big_int<b, A, Limb>::size() const noexcept {
+template <std::size_t b, class A, class LimbType>
+constexpr std::size_t basic_big_int<b, A, LimbType>::size() const noexcept {
     if (is_negative()) {
-        basic_big_int<b, A, Limb> negated(*this);
+        basic_big_int<b, A, LimbType> negated(*this);
         negated.negate();
         return negated.size();
     } else if (is_zero()) {
@@ -1379,14 +1382,14 @@ constexpr std::size_t basic_big_int<b, A, Limb>::size() const noexcept {
     }
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr std::size_t basic_big_int<b, A, Limb>::max_size() noexcept {
+template <std::size_t b, class A, class LimbType>
+constexpr std::size_t basic_big_int<b, A, LimbType>::max_size() noexcept {
     // Maximum number of bits the magnitude may occupy.
     return max_representation_size() * bits_per_limb;
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr std::size_t basic_big_int<b, A, Limb>::max_representation_size() noexcept {
+template <std::size_t b, class A, class LimbType>
+constexpr std::size_t basic_big_int<b, A, LimbType>::max_representation_size() noexcept {
     // A limb count occupies 31 bits of the control word; in addition, the bit count reported
     // by max_size() must be representable in size_type. The smaller of the two limits wins.
     constexpr size_type storage_cap  = (size_type{1} << 31U) - 1U;
@@ -1394,33 +1397,33 @@ constexpr std::size_t basic_big_int<b, A, Limb>::max_representation_size() noexc
     return std::min(storage_cap, overflow_cap);
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr void basic_big_int<b, A, Limb>::reserve(const size_type n) {
+template <std::size_t b, class A, class LimbType>
+constexpr void basic_big_int<b, A, LimbType>::reserve(const size_type n) {
     // n is a bit count; reserve enough limbs to hold it.
     reserve_representation(detail::div_to_pos_inf(n, bits_per_limb));
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr void basic_big_int<b, A, Limb>::reserve_representation(const size_type n) {
+template <std::size_t b, class A, class LimbType>
+constexpr void basic_big_int<b, A, LimbType>::reserve_representation(const size_type n) {
     // Reserve room for at least n representation limbs.
     grow(n);
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr auto basic_big_int<b, A, Limb>::capacity() const noexcept -> size_type {
+template <std::size_t b, class A, class LimbType>
+constexpr auto basic_big_int<b, A, LimbType>::capacity() const noexcept -> size_type {
     // Number of bits of storage currently available without reallocating.
     return representation_capacity() * bits_per_limb;
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr auto basic_big_int<b, A, Limb>::representation_capacity() const noexcept -> size_type {
+template <std::size_t b, class A, class LimbType>
+constexpr auto basic_big_int<b, A, LimbType>::representation_capacity() const noexcept -> size_type {
     // Usable limb capacity: the in-place limb count, or the dynamic allocation size once
     // the value has spilled to the heap. Never drops below inplace_capacity.
     return std::max<size_type>(inplace_capacity, m_capacity);
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr void basic_big_int<b, A, Limb>::shrink_to_fit() {
+template <std::size_t b, class A, class LimbType>
+constexpr void basic_big_int<b, A, LimbType>::shrink_to_fit() {
     const auto count = limb_count();
 
     if (is_representation_inplace() || m_capacity <= count) {
@@ -1453,32 +1456,32 @@ constexpr void basic_big_int<b, A, Limb>::shrink_to_fit() {
 
 // [big.int.unary]
 
-template <std::size_t b, class A, class Limb>
-constexpr auto basic_big_int<b, A, Limb>::operator+() const& -> basic_big_int {
+template <std::size_t b, class A, class LimbType>
+constexpr auto basic_big_int<b, A, LimbType>::operator+() const& -> basic_big_int {
     return *this;
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr auto basic_big_int<b, A, Limb>::operator+() && noexcept -> basic_big_int {
+template <std::size_t b, class A, class LimbType>
+constexpr auto basic_big_int<b, A, LimbType>::operator+() && noexcept -> basic_big_int {
     return std::move(*this);
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr auto basic_big_int<b, A, Limb>::operator-() const& -> basic_big_int {
+template <std::size_t b, class A, class LimbType>
+constexpr auto basic_big_int<b, A, LimbType>::operator-() const& -> basic_big_int {
     auto copy = *this;
     copy.negate();
     return copy;
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr auto basic_big_int<b, A, Limb>::operator-() && noexcept -> basic_big_int {
+template <std::size_t b, class A, class LimbType>
+constexpr auto basic_big_int<b, A, LimbType>::operator-() && noexcept -> basic_big_int {
     auto copy = std::move(*this);
     copy.negate();
     return copy;
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr auto basic_big_int<b, A, Limb>::operator~() const& -> basic_big_int {
+template <std::size_t b, class A, class LimbType>
+constexpr auto basic_big_int<b, A, LimbType>::operator~() const& -> basic_big_int {
     // Bitwise operations emulate two's complement behavior,
     // where ~x is mathematically (-x - 1).
     auto copy = *this;
@@ -1487,8 +1490,8 @@ constexpr auto basic_big_int<b, A, Limb>::operator~() const& -> basic_big_int {
     return copy;
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr auto basic_big_int<b, A, Limb>::operator~() && -> basic_big_int {
+template <std::size_t b, class A, class LimbType>
+constexpr auto basic_big_int<b, A, LimbType>::operator~() && -> basic_big_int {
     // See also the const& overload.
     // Unlike operator-, we cannot make this noexcept because the decrement may reallocate.
     auto copy = std::move(*this);
@@ -1497,8 +1500,8 @@ constexpr auto basic_big_int<b, A, Limb>::operator~() && -> basic_big_int {
     return copy;
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr auto basic_big_int<b, A, Limb>::operator++() & -> basic_big_int& {
+template <std::size_t b, class A, class LimbType>
+constexpr auto basic_big_int<b, A, LimbType>::operator++() & -> basic_big_int& {
     if (is_negative()) {
         unchecked_decrement_magnitude();
         if (limb_count() == 1 && limb_ptr()[0] == 0) {
@@ -1510,15 +1513,15 @@ constexpr auto basic_big_int<b, A, Limb>::operator++() & -> basic_big_int& {
     return *this;
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr auto basic_big_int<b, A, Limb>::operator++(int) & -> basic_big_int {
+template <std::size_t b, class A, class LimbType>
+constexpr auto basic_big_int<b, A, LimbType>::operator++(int) & -> basic_big_int {
     auto copy = *this;
     ++(*this);
     return copy;
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr auto basic_big_int<b, A, Limb>::operator--() & -> basic_big_int& {
+template <std::size_t b, class A, class LimbType>
+constexpr auto basic_big_int<b, A, LimbType>::operator--() & -> basic_big_int& {
     if (is_negative()) {
         unchecked_increment_magnitude();
     } else {
@@ -1529,8 +1532,8 @@ constexpr auto basic_big_int<b, A, Limb>::operator--() & -> basic_big_int& {
     return *this;
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr auto basic_big_int<b, A, Limb>::operator--(int) & -> basic_big_int {
+template <std::size_t b, class A, class LimbType>
+constexpr auto basic_big_int<b, A, LimbType>::operator--(int) & -> basic_big_int {
     auto copy = *this;
     --(*this);
     return copy;
@@ -1565,9 +1568,9 @@ constexpr std::strong_ordering operator<=>(const L& lhs, const R& rhs) noexcept 
     }
 }
 
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <detail::cv_unqualified_arithmetic T, bool ignore_sign>
-constexpr T basic_big_int<b, A, Limb>::to() const noexcept {
+constexpr T basic_big_int<b, A, LimbType>::to() const noexcept {
     if constexpr (std::is_same_v<T, bool>) {
         return !is_zero();
     } else if constexpr (std::is_floating_point_v<T>) {
@@ -1743,9 +1746,9 @@ inline constexpr binary_op_form classify_form_v = [] {
 
 } // namespace detail
 
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <detail::bitwise_op op, class T>
-constexpr auto basic_big_int<b, A, Limb>::bitwise_assign_impl(T&& rhs) -> basic_big_int&
+constexpr auto basic_big_int<b, A, LimbType>::bitwise_assign_impl(T&& rhs) -> basic_big_int&
     requires detail::common_big_int_type_with<T, basic_big_int>
 {
     if constexpr (detail::is_basic_big_int_v<std::remove_cvref_t<T>>) {
@@ -1780,7 +1783,7 @@ constexpr auto basic_big_int<b, A, Limb>::bitwise_assign_impl(T&& rhs) -> basic_
 //   * one  `basic_big_int` lvalue   -> copy it (the other side is a primitive)
 //
 // `common_big_int_type` only yields a type when both `basic_big_int` operands are the
-// exact same `basic_big_int<b, A, Limb>` instantiation, so the operand type already matches
+// exact same `basic_big_int<b, A, LimbType>` instantiation, so the operand type already matches
 // `Result` and no explicit type-equality guard is needed.
 template <class L, class R>
 constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y) {
@@ -1916,9 +1919,9 @@ constexpr detail::common_big_int_type<L, R> operator-(L&& x, R&& y) {
     }
 }
 
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <detail::bitwise_op op, class L, class R>
-constexpr detail::common_big_int_type<L, R> basic_big_int<b, A, Limb>::bitwise_impl(L&& x, R&& y) {
+constexpr detail::common_big_int_type<L, R> basic_big_int<b, A, LimbType>::bitwise_impl(L&& x, R&& y) {
     using Result        = detail::common_big_int_type<L, R>;
     constexpr auto form = detail::classify_form_v<L, R>;
 
@@ -1937,10 +1940,11 @@ constexpr detail::common_big_int_type<L, R> basic_big_int<b, A, Limb>::bitwise_i
     }
 }
 
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <detail::bitwise_op op, std::size_t extent>
-constexpr void basic_big_int<b, A, Limb>::bitwise_in_place(const std::span<const uint_multiprecision_t, extent> other,
-                                                           const bool other_neg) {
+constexpr void
+basic_big_int<b, A, LimbType>::bitwise_in_place(const std::span<const uint_multiprecision_t, extent> other,
+                                                const bool                                           other_neg) {
     const bool this_neg = is_negative();
 
     const auto run = [&]<bool NL, bool NR>() {
@@ -2145,9 +2149,9 @@ constexpr std::remove_cvref_t<T> operator>>(T&& x, const S s) {
     }
 }
 
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <detail::signed_or_unsigned Integer>
-constexpr bool basic_big_int<b, A, Limb>::equals_integer(const Integer x) const noexcept {
+constexpr bool basic_big_int<b, A, LimbType>::equals_integer(const Integer x) const noexcept {
     if constexpr (std::is_unsigned_v<Integer>) {
         if (is_negative()) {
             return false;
@@ -2164,16 +2168,16 @@ constexpr bool basic_big_int<b, A, Limb>::equals_integer(const Integer x) const 
     }
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr bool basic_big_int<b, A, Limb>::equals_big_int(const basic_big_int& x) const noexcept {
+template <std::size_t b, class A, class LimbType>
+constexpr bool basic_big_int<b, A, LimbType>::equals_big_int(const basic_big_int& x) const noexcept {
     // We can do fancier things in the future, but this works for now.
     return equals_limbs(x.representation(), x.is_negative());
 }
 
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <std::size_t extent>
-constexpr bool basic_big_int<b, A, Limb>::equals_limbs(const std::span<const uint_multiprecision_t, extent> limbs,
-                                                       const bool limbs_negative) const noexcept {
+constexpr bool basic_big_int<b, A, LimbType>::equals_limbs(const std::span<const uint_multiprecision_t, extent> limbs,
+                                                           const bool limbs_negative) const noexcept {
     if (is_negative() != limbs_negative) {
         return false;
     }
@@ -2213,9 +2217,9 @@ constexpr bool basic_big_int<b, A, Limb>::equals_limbs(const std::span<const uin
     return true;
 }
 
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <detail::signed_or_unsigned Integer>
-constexpr std::strong_ordering basic_big_int<b, A, Limb>::compare_integer(const Integer x) const noexcept {
+constexpr std::strong_ordering basic_big_int<b, A, LimbType>::compare_integer(const Integer x) const noexcept {
     if constexpr (std::is_unsigned_v<Integer>) {
         if (is_negative()) {
             return std::strong_ordering::less;
@@ -2244,17 +2248,17 @@ constexpr std::strong_ordering basic_big_int<b, A, Limb>::compare_integer(const 
     }
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr std::strong_ordering basic_big_int<b, A, Limb>::compare_big_int(const basic_big_int& x) const noexcept {
+template <std::size_t b, class A, class LimbType>
+constexpr std::strong_ordering basic_big_int<b, A, LimbType>::compare_big_int(const basic_big_int& x) const noexcept {
     // We can do fancier things in the future, but this works for now.
     return compare_limbs(x.representation(), x.is_negative());
 }
 
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <std::size_t extent>
 constexpr std::strong_ordering
-basic_big_int<b, A, Limb>::compare_limbs(const std::span<const uint_multiprecision_t, extent> limbs,
-                                         const bool limbs_negative) const noexcept {
+basic_big_int<b, A, LimbType>::compare_limbs(const std::span<const uint_multiprecision_t, extent> limbs,
+                                             const bool limbs_negative) const noexcept {
     // A mismatch between signs lets us short-circuit without comparing the magnitudes.
     const auto sign_compare = limbs_negative <=> is_negative();
     if (std::is_neq(sign_compare)) {
@@ -2272,11 +2276,11 @@ basic_big_int<b, A, Limb>::compare_limbs(const std::span<const uint_multiprecisi
 // Adds `(other, other_neg)` into `*this` in place. Shared core for `operator+` and
 // `operator-`: the caller chooses the destination (an rvalue operand's storage or a
 // copy of an lvalue operand) and supplies the other side as a limb span + sign.
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <std::size_t extent_other>
 constexpr void
-basic_big_int<b, A, Limb>::add_in_place(const std::span<const uint_multiprecision_t, extent_other> other,
-                                        const bool                                                 other_neg) {
+basic_big_int<b, A, LimbType>::add_in_place(const std::span<const uint_multiprecision_t, extent_other> other,
+                                            const bool                                                 other_neg) {
     const bool this_neg = is_negative();
 
     if (this_neg == other_neg) {
@@ -2365,12 +2369,12 @@ basic_big_int<b, A, Limb>::add_in_place(const std::span<const uint_multiprecisio
 // Computes `(a, a_neg) + (b, b_neg)` directly into `*this`.
 // Fuses copy and potential second allocation
 // Precondition: `a.size() >= b.size()`
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <std::size_t extent_a, std::size_t extent_b>
-constexpr void basic_big_int<b, A, Limb>::add_into(const std::span<const uint_multiprecision_t, extent_a> a,
-                                                   const bool                                             a_neg,
-                                                   const std::span<const uint_multiprecision_t, extent_b> b_span,
-                                                   const bool                                             b_neg) {
+constexpr void basic_big_int<b, A, LimbType>::add_into(const std::span<const uint_multiprecision_t, extent_a> a,
+                                                       const bool                                             a_neg,
+                                                       const std::span<const uint_multiprecision_t, extent_b> b_span,
+                                                       const bool                                             b_neg) {
     BEMAN_BIG_INT_DEBUG_ASSERT(a.size() >= b_span.size());
 
     if (a_neg == b_neg) {
@@ -2562,12 +2566,13 @@ constexpr void basic_big_int<b, A, Limb>::add_into(const std::span<const uint_mu
 }
 
 // Computes `a * b` and stores the result into `*this`.
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <std::size_t extent_a, std::size_t extent_b>
-constexpr void basic_big_int<b, A, Limb>::multiply_into(const std::span<const uint_multiprecision_t, extent_a> a,
-                                                        const bool                                             a_neg,
-                                                        const std::span<const uint_multiprecision_t, extent_b> b_span,
-                                                        const bool                                             b_neg) {
+constexpr void
+basic_big_int<b, A, LimbType>::multiply_into(const std::span<const uint_multiprecision_t, extent_a> a,
+                                             const bool                                             a_neg,
+                                             const std::span<const uint_multiprecision_t, extent_b> b_span,
+                                             const bool                                             b_neg) {
     const auto a_trimmed = a.first(detail::trimmed_size_span(a));
     const auto b_trimmed = b_span.first(detail::trimmed_size_span(b_span));
 
@@ -2612,11 +2617,11 @@ constexpr void basic_big_int<b, A, Limb>::multiply_into(const std::span<const ui
     unchecked_set_sign(a_neg != b_neg && !unchecked_is_magnitude_zero());
 }
 
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <detail::bitwise_op op, bool neg_left, bool neg_right, std::size_t extent_a, std::size_t extent_b>
-constexpr basic_big_int<b, A, Limb>
-basic_big_int<b, A, Limb>::make_bitwise_of_limbs(const std::span<const uint_multiprecision_t, extent_a> lhs,
-                                                 const std::span<const uint_multiprecision_t, extent_b> rhs) {
+constexpr basic_big_int<b, A, LimbType>
+basic_big_int<b, A, LimbType>::make_bitwise_of_limbs(const std::span<const uint_multiprecision_t, extent_a> lhs,
+                                                     const std::span<const uint_multiprecision_t, extent_b> rhs) {
     constexpr bool res_neg = detail::eval_bitwise<op>(neg_left, neg_right);
 
     const std::size_t n = [&]() -> std::size_t {
@@ -2646,13 +2651,13 @@ basic_big_int<b, A, Limb>::make_bitwise_of_limbs(const std::span<const uint_mult
     return result;
 }
 
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <detail::bitwise_op op, std::size_t extent_a, std::size_t extent_b>
-constexpr basic_big_int<b, A, Limb>
-basic_big_int<b, A, Limb>::dispatch_bitwise(const std::span<const uint_multiprecision_t, extent_a> lhs,
-                                            const bool                                             lhs_neg,
-                                            const std::span<const uint_multiprecision_t, extent_b> rhs,
-                                            const bool                                             rhs_neg) {
+constexpr basic_big_int<b, A, LimbType>
+basic_big_int<b, A, LimbType>::dispatch_bitwise(const std::span<const uint_multiprecision_t, extent_a> lhs,
+                                                const bool                                             lhs_neg,
+                                                const std::span<const uint_multiprecision_t, extent_b> rhs,
+                                                const bool                                             rhs_neg) {
     if (!lhs_neg && !rhs_neg) {
         return make_bitwise_of_limbs<op, false, false>(lhs, rhs);
     }
@@ -2724,9 +2729,9 @@ constexpr detail::common_big_int_type<L, R> operator*(L&& x, R&& y) {
 // `*this` is always the destination, so we skip the copy/move step that the free
 // `operator+` / `operator-` need and fold `rhs` directly into our own storage via
 // `add_in_place`.
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <class T>
-constexpr auto basic_big_int<b, A, Limb>::operator+=(T&& rhs) -> basic_big_int&
+constexpr auto basic_big_int<b, A, LimbType>::operator+=(T&& rhs) -> basic_big_int&
     requires detail::common_big_int_type_with<T, basic_big_int>
 {
     if constexpr (detail::is_basic_big_int_v<std::remove_cvref_t<T>>) {
@@ -2738,9 +2743,9 @@ constexpr auto basic_big_int<b, A, Limb>::operator+=(T&& rhs) -> basic_big_int&
     return *this;
 }
 
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <class T>
-constexpr auto basic_big_int<b, A, Limb>::operator-=(T&& rhs) -> basic_big_int&
+constexpr auto basic_big_int<b, A, LimbType>::operator-=(T&& rhs) -> basic_big_int&
     requires detail::common_big_int_type_with<T, basic_big_int>
 {
     if constexpr (detail::is_basic_big_int_v<std::remove_cvref_t<T>>) {
@@ -2757,9 +2762,9 @@ constexpr auto basic_big_int<b, A, Limb>::operator-=(T&& rhs) -> basic_big_int&
 }
 
 // Compound multiplication assignment.
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <class T>
-constexpr auto basic_big_int<b, A, Limb>::operator*=(T&& rhs) -> basic_big_int&
+constexpr auto basic_big_int<b, A, LimbType>::operator*=(T&& rhs) -> basic_big_int&
     requires detail::common_big_int_type_with<T, basic_big_int>
 {
     if constexpr (detail::is_basic_big_int_v<std::remove_cvref_t<T>>) {
@@ -2787,14 +2792,14 @@ constexpr auto basic_big_int<b, A, Limb>::operator*=(T&& rhs) -> basic_big_int&
 // Single-limb divisor fast path from Knuth
 // Avoids allocating a remainder scratch buffer and a `t` buffer: we just stream the quotient through `*this`'s
 // limbs and carry a single remainder limb between iterations.
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <std::size_t extent_a>
 constexpr uint_multiprecision_t
-basic_big_int<b, A, Limb>::divmod_into_short(const std::span<const uint_multiprecision_t, extent_a> dividend,
-                                             const bool                                             dividend_neg,
-                                             const uint_multiprecision_t                            divisor,
-                                             const bool                                             divisor_neg,
-                                             const detail::division_op                              op) {
+basic_big_int<b, A, LimbType>::divmod_into_short(const std::span<const uint_multiprecision_t, extent_a> dividend,
+                                                 const bool                                             dividend_neg,
+                                                 const uint_multiprecision_t                            divisor,
+                                                 const bool                                             divisor_neg,
+                                                 const detail::division_op                              op) {
     BEMAN_BIG_INT_ASSERT(divisor != 0);
 
     const bool want_quotient = op != detail::division_op::rem;
@@ -2836,10 +2841,9 @@ basic_big_int<b, A, Limb>::divmod_into_short(const std::span<const uint_multipre
     return remainder;
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr uint_multiprecision_t basic_big_int<b, A, Limb>::divmod_in_place_short(const uint_multiprecision_t divisor,
-                                                                                 const bool                divisor_neg,
-                                                                                 const detail::division_op op) {
+template <std::size_t b, class A, class LimbType>
+constexpr uint_multiprecision_t basic_big_int<b, A, LimbType>::divmod_in_place_short(
+    const uint_multiprecision_t divisor, const bool divisor_neg, const detail::division_op op) {
     BEMAN_BIG_INT_ASSERT(divisor != 0);
 
     const bool                  want_quotient = op != detail::division_op::rem;
@@ -2863,13 +2867,14 @@ constexpr uint_multiprecision_t basic_big_int<b, A, Limb>::divmod_in_place_short
 //   3) |dividend| < |divisor|,
 //   4) single-limb divisor
 // before falling through to `detail::divide_dispatch`.
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <std::size_t extent_a, std::size_t extent_b>
-constexpr auto basic_big_int<b, A, Limb>::divmod_into(const std::span<const uint_multiprecision_t, extent_a> dividend,
-                                                      const bool dividend_neg,
-                                                      const std::span<const uint_multiprecision_t, extent_b> divisor,
-                                                      const bool                divisor_neg,
-                                                      const detail::division_op op) -> basic_big_int {
+constexpr auto
+basic_big_int<b, A, LimbType>::divmod_into(const std::span<const uint_multiprecision_t, extent_a> dividend,
+                                           const bool                                             dividend_neg,
+                                           const std::span<const uint_multiprecision_t, extent_b> divisor,
+                                           const bool                                             divisor_neg,
+                                           const detail::division_op op) -> basic_big_int {
     const auto dividend_trim = dividend.first(detail::trimmed_size_span(dividend));
     const auto divisor_trim  = divisor.first(detail::trimmed_size_span(divisor));
 
@@ -3095,9 +3100,9 @@ constexpr detail::common_big_int_type<L, R> operator%(L&& x, R&& y) {
 }
 
 // Compound division and modulus assignments.
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <class T>
-constexpr auto basic_big_int<b, A, Limb>::operator/=(T&& rhs) -> basic_big_int&
+constexpr auto basic_big_int<b, A, LimbType>::operator/=(T&& rhs) -> basic_big_int&
     requires detail::common_big_int_type_with<T, basic_big_int>
 {
     if constexpr (detail::is_basic_big_int_v<std::remove_cvref_t<T>>) {
@@ -3139,9 +3144,9 @@ constexpr auto basic_big_int<b, A, Limb>::operator/=(T&& rhs) -> basic_big_int&
     return *this;
 }
 
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <class T>
-constexpr auto basic_big_int<b, A, Limb>::operator%=(T&& rhs) -> basic_big_int&
+constexpr auto basic_big_int<b, A, LimbType>::operator%=(T&& rhs) -> basic_big_int&
     requires detail::common_big_int_type_with<T, basic_big_int>
 {
     if constexpr (detail::is_basic_big_int_v<std::remove_cvref_t<T>>) {
@@ -3182,25 +3187,25 @@ constexpr auto basic_big_int<b, A, Limb>::operator%=(T&& rhs) -> basic_big_int&
     return *this;
 }
 
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <class T>
-constexpr auto basic_big_int<b, A, Limb>::operator&=(T&& rhs) -> basic_big_int&
+constexpr auto basic_big_int<b, A, LimbType>::operator&=(T&& rhs) -> basic_big_int&
     requires detail::common_big_int_type_with<T, basic_big_int>
 {
     return bitwise_assign_impl<detail::bitwise_op::and_>(std::forward<T>(rhs));
 }
 
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <class T>
-constexpr auto basic_big_int<b, A, Limb>::operator|=(T&& rhs) -> basic_big_int&
+constexpr auto basic_big_int<b, A, LimbType>::operator|=(T&& rhs) -> basic_big_int&
     requires detail::common_big_int_type_with<T, basic_big_int>
 {
     return bitwise_assign_impl<detail::bitwise_op::or_>(std::forward<T>(rhs));
 }
 
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <class T>
-constexpr auto basic_big_int<b, A, Limb>::operator^=(T&& rhs) -> basic_big_int&
+constexpr auto basic_big_int<b, A, LimbType>::operator^=(T&& rhs) -> basic_big_int&
     requires detail::common_big_int_type_with<T, basic_big_int>
 {
     return bitwise_assign_impl<detail::bitwise_op::xor_>(std::forward<T>(rhs));
@@ -3208,9 +3213,9 @@ constexpr auto basic_big_int<b, A, Limb>::operator^=(T&& rhs) -> basic_big_int&
 
 // private helpers
 
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <detail::unsigned_integer T>
-constexpr void basic_big_int<b, A, Limb>::assign_magnitude(T value) noexcept {
+constexpr void basic_big_int<b, A, LimbType>::assign_magnitude(T value) noexcept {
     constexpr size_type value_limbs = detail::div_to_pos_inf(detail::width_v<T>, bits_per_limb);
     if constexpr (value_limbs == 1) {
         limb_ptr()[0] = static_cast<limb_type>(value);
@@ -3240,9 +3245,9 @@ constexpr void basic_big_int<b, A, Limb>::assign_magnitude(T value) noexcept {
     }
 }
 
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 template <detail::cv_unqualified_floating_point F>
-constexpr void basic_big_int<b, A, Limb>::assign_from_float(const F value) noexcept {
+constexpr void basic_big_int<b, A, LimbType>::assign_from_float(const F value) noexcept {
     using traits = detail::ieee_traits<F>;
 #ifdef BEMAN_BIG_INT_UNSUPPORTED_LONG_DOUBLE
     static_assert(!std::is_same_v<F, long double>, "long double is not supported on this platform");
@@ -3280,8 +3285,8 @@ constexpr void basic_big_int<b, A, Limb>::assign_from_float(const F value) noexc
     unchecked_set_sign(sign);
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr auto basic_big_int<b, A, Limb>::alloc_limbs(const size_type n) -> alloc_result {
+template <std::size_t b, class A, class LimbType>
+constexpr auto basic_big_int<b, A, LimbType>::alloc_limbs(const size_type n) -> alloc_result {
     BEMAN_BIG_INT_ASSERT(n != 0);
 #if defined(__cpp_lib_allocate_at_least) && __cpp_lib_allocate_at_least >= 202302L
     if constexpr (detail::traits_has_allocate_at_least<alloc_traits, A>) {
@@ -3294,8 +3299,8 @@ constexpr auto basic_big_int<b, A, Limb>::alloc_limbs(const size_type n) -> allo
 #endif
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr void basic_big_int<b, A, Limb>::free_limbs(pointer p, const size_type n) {
+template <std::size_t b, class A, class LimbType>
+constexpr void basic_big_int<b, A, LimbType>::free_limbs(pointer p, const size_type n) {
     BEMAN_BIG_INT_ASSERT(p != nullptr);
     BEMAN_BIG_INT_ASSERT(n != 0);
     // Need to suppress known false positive warning.
@@ -3306,15 +3311,15 @@ constexpr void basic_big_int<b, A, Limb>::free_limbs(pointer p, const size_type 
     BEMAN_BIG_INT_DIAGNOSTIC_POP()
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr void basic_big_int<b, A, Limb>::free_storage() {
+template <std::size_t b, class A, class LimbType>
+constexpr void basic_big_int<b, A, LimbType>::free_storage() {
     if (!is_representation_inplace()) {
         free_limbs(m_storage.data, m_capacity);
     }
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr void basic_big_int<b, A, Limb>::grow(const size_type limbs_needed) {
+template <std::size_t b, class A, class LimbType>
+constexpr void basic_big_int<b, A, LimbType>::grow(const size_type limbs_needed) {
     const size_type current_cap = is_representation_inplace() ? inplace_capacity : m_capacity;
     if (limbs_needed <= current_cap) {
         return;
@@ -3332,9 +3337,10 @@ constexpr void basic_big_int<b, A, Limb>::grow(const size_type limbs_needed) {
     m_capacity     = static_cast<std::uint32_t>(allocation.count);
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr void
-basic_big_int<b, A, Limb>::copy_n_to_allocation(const limb_type* const p, const size_type n, const alloc_result out) {
+template <std::size_t b, class A, class LimbType>
+constexpr void basic_big_int<b, A, LimbType>::copy_n_to_allocation(const limb_type* const p,
+                                                                   const size_type        n,
+                                                                   const alloc_result     out) {
     BEMAN_BIG_INT_ASSERT(p != nullptr);
     BEMAN_BIG_INT_ASSERT(out.ptr != nullptr);
     BEMAN_BIG_INT_ASSERT(n <= out.count);
@@ -3361,8 +3367,8 @@ basic_big_int<b, A, Limb>::copy_n_to_allocation(const limb_type* const p, const 
 #endif
 }
 
-template <std::size_t b, class A, class Limb>
-constexpr void basic_big_int<b, A, Limb>::push_back_limb(limb_type limb) {
+template <std::size_t b, class A, class LimbType>
+constexpr void basic_big_int<b, A, LimbType>::push_back_limb(limb_type limb) {
     const auto count = limb_count();
     if (count >= (is_representation_inplace() ? inplace_capacity : m_capacity)) {
         grow(count + 1); // exponential growth
@@ -3400,8 +3406,8 @@ using big_int = basic_big_int<64, std::allocator<uint_multiprecision_t>>;
 
 namespace pmr {
 
-template <std::size_t b, class Limb = uint_multiprecision_t>
-using basic_big_int = beman::big_int::basic_big_int<b, std::pmr::polymorphic_allocator<Limb>, Limb>;
+template <std::size_t b, class LimbType = uint_multiprecision_t>
+using basic_big_int = beman::big_int::basic_big_int<b, std::pmr::polymorphic_allocator<LimbType>, LimbType>;
 
 using big_int = basic_big_int<beman::big_int::big_int::inplace_bits>;
 
@@ -3410,10 +3416,10 @@ using big_int = basic_big_int<beman::big_int::big_int::inplace_bits>;
 } // namespace beman::big_int
 
 // [big.int.hash], hash support
-template <std::size_t b, class A, class Limb>
-struct std::hash<beman::big_int::basic_big_int<b, A, Limb>> {
+template <std::size_t b, class A, class LimbType>
+struct std::hash<beman::big_int::basic_big_int<b, A, LimbType>> {
 
-    std::size_t operator()(const beman::big_int::basic_big_int<b, A, Limb>& x) const noexcept {
+    std::size_t operator()(const beman::big_int::basic_big_int<b, A, LimbType>& x) const noexcept {
         return beman::big_int::detail::siphash(x.representation(), x.is_negative());
     }
 };

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -42,25 +42,39 @@ namespace beman::big_int {
 using beman::big_int::uint_multiprecision_t;
 
 // Forward decl so that we can define our concepts
-template <std::size_t min_inplace_bits, class Allocator = std::allocator<uint_multiprecision_t>>
+template <std::size_t min_inplace_bits,
+          class Allocator = std::allocator<uint_multiprecision_t>,
+          class LimbType  = uint_multiprecision_t>
 class basic_big_int;
 
-template <std::size_t b, class A>
-constexpr std::from_chars_result from_chars(const char*, const char*, basic_big_int<b, A>&, int = 10);
+template <std::size_t b, class A, class Limb>
+constexpr std::from_chars_result from_chars(const char*, const char*, basic_big_int<b, A, Limb>&, int = 10);
 
-template <std::size_t b, class A>
-constexpr std::to_chars_result to_chars(char*, char*, const basic_big_int<b, A>&, int = 10);
+template <std::size_t b, class A, class Limb>
+constexpr std::to_chars_result to_chars(char*, char*, const basic_big_int<b, A, Limb>&, int = 10);
 
 namespace detail {
 
 template <class>
 struct is_basic_big_int : std::false_type {};
 
-template <std::size_t b, class A>
-struct is_basic_big_int<basic_big_int<b, A>> : std::true_type {};
+template <std::size_t b, class A, class Limb>
+struct is_basic_big_int<basic_big_int<b, A, Limb>> : std::true_type {};
 
 template <class T>
 inline constexpr bool is_basic_big_int_v = is_basic_big_int<std::remove_cvref_t<T>>::value;
+
+// Recovers the limb type of a basic_big_int specialization, which is otherwise private.
+template <class>
+struct limb_type_of {};
+
+template <std::size_t b, class A, class Limb>
+struct limb_type_of<basic_big_int<b, A, Limb>> {
+    using type = Limb;
+};
+
+template <class T>
+using limb_type_of_t = typename limb_type_of<std::remove_cvref_t<T>>::type;
 
 // [big.ing.expos]
 template <class T>
@@ -98,9 +112,10 @@ inline constexpr bool no_alloc_constructible_from = []() {
     }
 }();
 
-template <std::size_t b, class A, class T>
+template <std::size_t b, class A, class Limb, class T>
 inline constexpr bool is_implicit_constructible_from =
-    detail::signed_or_unsigned<std::remove_cvref_t<T>> || std::is_same_v<std::remove_cvref_t<T>, basic_big_int<b, A>>;
+    detail::signed_or_unsigned<std::remove_cvref_t<T>> ||
+    std::is_same_v<std::remove_cvref_t<T>, basic_big_int<b, A, Limb>>;
 
 #if defined(__cpp_lib_allocate_at_least) && __cpp_lib_allocate_at_least >= 202302L
 using std::allocation_result;
@@ -252,10 +267,15 @@ template <class T>
 constexpr std::remove_cvref_t<T> abs(T&& x);
 
 // [big.int.class], class template basic_big_int
-template <std::size_t min_inplace_bits, class Allocator>
+template <std::size_t min_inplace_bits, class Allocator, class LimbType>
 class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
 
-    using limb_type        = uint_multiprecision_t;
+    // The limb type is a template parameter so that a future revision can change it without
+    // changing the signature of basic_big_int. Only uint_multiprecision_t is supported today:
+    // the compiled multiplication and division kernels in src/ have a fixed-limb ABI.
+    static_assert(std::is_same_v<LimbType, uint_multiprecision_t>, "LimbType must be uint_multiprecision_t.");
+
+    using limb_type        = LimbType;
     using signed_limb_type = detail::int_multiprecision_t;
 
 #ifdef BEMAN_BIG_INT_HAS_WIDE_INT
@@ -268,17 +288,17 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     using size_type      = std::size_t;
     using pointer        = typename std::allocator_traits<Allocator>::pointer;
     using const_pointer  = typename std::allocator_traits<Allocator>::const_pointer;
-    static_assert(std::is_same_v<typename Allocator::value_type, uint_multiprecision_t>,
-                  "Allocator::value_type must be uint_multiprecision_t.");
+    static_assert(std::is_same_v<typename Allocator::value_type, limb_type>,
+                  "Allocator::value_type must be the limb type.");
 
-    template <std::size_t, class>
+    template <std::size_t, class, class>
     friend class basic_big_int;
 
-    template <std::size_t b, class A>
-    friend constexpr std::from_chars_result from_chars(const char*, const char*, basic_big_int<b, A>&, int);
+    template <std::size_t b, class A, class Limb>
+    friend constexpr std::from_chars_result from_chars(const char*, const char*, basic_big_int<b, A, Limb>&, int);
 
-    template <std::size_t b, class A>
-    friend constexpr std::to_chars_result to_chars(char*, char*, const basic_big_int<b, A>&, int);
+    template <std::size_t b, class A, class Limb>
+    friend constexpr std::to_chars_result to_chars(char*, char*, const basic_big_int<b, A, Limb>&, int);
 
     friend struct ::std::hash<basic_big_int>;
 
@@ -351,7 +371,7 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     // of constructors with conditional explicit + requires.
     template <detail::arbitrary_arithmetic T>
         requires(!std::same_as<std::remove_cvref_t<T>, basic_big_int>)
-    constexpr explicit(!detail::is_implicit_constructible_from<inplace_bits, Allocator, T>)
+    constexpr explicit(!detail::is_implicit_constructible_from<inplace_bits, Allocator, limb_type, T>)
         basic_big_int(T&& value) noexcept(detail::no_alloc_constructible_from<inplace_bits, T>)
         : m_capacity{0}, m_size_and_sign{1}, m_storage{}, m_alloc{} {
         if constexpr (std::is_floating_point_v<std::remove_cvref_t<T>>) {
@@ -890,34 +910,34 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
 
 // Internal accessors
 
-template <std::size_t b, class A>
-constexpr bool basic_big_int<b, A>::is_representation_inplace() const noexcept {
+template <std::size_t b, class A, class Limb>
+constexpr bool basic_big_int<b, A, Limb>::is_representation_inplace() const noexcept {
     return m_capacity == 0;
 }
 
-template <std::size_t b, class A>
-constexpr std::uint32_t basic_big_int<b, A>::limb_count() const noexcept {
+template <std::size_t b, class A, class Limb>
+constexpr std::uint32_t basic_big_int<b, A, Limb>::limb_count() const noexcept {
     constexpr std::uint32_t negative_zero_size_and_sign = 0x8000'0000U;
     BEMAN_BIG_INT_DEBUG_ASSERT(m_size_and_sign != negative_zero_size_and_sign);
     return m_size_and_sign & 0x7FFF'FFFFU;
 }
 
-template <std::size_t b, class A>
-constexpr bool basic_big_int<b, A>::is_negative() const noexcept {
+template <std::size_t b, class A, class Limb>
+constexpr bool basic_big_int<b, A, Limb>::is_negative() const noexcept {
     constexpr std::uint32_t negative_zero_size_and_sign = 0x8000'0000U;
     BEMAN_BIG_INT_DEBUG_ASSERT(m_size_and_sign != negative_zero_size_and_sign);
     return (m_size_and_sign & 0x8000'0000U) != 0;
 }
 
-template <std::size_t b, class A>
-constexpr bool basic_big_int<b, A>::is_zero() const noexcept {
+template <std::size_t b, class A, class Limb>
+constexpr bool basic_big_int<b, A, Limb>::is_zero() const noexcept {
     // We have the invariant that the sign bit is never set for zero magnitude,
     // so negative numbers short-circuit here.
     return !is_negative() && unchecked_is_magnitude_zero();
 }
 
-template <std::size_t b, class A>
-constexpr bool basic_big_int<b, A>::unchecked_is_magnitude_zero() const noexcept {
+template <std::size_t b, class A, class Limb>
+constexpr bool basic_big_int<b, A, Limb>::unchecked_is_magnitude_zero() const noexcept {
     const std::uint32_t unchecked_limb_count = m_size_and_sign & 0x7FFF'FFFFU;
     const limb_type*    limbs                = limb_ptr();
     for (std::uint32_t i = 0; i < unchecked_limb_count; ++i) {
@@ -928,32 +948,32 @@ constexpr bool basic_big_int<b, A>::unchecked_is_magnitude_zero() const noexcept
     return true;
 }
 
-template <std::size_t b, class A>
-constexpr void basic_big_int<b, A>::unchecked_set_limb_count(const std::uint32_t n) noexcept {
+template <std::size_t b, class A, class Limb>
+constexpr void basic_big_int<b, A, Limb>::unchecked_set_limb_count(const std::uint32_t n) noexcept {
     BEMAN_BIG_INT_DEBUG_ASSERT(n != 0);
     m_size_and_sign = (m_size_and_sign & 0x8000'0000U) | n;
 }
 
-template <std::size_t b, class A>
-constexpr void basic_big_int<b, A>::unchecked_set_sign(const bool s) noexcept {
+template <std::size_t b, class A, class Limb>
+constexpr void basic_big_int<b, A, Limb>::unchecked_set_sign(const bool s) noexcept {
     m_size_and_sign = (m_size_and_sign & 0x7FFF'FFFFU) | (static_cast<std::uint32_t>(s) << 31);
 }
 
-template <std::size_t b, class A>
-constexpr void basic_big_int<b, A>::negate() noexcept {
+template <std::size_t b, class A, class Limb>
+constexpr void basic_big_int<b, A, Limb>::negate() noexcept {
     if (!is_zero()) {
         m_size_and_sign ^= 0x8000'0000U;
     }
 }
 
-template <std::size_t b, class A>
-constexpr void basic_big_int<b, A>::set_zero() noexcept {
+template <std::size_t b, class A, class Limb>
+constexpr void basic_big_int<b, A, Limb>::set_zero() noexcept {
     limb_ptr()[0]   = 0;
     m_size_and_sign = 1;
 }
 
-template <std::size_t b, class A>
-constexpr void basic_big_int<b, A>::unchecked_trim_magnitude() noexcept {
+template <std::size_t b, class A, class Limb>
+constexpr void basic_big_int<b, A, Limb>::unchecked_trim_magnitude() noexcept {
     const limb_type* const limbs = limb_ptr();
     std::uint32_t          size  = m_size_and_sign & 0x7FFF'FFFFU;
     if (size > 1 && limbs[size - 1] == 0) {
@@ -966,25 +986,25 @@ constexpr void basic_big_int<b, A>::unchecked_trim_magnitude() noexcept {
     }
 }
 
-template <std::size_t b, class A>
-constexpr auto basic_big_int<b, A>::limb_ptr() noexcept -> limb_type* {
+template <std::size_t b, class A, class Limb>
+constexpr auto basic_big_int<b, A, Limb>::limb_ptr() noexcept -> limb_type* {
     return is_representation_inplace() ? m_storage.limbs : m_storage.data;
 }
 
-template <std::size_t b, class A>
-constexpr auto basic_big_int<b, A>::limb_ptr() const noexcept -> const limb_type* {
+template <std::size_t b, class A, class Limb>
+constexpr auto basic_big_int<b, A, Limb>::limb_ptr() const noexcept -> const limb_type* {
     return is_representation_inplace() ? m_storage.limbs : m_storage.data;
 }
 
-template <std::size_t b, class A>
-constexpr std::span<uint_multiprecision_t> basic_big_int<b, A>::limb_span() noexcept {
+template <std::size_t b, class A, class Limb>
+constexpr std::span<uint_multiprecision_t> basic_big_int<b, A, Limb>::limb_span() noexcept {
     return {limb_ptr(), limb_count()};
 }
 
 // [big.int.cons] — constructors
 
-template <std::size_t b, class A>
-constexpr basic_big_int<b, A>::basic_big_int(const basic_big_int& x)
+template <std::size_t b, class A, class Limb>
+constexpr basic_big_int<b, A, Limb>::basic_big_int(const basic_big_int& x)
     : m_capacity{0}, m_size_and_sign{x.m_size_and_sign}, m_storage{}, m_alloc{x.m_alloc} {
     if (x.limb_count() <= inplace_capacity) {
         if (x.is_representation_inplace()) {
@@ -1009,8 +1029,8 @@ constexpr basic_big_int<b, A>::basic_big_int(const basic_big_int& x)
     }
 }
 
-template <std::size_t b, class A>
-constexpr basic_big_int<b, A>::basic_big_int(basic_big_int&& x) noexcept
+template <std::size_t b, class A, class Limb>
+constexpr basic_big_int<b, A, Limb>::basic_big_int(basic_big_int&& x) noexcept
     : m_capacity{x.m_capacity}, m_size_and_sign{x.m_size_and_sign}, m_storage{}, m_alloc{std::move(x.m_alloc)} {
     if (x.is_representation_inplace()) {
         for (size_type i = 0; i < inplace_capacity; ++i) {
@@ -1024,14 +1044,14 @@ constexpr basic_big_int<b, A>::basic_big_int(basic_big_int&& x) noexcept
     }
 }
 
-template <std::size_t b, class A>
-constexpr basic_big_int<b, A>& basic_big_int<b, A>::operator=(const basic_big_int& x) {
+template <std::size_t b, class A, class Limb>
+constexpr basic_big_int<b, A, Limb>& basic_big_int<b, A, Limb>::operator=(const basic_big_int& x) {
     assign_value(x);
     return *this;
 }
 
-template <std::size_t b, class A>
-constexpr basic_big_int<b, A>& basic_big_int<b, A>::operator=(basic_big_int&& x) noexcept {
+template <std::size_t b, class A, class Limb>
+constexpr basic_big_int<b, A, Limb>& basic_big_int<b, A, Limb>::operator=(basic_big_int&& x) noexcept {
     // Invariant: `assign_value` with `extra_space == 0` and an rvalue `src`
     // never allocates -- either `*this` already fits `x.limb_count()`, or we
     // steal `x`'s heap buffer, or `x` is inline and fits inline in `*this`.
@@ -1047,10 +1067,9 @@ constexpr basic_big_int<b, A>& basic_big_int<b, A>::operator=(basic_big_int&& x)
 // heap operand's storage while the freed pointer is adopted by the other.
 // The allocator participates only when `propagate_on_container_swap` holds;
 // otherwise [container.reqmts] requires the two allocators to compare equal.
-template <std::size_t b, class A>
-constexpr void
-basic_big_int<b, A>::swap(basic_big_int& x) noexcept(std::allocator_traits<A>::propagate_on_container_swap::value ||
-                                                     std::allocator_traits<A>::is_always_equal::value) {
+template <std::size_t b, class A, class Limb>
+constexpr void basic_big_int<b, A, Limb>::swap(basic_big_int& x) noexcept(
+    std::allocator_traits<A>::propagate_on_container_swap::value || std::allocator_traits<A>::is_always_equal::value) {
     if (this == std::addressof(x)) {
         return;
     }
@@ -1089,9 +1108,9 @@ basic_big_int<b, A>::swap(basic_big_int& x) noexcept(std::allocator_traits<A>::p
     }
 }
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <detail::arbitrary_arithmetic T>
-constexpr basic_big_int<b, A>::basic_big_int(const T& value, const allocator_type& a) noexcept(
+constexpr basic_big_int<b, A, Limb>::basic_big_int(const T& value, const allocator_type& a) noexcept(
     detail::no_alloc_constructible_from<inplace_bits, T>)
     : m_capacity{0}, m_size_and_sign{1}, m_storage{}, m_alloc{a} {
     if constexpr (std::is_floating_point_v<std::remove_cvref_t<T>>) {
@@ -1116,10 +1135,10 @@ constexpr basic_big_int<b, A>::basic_big_int(const T& value, const allocator_typ
     }
 }
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <std::input_iterator I, std::sentinel_for<I> S>
     requires detail::signed_or_unsigned<std::iter_value_t<I>>
-constexpr basic_big_int<b, A>::basic_big_int(I begin, S end, const allocator_type& a)
+constexpr basic_big_int<b, A, Limb>::basic_big_int(I begin, S end, const allocator_type& a)
     : m_capacity{0}, m_size_and_sign{1}, m_storage{}, m_alloc{a} {
 
     if constexpr (std::ranges::sized_range<std::ranges::subrange<I, S>>) {
@@ -1145,16 +1164,16 @@ constexpr basic_big_int<b, A>::basic_big_int(I begin, S end, const allocator_typ
     }
 }
 
-template <std::size_t b, class A>
-constexpr basic_big_int<b, A>::~basic_big_int() {
+template <std::size_t b, class A, class Limb>
+constexpr basic_big_int<b, A, Limb>::~basic_big_int() {
     free_storage();
 }
 
 // [big.int.modifiers]
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <detail::signed_or_unsigned S>
-constexpr auto basic_big_int<b, A>::operator>>=(const S s) -> basic_big_int& {
+constexpr auto basic_big_int<b, A, Limb>::operator>>=(const S s) -> basic_big_int& {
     // If this pattern comes up more often, we should consider something like a `safe_cast` utility.
     // This would convert to another type and signal whether the result is exactly representable.
     if constexpr (std::is_signed_v<S>) {
@@ -1167,9 +1186,9 @@ constexpr auto basic_big_int<b, A>::operator>>=(const S s) -> basic_big_int& {
     return *this;
 }
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <detail::signed_or_unsigned S>
-constexpr auto basic_big_int<b, A>::operator<<=(const S s) -> basic_big_int& {
+constexpr auto basic_big_int<b, A, Limb>::operator<<=(const S s) -> basic_big_int& {
     if constexpr (std::is_signed_v<S>) {
         BEMAN_BIG_INT_DEBUG_ASSERT(s >= 0);
         BEMAN_BIG_INT_DEBUG_ASSERT(static_cast<detail::make_unsigned_t<S>>(s) <= shift_max);
@@ -1180,8 +1199,8 @@ constexpr auto basic_big_int<b, A>::operator<<=(const S s) -> basic_big_int& {
     return *this;
 }
 
-template <std::size_t b, class A>
-constexpr bool basic_big_int<b, A>::unchecked_increment_magnitude() {
+template <std::size_t b, class A, class Limb>
+constexpr bool basic_big_int<b, A, Limb>::unchecked_increment_magnitude() {
     limb_type* const limbs    = limb_ptr();
     bool             carry_in = true;
     for (size_type i = 0; carry_in && i < limb_count(); ++i) {
@@ -1197,8 +1216,8 @@ constexpr bool basic_big_int<b, A>::unchecked_increment_magnitude() {
     return carry_in;
 }
 
-template <std::size_t b, class A>
-constexpr bool basic_big_int<b, A>::unchecked_decrement_magnitude() {
+template <std::size_t b, class A, class Limb>
+constexpr bool basic_big_int<b, A, Limb>::unchecked_decrement_magnitude() {
     limb_type* const limbs     = limb_ptr();
     bool             borrow_in = true;
     for (size_type i = 0; borrow_in && i < limb_count(); ++i) {
@@ -1217,8 +1236,8 @@ constexpr bool basic_big_int<b, A>::unchecked_decrement_magnitude() {
     return borrow_in;
 }
 
-template <std::size_t b, class A>
-constexpr void basic_big_int<b, A>::shift_left(const shift_type s) {
+template <std::size_t b, class A, class Limb>
+constexpr void basic_big_int<b, A, Limb>::shift_left(const shift_type s) {
     BEMAN_BIG_INT_DEBUG_ASSERT(s <= shift_max);
     if (s == 0) {
         return;
@@ -1260,8 +1279,8 @@ constexpr void basic_big_int<b, A>::shift_left(const shift_type s) {
     }
 }
 
-template <std::size_t b, class A>
-constexpr void basic_big_int<b, A>::shift_right(const shift_type s) {
+template <std::size_t b, class A, class Limb>
+constexpr void basic_big_int<b, A, Limb>::shift_right(const shift_type s) {
     BEMAN_BIG_INT_DEBUG_ASSERT(s <= shift_max);
     if (s == 0) {
         return;
@@ -1319,8 +1338,8 @@ constexpr void basic_big_int<b, A>::shift_right(const shift_type s) {
 
 // [big.int.ops]
 
-template <std::size_t b, class A>
-constexpr std::size_t basic_big_int<b, A>::width_mag() const noexcept {
+template <std::size_t b, class A, class Limb>
+constexpr std::size_t basic_big_int<b, A, Limb>::width_mag() const noexcept {
     const auto count = limb_count();
     const auto top   = limb_ptr()[count - 1];
     if (top == 0) {
@@ -1329,27 +1348,28 @@ constexpr std::size_t basic_big_int<b, A>::width_mag() const noexcept {
     return (count - 1) * bits_per_limb + (bits_per_limb - static_cast<size_type>(std::countl_zero(top)));
 }
 
-template <std::size_t b, class A>
-constexpr std::span<const uint_multiprecision_t> basic_big_int<b, A>::representation() const noexcept {
+template <std::size_t b, class A, class Limb>
+constexpr std::span<const uint_multiprecision_t> basic_big_int<b, A, Limb>::representation() const noexcept {
     return {limb_ptr(), limb_count()};
 }
 
-template <std::size_t b, class A>
-constexpr std::size_t basic_big_int<b, A>::representation_size() const noexcept {
+template <std::size_t b, class A, class Limb>
+constexpr std::size_t basic_big_int<b, A, Limb>::representation_size() const noexcept {
     // Number of limbs spanned by the magnitude: a single limb for a zero value,
     // otherwise ceil(width_mag() / bits_per_limb). Equals representation().size().
     return is_zero() ? size_type{1} : detail::div_to_pos_inf(width_mag(), bits_per_limb);
 }
 
-template <std::size_t b, class A>
-constexpr typename basic_big_int<b, A>::allocator_type basic_big_int<b, A>::get_allocator() const noexcept {
+template <std::size_t b, class A, class Limb>
+constexpr typename basic_big_int<b, A, Limb>::allocator_type
+basic_big_int<b, A, Limb>::get_allocator() const noexcept {
     return m_alloc;
 }
 
-template <std::size_t b, class A>
-constexpr std::size_t basic_big_int<b, A>::size() const noexcept {
+template <std::size_t b, class A, class Limb>
+constexpr std::size_t basic_big_int<b, A, Limb>::size() const noexcept {
     if (is_negative()) {
-        basic_big_int<b, A> negated(*this);
+        basic_big_int<b, A, Limb> negated(*this);
         negated.negate();
         return negated.size();
     } else if (is_zero()) {
@@ -1359,14 +1379,14 @@ constexpr std::size_t basic_big_int<b, A>::size() const noexcept {
     }
 }
 
-template <std::size_t b, class A>
-constexpr std::size_t basic_big_int<b, A>::max_size() noexcept {
+template <std::size_t b, class A, class Limb>
+constexpr std::size_t basic_big_int<b, A, Limb>::max_size() noexcept {
     // Maximum number of bits the magnitude may occupy.
     return max_representation_size() * bits_per_limb;
 }
 
-template <std::size_t b, class A>
-constexpr std::size_t basic_big_int<b, A>::max_representation_size() noexcept {
+template <std::size_t b, class A, class Limb>
+constexpr std::size_t basic_big_int<b, A, Limb>::max_representation_size() noexcept {
     // A limb count occupies 31 bits of the control word; in addition, the bit count reported
     // by max_size() must be representable in size_type. The smaller of the two limits wins.
     constexpr size_type storage_cap  = (size_type{1} << 31U) - 1U;
@@ -1374,33 +1394,33 @@ constexpr std::size_t basic_big_int<b, A>::max_representation_size() noexcept {
     return std::min(storage_cap, overflow_cap);
 }
 
-template <std::size_t b, class A>
-constexpr void basic_big_int<b, A>::reserve(const size_type n) {
+template <std::size_t b, class A, class Limb>
+constexpr void basic_big_int<b, A, Limb>::reserve(const size_type n) {
     // n is a bit count; reserve enough limbs to hold it.
     reserve_representation(detail::div_to_pos_inf(n, bits_per_limb));
 }
 
-template <std::size_t b, class A>
-constexpr void basic_big_int<b, A>::reserve_representation(const size_type n) {
+template <std::size_t b, class A, class Limb>
+constexpr void basic_big_int<b, A, Limb>::reserve_representation(const size_type n) {
     // Reserve room for at least n representation limbs.
     grow(n);
 }
 
-template <std::size_t b, class A>
-constexpr auto basic_big_int<b, A>::capacity() const noexcept -> size_type {
+template <std::size_t b, class A, class Limb>
+constexpr auto basic_big_int<b, A, Limb>::capacity() const noexcept -> size_type {
     // Number of bits of storage currently available without reallocating.
     return representation_capacity() * bits_per_limb;
 }
 
-template <std::size_t b, class A>
-constexpr auto basic_big_int<b, A>::representation_capacity() const noexcept -> size_type {
+template <std::size_t b, class A, class Limb>
+constexpr auto basic_big_int<b, A, Limb>::representation_capacity() const noexcept -> size_type {
     // Usable limb capacity: the in-place limb count, or the dynamic allocation size once
     // the value has spilled to the heap. Never drops below inplace_capacity.
     return std::max<size_type>(inplace_capacity, m_capacity);
 }
 
-template <std::size_t b, class A>
-constexpr void basic_big_int<b, A>::shrink_to_fit() {
+template <std::size_t b, class A, class Limb>
+constexpr void basic_big_int<b, A, Limb>::shrink_to_fit() {
     const auto count = limb_count();
 
     if (is_representation_inplace() || m_capacity <= count) {
@@ -1433,32 +1453,32 @@ constexpr void basic_big_int<b, A>::shrink_to_fit() {
 
 // [big.int.unary]
 
-template <std::size_t b, class A>
-constexpr auto basic_big_int<b, A>::operator+() const& -> basic_big_int {
+template <std::size_t b, class A, class Limb>
+constexpr auto basic_big_int<b, A, Limb>::operator+() const& -> basic_big_int {
     return *this;
 }
 
-template <std::size_t b, class A>
-constexpr auto basic_big_int<b, A>::operator+() && noexcept -> basic_big_int {
+template <std::size_t b, class A, class Limb>
+constexpr auto basic_big_int<b, A, Limb>::operator+() && noexcept -> basic_big_int {
     return std::move(*this);
 }
 
-template <std::size_t b, class A>
-constexpr auto basic_big_int<b, A>::operator-() const& -> basic_big_int {
+template <std::size_t b, class A, class Limb>
+constexpr auto basic_big_int<b, A, Limb>::operator-() const& -> basic_big_int {
     auto copy = *this;
     copy.negate();
     return copy;
 }
 
-template <std::size_t b, class A>
-constexpr auto basic_big_int<b, A>::operator-() && noexcept -> basic_big_int {
+template <std::size_t b, class A, class Limb>
+constexpr auto basic_big_int<b, A, Limb>::operator-() && noexcept -> basic_big_int {
     auto copy = std::move(*this);
     copy.negate();
     return copy;
 }
 
-template <std::size_t b, class A>
-constexpr auto basic_big_int<b, A>::operator~() const& -> basic_big_int {
+template <std::size_t b, class A, class Limb>
+constexpr auto basic_big_int<b, A, Limb>::operator~() const& -> basic_big_int {
     // Bitwise operations emulate two's complement behavior,
     // where ~x is mathematically (-x - 1).
     auto copy = *this;
@@ -1467,8 +1487,8 @@ constexpr auto basic_big_int<b, A>::operator~() const& -> basic_big_int {
     return copy;
 }
 
-template <std::size_t b, class A>
-constexpr auto basic_big_int<b, A>::operator~() && -> basic_big_int {
+template <std::size_t b, class A, class Limb>
+constexpr auto basic_big_int<b, A, Limb>::operator~() && -> basic_big_int {
     // See also the const& overload.
     // Unlike operator-, we cannot make this noexcept because the decrement may reallocate.
     auto copy = std::move(*this);
@@ -1477,8 +1497,8 @@ constexpr auto basic_big_int<b, A>::operator~() && -> basic_big_int {
     return copy;
 }
 
-template <std::size_t b, class A>
-constexpr auto basic_big_int<b, A>::operator++() & -> basic_big_int& {
+template <std::size_t b, class A, class Limb>
+constexpr auto basic_big_int<b, A, Limb>::operator++() & -> basic_big_int& {
     if (is_negative()) {
         unchecked_decrement_magnitude();
         if (limb_count() == 1 && limb_ptr()[0] == 0) {
@@ -1490,15 +1510,15 @@ constexpr auto basic_big_int<b, A>::operator++() & -> basic_big_int& {
     return *this;
 }
 
-template <std::size_t b, class A>
-constexpr auto basic_big_int<b, A>::operator++(int) & -> basic_big_int {
+template <std::size_t b, class A, class Limb>
+constexpr auto basic_big_int<b, A, Limb>::operator++(int) & -> basic_big_int {
     auto copy = *this;
     ++(*this);
     return copy;
 }
 
-template <std::size_t b, class A>
-constexpr auto basic_big_int<b, A>::operator--() & -> basic_big_int& {
+template <std::size_t b, class A, class Limb>
+constexpr auto basic_big_int<b, A, Limb>::operator--() & -> basic_big_int& {
     if (is_negative()) {
         unchecked_increment_magnitude();
     } else {
@@ -1509,8 +1529,8 @@ constexpr auto basic_big_int<b, A>::operator--() & -> basic_big_int& {
     return *this;
 }
 
-template <std::size_t b, class A>
-constexpr auto basic_big_int<b, A>::operator--(int) & -> basic_big_int {
+template <std::size_t b, class A, class Limb>
+constexpr auto basic_big_int<b, A, Limb>::operator--(int) & -> basic_big_int {
     auto copy = *this;
     --(*this);
     return copy;
@@ -1545,9 +1565,9 @@ constexpr std::strong_ordering operator<=>(const L& lhs, const R& rhs) noexcept 
     }
 }
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <detail::cv_unqualified_arithmetic T, bool ignore_sign>
-constexpr T basic_big_int<b, A>::to() const noexcept {
+constexpr T basic_big_int<b, A, Limb>::to() const noexcept {
     if constexpr (std::is_same_v<T, bool>) {
         return !is_zero();
     } else if constexpr (std::is_floating_point_v<T>) {
@@ -1723,9 +1743,9 @@ inline constexpr binary_op_form classify_form_v = [] {
 
 } // namespace detail
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <detail::bitwise_op op, class T>
-constexpr auto basic_big_int<b, A>::bitwise_assign_impl(T&& rhs) -> basic_big_int&
+constexpr auto basic_big_int<b, A, Limb>::bitwise_assign_impl(T&& rhs) -> basic_big_int&
     requires detail::common_big_int_type_with<T, basic_big_int>
 {
     if constexpr (detail::is_basic_big_int_v<std::remove_cvref_t<T>>) {
@@ -1760,7 +1780,7 @@ constexpr auto basic_big_int<b, A>::bitwise_assign_impl(T&& rhs) -> basic_big_in
 //   * one  `basic_big_int` lvalue   -> copy it (the other side is a primitive)
 //
 // `common_big_int_type` only yields a type when both `basic_big_int` operands are the
-// exact same `basic_big_int<b, A>` instantiation, so the operand type already matches
+// exact same `basic_big_int<b, A, Limb>` instantiation, so the operand type already matches
 // `Result` and no explicit type-equality guard is needed.
 template <class L, class R>
 constexpr detail::common_big_int_type<L, R> operator+(L&& x, R&& y) {
@@ -1896,9 +1916,9 @@ constexpr detail::common_big_int_type<L, R> operator-(L&& x, R&& y) {
     }
 }
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <detail::bitwise_op op, class L, class R>
-constexpr detail::common_big_int_type<L, R> basic_big_int<b, A>::bitwise_impl(L&& x, R&& y) {
+constexpr detail::common_big_int_type<L, R> basic_big_int<b, A, Limb>::bitwise_impl(L&& x, R&& y) {
     using Result        = detail::common_big_int_type<L, R>;
     constexpr auto form = detail::classify_form_v<L, R>;
 
@@ -1917,10 +1937,10 @@ constexpr detail::common_big_int_type<L, R> basic_big_int<b, A>::bitwise_impl(L&
     }
 }
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <detail::bitwise_op op, std::size_t extent>
-constexpr void basic_big_int<b, A>::bitwise_in_place(const std::span<const uint_multiprecision_t, extent> other,
-                                                     const bool                                           other_neg) {
+constexpr void basic_big_int<b, A, Limb>::bitwise_in_place(const std::span<const uint_multiprecision_t, extent> other,
+                                                           const bool other_neg) {
     const bool this_neg = is_negative();
 
     const auto run = [&]<bool NL, bool NR>() {
@@ -2125,9 +2145,9 @@ constexpr std::remove_cvref_t<T> operator>>(T&& x, const S s) {
     }
 }
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <detail::signed_or_unsigned Integer>
-constexpr bool basic_big_int<b, A>::equals_integer(const Integer x) const noexcept {
+constexpr bool basic_big_int<b, A, Limb>::equals_integer(const Integer x) const noexcept {
     if constexpr (std::is_unsigned_v<Integer>) {
         if (is_negative()) {
             return false;
@@ -2144,16 +2164,16 @@ constexpr bool basic_big_int<b, A>::equals_integer(const Integer x) const noexce
     }
 }
 
-template <std::size_t b, class A>
-constexpr bool basic_big_int<b, A>::equals_big_int(const basic_big_int& x) const noexcept {
+template <std::size_t b, class A, class Limb>
+constexpr bool basic_big_int<b, A, Limb>::equals_big_int(const basic_big_int& x) const noexcept {
     // We can do fancier things in the future, but this works for now.
     return equals_limbs(x.representation(), x.is_negative());
 }
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <std::size_t extent>
-constexpr bool basic_big_int<b, A>::equals_limbs(const std::span<const uint_multiprecision_t, extent> limbs,
-                                                 const bool limbs_negative) const noexcept {
+constexpr bool basic_big_int<b, A, Limb>::equals_limbs(const std::span<const uint_multiprecision_t, extent> limbs,
+                                                       const bool limbs_negative) const noexcept {
     if (is_negative() != limbs_negative) {
         return false;
     }
@@ -2193,9 +2213,9 @@ constexpr bool basic_big_int<b, A>::equals_limbs(const std::span<const uint_mult
     return true;
 }
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <detail::signed_or_unsigned Integer>
-constexpr std::strong_ordering basic_big_int<b, A>::compare_integer(const Integer x) const noexcept {
+constexpr std::strong_ordering basic_big_int<b, A, Limb>::compare_integer(const Integer x) const noexcept {
     if constexpr (std::is_unsigned_v<Integer>) {
         if (is_negative()) {
             return std::strong_ordering::less;
@@ -2224,17 +2244,17 @@ constexpr std::strong_ordering basic_big_int<b, A>::compare_integer(const Intege
     }
 }
 
-template <std::size_t b, class A>
-constexpr std::strong_ordering basic_big_int<b, A>::compare_big_int(const basic_big_int& x) const noexcept {
+template <std::size_t b, class A, class Limb>
+constexpr std::strong_ordering basic_big_int<b, A, Limb>::compare_big_int(const basic_big_int& x) const noexcept {
     // We can do fancier things in the future, but this works for now.
     return compare_limbs(x.representation(), x.is_negative());
 }
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <std::size_t extent>
 constexpr std::strong_ordering
-basic_big_int<b, A>::compare_limbs(const std::span<const uint_multiprecision_t, extent> limbs,
-                                   const bool limbs_negative) const noexcept {
+basic_big_int<b, A, Limb>::compare_limbs(const std::span<const uint_multiprecision_t, extent> limbs,
+                                         const bool limbs_negative) const noexcept {
     // A mismatch between signs lets us short-circuit without comparing the magnitudes.
     const auto sign_compare = limbs_negative <=> is_negative();
     if (std::is_neq(sign_compare)) {
@@ -2252,10 +2272,11 @@ basic_big_int<b, A>::compare_limbs(const std::span<const uint_multiprecision_t, 
 // Adds `(other, other_neg)` into `*this` in place. Shared core for `operator+` and
 // `operator-`: the caller chooses the destination (an rvalue operand's storage or a
 // copy of an lvalue operand) and supplies the other side as a limb span + sign.
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <std::size_t extent_other>
-constexpr void basic_big_int<b, A>::add_in_place(const std::span<const uint_multiprecision_t, extent_other> other,
-                                                 const bool other_neg) {
+constexpr void
+basic_big_int<b, A, Limb>::add_in_place(const std::span<const uint_multiprecision_t, extent_other> other,
+                                        const bool                                                 other_neg) {
     const bool this_neg = is_negative();
 
     if (this_neg == other_neg) {
@@ -2344,12 +2365,12 @@ constexpr void basic_big_int<b, A>::add_in_place(const std::span<const uint_mult
 // Computes `(a, a_neg) + (b, b_neg)` directly into `*this`.
 // Fuses copy and potential second allocation
 // Precondition: `a.size() >= b.size()`
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <std::size_t extent_a, std::size_t extent_b>
-constexpr void basic_big_int<b, A>::add_into(const std::span<const uint_multiprecision_t, extent_a> a,
-                                             const bool                                             a_neg,
-                                             const std::span<const uint_multiprecision_t, extent_b> b_span,
-                                             const bool                                             b_neg) {
+constexpr void basic_big_int<b, A, Limb>::add_into(const std::span<const uint_multiprecision_t, extent_a> a,
+                                                   const bool                                             a_neg,
+                                                   const std::span<const uint_multiprecision_t, extent_b> b_span,
+                                                   const bool                                             b_neg) {
     BEMAN_BIG_INT_DEBUG_ASSERT(a.size() >= b_span.size());
 
     if (a_neg == b_neg) {
@@ -2541,12 +2562,12 @@ constexpr void basic_big_int<b, A>::add_into(const std::span<const uint_multipre
 }
 
 // Computes `a * b` and stores the result into `*this`.
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <std::size_t extent_a, std::size_t extent_b>
-constexpr void basic_big_int<b, A>::multiply_into(const std::span<const uint_multiprecision_t, extent_a> a,
-                                                  const bool                                             a_neg,
-                                                  const std::span<const uint_multiprecision_t, extent_b> b_span,
-                                                  const bool                                             b_neg) {
+constexpr void basic_big_int<b, A, Limb>::multiply_into(const std::span<const uint_multiprecision_t, extent_a> a,
+                                                        const bool                                             a_neg,
+                                                        const std::span<const uint_multiprecision_t, extent_b> b_span,
+                                                        const bool                                             b_neg) {
     const auto a_trimmed = a.first(detail::trimmed_size_span(a));
     const auto b_trimmed = b_span.first(detail::trimmed_size_span(b_span));
 
@@ -2591,11 +2612,11 @@ constexpr void basic_big_int<b, A>::multiply_into(const std::span<const uint_mul
     unchecked_set_sign(a_neg != b_neg && !unchecked_is_magnitude_zero());
 }
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <detail::bitwise_op op, bool neg_left, bool neg_right, std::size_t extent_a, std::size_t extent_b>
-constexpr basic_big_int<b, A>
-basic_big_int<b, A>::make_bitwise_of_limbs(const std::span<const uint_multiprecision_t, extent_a> lhs,
-                                           const std::span<const uint_multiprecision_t, extent_b> rhs) {
+constexpr basic_big_int<b, A, Limb>
+basic_big_int<b, A, Limb>::make_bitwise_of_limbs(const std::span<const uint_multiprecision_t, extent_a> lhs,
+                                                 const std::span<const uint_multiprecision_t, extent_b> rhs) {
     constexpr bool res_neg = detail::eval_bitwise<op>(neg_left, neg_right);
 
     const std::size_t n = [&]() -> std::size_t {
@@ -2625,13 +2646,13 @@ basic_big_int<b, A>::make_bitwise_of_limbs(const std::span<const uint_multipreci
     return result;
 }
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <detail::bitwise_op op, std::size_t extent_a, std::size_t extent_b>
-constexpr basic_big_int<b, A>
-basic_big_int<b, A>::dispatch_bitwise(const std::span<const uint_multiprecision_t, extent_a> lhs,
-                                      const bool                                             lhs_neg,
-                                      const std::span<const uint_multiprecision_t, extent_b> rhs,
-                                      const bool                                             rhs_neg) {
+constexpr basic_big_int<b, A, Limb>
+basic_big_int<b, A, Limb>::dispatch_bitwise(const std::span<const uint_multiprecision_t, extent_a> lhs,
+                                            const bool                                             lhs_neg,
+                                            const std::span<const uint_multiprecision_t, extent_b> rhs,
+                                            const bool                                             rhs_neg) {
     if (!lhs_neg && !rhs_neg) {
         return make_bitwise_of_limbs<op, false, false>(lhs, rhs);
     }
@@ -2703,9 +2724,9 @@ constexpr detail::common_big_int_type<L, R> operator*(L&& x, R&& y) {
 // `*this` is always the destination, so we skip the copy/move step that the free
 // `operator+` / `operator-` need and fold `rhs` directly into our own storage via
 // `add_in_place`.
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <class T>
-constexpr auto basic_big_int<b, A>::operator+=(T&& rhs) -> basic_big_int&
+constexpr auto basic_big_int<b, A, Limb>::operator+=(T&& rhs) -> basic_big_int&
     requires detail::common_big_int_type_with<T, basic_big_int>
 {
     if constexpr (detail::is_basic_big_int_v<std::remove_cvref_t<T>>) {
@@ -2717,9 +2738,9 @@ constexpr auto basic_big_int<b, A>::operator+=(T&& rhs) -> basic_big_int&
     return *this;
 }
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <class T>
-constexpr auto basic_big_int<b, A>::operator-=(T&& rhs) -> basic_big_int&
+constexpr auto basic_big_int<b, A, Limb>::operator-=(T&& rhs) -> basic_big_int&
     requires detail::common_big_int_type_with<T, basic_big_int>
 {
     if constexpr (detail::is_basic_big_int_v<std::remove_cvref_t<T>>) {
@@ -2736,9 +2757,9 @@ constexpr auto basic_big_int<b, A>::operator-=(T&& rhs) -> basic_big_int&
 }
 
 // Compound multiplication assignment.
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <class T>
-constexpr auto basic_big_int<b, A>::operator*=(T&& rhs) -> basic_big_int&
+constexpr auto basic_big_int<b, A, Limb>::operator*=(T&& rhs) -> basic_big_int&
     requires detail::common_big_int_type_with<T, basic_big_int>
 {
     if constexpr (detail::is_basic_big_int_v<std::remove_cvref_t<T>>) {
@@ -2766,14 +2787,14 @@ constexpr auto basic_big_int<b, A>::operator*=(T&& rhs) -> basic_big_int&
 // Single-limb divisor fast path from Knuth
 // Avoids allocating a remainder scratch buffer and a `t` buffer: we just stream the quotient through `*this`'s
 // limbs and carry a single remainder limb between iterations.
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <std::size_t extent_a>
 constexpr uint_multiprecision_t
-basic_big_int<b, A>::divmod_into_short(const std::span<const uint_multiprecision_t, extent_a> dividend,
-                                       const bool                                             dividend_neg,
-                                       const uint_multiprecision_t                            divisor,
-                                       const bool                                             divisor_neg,
-                                       const detail::division_op                              op) {
+basic_big_int<b, A, Limb>::divmod_into_short(const std::span<const uint_multiprecision_t, extent_a> dividend,
+                                             const bool                                             dividend_neg,
+                                             const uint_multiprecision_t                            divisor,
+                                             const bool                                             divisor_neg,
+                                             const detail::division_op                              op) {
     BEMAN_BIG_INT_ASSERT(divisor != 0);
 
     const bool want_quotient = op != detail::division_op::rem;
@@ -2815,10 +2836,10 @@ basic_big_int<b, A>::divmod_into_short(const std::span<const uint_multiprecision
     return remainder;
 }
 
-template <std::size_t b, class A>
-constexpr uint_multiprecision_t basic_big_int<b, A>::divmod_in_place_short(const uint_multiprecision_t divisor,
-                                                                           const bool                  divisor_neg,
-                                                                           const detail::division_op   op) {
+template <std::size_t b, class A, class Limb>
+constexpr uint_multiprecision_t basic_big_int<b, A, Limb>::divmod_in_place_short(const uint_multiprecision_t divisor,
+                                                                                 const bool                divisor_neg,
+                                                                                 const detail::division_op op) {
     BEMAN_BIG_INT_ASSERT(divisor != 0);
 
     const bool                  want_quotient = op != detail::division_op::rem;
@@ -2842,13 +2863,13 @@ constexpr uint_multiprecision_t basic_big_int<b, A>::divmod_in_place_short(const
 //   3) |dividend| < |divisor|,
 //   4) single-limb divisor
 // before falling through to `detail::divide_dispatch`.
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <std::size_t extent_a, std::size_t extent_b>
-constexpr auto basic_big_int<b, A>::divmod_into(const std::span<const uint_multiprecision_t, extent_a> dividend,
-                                                const bool                                             dividend_neg,
-                                                const std::span<const uint_multiprecision_t, extent_b> divisor,
-                                                const bool                                             divisor_neg,
-                                                const detail::division_op op) -> basic_big_int {
+constexpr auto basic_big_int<b, A, Limb>::divmod_into(const std::span<const uint_multiprecision_t, extent_a> dividend,
+                                                      const bool dividend_neg,
+                                                      const std::span<const uint_multiprecision_t, extent_b> divisor,
+                                                      const bool                divisor_neg,
+                                                      const detail::division_op op) -> basic_big_int {
     const auto dividend_trim = dividend.first(detail::trimmed_size_span(dividend));
     const auto divisor_trim  = divisor.first(detail::trimmed_size_span(divisor));
 
@@ -3074,9 +3095,9 @@ constexpr detail::common_big_int_type<L, R> operator%(L&& x, R&& y) {
 }
 
 // Compound division and modulus assignments.
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <class T>
-constexpr auto basic_big_int<b, A>::operator/=(T&& rhs) -> basic_big_int&
+constexpr auto basic_big_int<b, A, Limb>::operator/=(T&& rhs) -> basic_big_int&
     requires detail::common_big_int_type_with<T, basic_big_int>
 {
     if constexpr (detail::is_basic_big_int_v<std::remove_cvref_t<T>>) {
@@ -3118,9 +3139,9 @@ constexpr auto basic_big_int<b, A>::operator/=(T&& rhs) -> basic_big_int&
     return *this;
 }
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <class T>
-constexpr auto basic_big_int<b, A>::operator%=(T&& rhs) -> basic_big_int&
+constexpr auto basic_big_int<b, A, Limb>::operator%=(T&& rhs) -> basic_big_int&
     requires detail::common_big_int_type_with<T, basic_big_int>
 {
     if constexpr (detail::is_basic_big_int_v<std::remove_cvref_t<T>>) {
@@ -3161,25 +3182,25 @@ constexpr auto basic_big_int<b, A>::operator%=(T&& rhs) -> basic_big_int&
     return *this;
 }
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <class T>
-constexpr auto basic_big_int<b, A>::operator&=(T&& rhs) -> basic_big_int&
+constexpr auto basic_big_int<b, A, Limb>::operator&=(T&& rhs) -> basic_big_int&
     requires detail::common_big_int_type_with<T, basic_big_int>
 {
     return bitwise_assign_impl<detail::bitwise_op::and_>(std::forward<T>(rhs));
 }
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <class T>
-constexpr auto basic_big_int<b, A>::operator|=(T&& rhs) -> basic_big_int&
+constexpr auto basic_big_int<b, A, Limb>::operator|=(T&& rhs) -> basic_big_int&
     requires detail::common_big_int_type_with<T, basic_big_int>
 {
     return bitwise_assign_impl<detail::bitwise_op::or_>(std::forward<T>(rhs));
 }
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <class T>
-constexpr auto basic_big_int<b, A>::operator^=(T&& rhs) -> basic_big_int&
+constexpr auto basic_big_int<b, A, Limb>::operator^=(T&& rhs) -> basic_big_int&
     requires detail::common_big_int_type_with<T, basic_big_int>
 {
     return bitwise_assign_impl<detail::bitwise_op::xor_>(std::forward<T>(rhs));
@@ -3187,9 +3208,9 @@ constexpr auto basic_big_int<b, A>::operator^=(T&& rhs) -> basic_big_int&
 
 // private helpers
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <detail::unsigned_integer T>
-constexpr void basic_big_int<b, A>::assign_magnitude(T value) noexcept {
+constexpr void basic_big_int<b, A, Limb>::assign_magnitude(T value) noexcept {
     constexpr size_type value_limbs = detail::div_to_pos_inf(detail::width_v<T>, bits_per_limb);
     if constexpr (value_limbs == 1) {
         limb_ptr()[0] = static_cast<limb_type>(value);
@@ -3219,9 +3240,9 @@ constexpr void basic_big_int<b, A>::assign_magnitude(T value) noexcept {
     }
 }
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 template <detail::cv_unqualified_floating_point F>
-constexpr void basic_big_int<b, A>::assign_from_float(const F value) noexcept {
+constexpr void basic_big_int<b, A, Limb>::assign_from_float(const F value) noexcept {
     using traits = detail::ieee_traits<F>;
 #ifdef BEMAN_BIG_INT_UNSUPPORTED_LONG_DOUBLE
     static_assert(!std::is_same_v<F, long double>, "long double is not supported on this platform");
@@ -3259,8 +3280,8 @@ constexpr void basic_big_int<b, A>::assign_from_float(const F value) noexcept {
     unchecked_set_sign(sign);
 }
 
-template <std::size_t b, class A>
-constexpr auto basic_big_int<b, A>::alloc_limbs(const size_type n) -> alloc_result {
+template <std::size_t b, class A, class Limb>
+constexpr auto basic_big_int<b, A, Limb>::alloc_limbs(const size_type n) -> alloc_result {
     BEMAN_BIG_INT_ASSERT(n != 0);
 #if defined(__cpp_lib_allocate_at_least) && __cpp_lib_allocate_at_least >= 202302L
     if constexpr (detail::traits_has_allocate_at_least<alloc_traits, A>) {
@@ -3273,8 +3294,8 @@ constexpr auto basic_big_int<b, A>::alloc_limbs(const size_type n) -> alloc_resu
 #endif
 }
 
-template <std::size_t b, class A>
-constexpr void basic_big_int<b, A>::free_limbs(pointer p, const size_type n) {
+template <std::size_t b, class A, class Limb>
+constexpr void basic_big_int<b, A, Limb>::free_limbs(pointer p, const size_type n) {
     BEMAN_BIG_INT_ASSERT(p != nullptr);
     BEMAN_BIG_INT_ASSERT(n != 0);
     // Need to suppress known false positive warning.
@@ -3285,15 +3306,15 @@ constexpr void basic_big_int<b, A>::free_limbs(pointer p, const size_type n) {
     BEMAN_BIG_INT_DIAGNOSTIC_POP()
 }
 
-template <std::size_t b, class A>
-constexpr void basic_big_int<b, A>::free_storage() {
+template <std::size_t b, class A, class Limb>
+constexpr void basic_big_int<b, A, Limb>::free_storage() {
     if (!is_representation_inplace()) {
         free_limbs(m_storage.data, m_capacity);
     }
 }
 
-template <std::size_t b, class A>
-constexpr void basic_big_int<b, A>::grow(const size_type limbs_needed) {
+template <std::size_t b, class A, class Limb>
+constexpr void basic_big_int<b, A, Limb>::grow(const size_type limbs_needed) {
     const size_type current_cap = is_representation_inplace() ? inplace_capacity : m_capacity;
     if (limbs_needed <= current_cap) {
         return;
@@ -3311,9 +3332,9 @@ constexpr void basic_big_int<b, A>::grow(const size_type limbs_needed) {
     m_capacity     = static_cast<std::uint32_t>(allocation.count);
 }
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 constexpr void
-basic_big_int<b, A>::copy_n_to_allocation(const limb_type* const p, const size_type n, const alloc_result out) {
+basic_big_int<b, A, Limb>::copy_n_to_allocation(const limb_type* const p, const size_type n, const alloc_result out) {
     BEMAN_BIG_INT_ASSERT(p != nullptr);
     BEMAN_BIG_INT_ASSERT(out.ptr != nullptr);
     BEMAN_BIG_INT_ASSERT(n <= out.count);
@@ -3340,8 +3361,8 @@ basic_big_int<b, A>::copy_n_to_allocation(const limb_type* const p, const size_t
 #endif
 }
 
-template <std::size_t b, class A>
-constexpr void basic_big_int<b, A>::push_back_limb(limb_type limb) {
+template <std::size_t b, class A, class Limb>
+constexpr void basic_big_int<b, A, Limb>::push_back_limb(limb_type limb) {
     const auto count = limb_count();
     if (count >= (is_representation_inplace() ? inplace_capacity : m_capacity)) {
         grow(count + 1); // exponential growth
@@ -3354,10 +3375,13 @@ constexpr void basic_big_int<b, A>::push_back_limb(limb_type limb) {
 // `basic_big_int<N, A>` whose inline storage is large enough to hold the value
 // without any heap allocation.
 // Bridges consteval-computed values to runtime.
-// The result preserves the source's allocator type and instance.
+// The result preserves the source's allocator and limb types, and the allocator instance.
 template <typename Generator>
 [[nodiscard]] consteval auto copy_to_runtime() {
-    constexpr std::size_t bits_per_limb = sizeof(uint_multiprecision_t) * CHAR_BIT;
+    using source_type = std::remove_cvref_t<decltype(Generator{}())>;
+    using limb_type   = detail::limb_type_of_t<source_type>;
+
+    constexpr std::size_t bits_per_limb = detail::width_v<limb_type>;
 
     constexpr std::size_t target_bits = []() consteval {
         const auto v = Generator{}();
@@ -3365,8 +3389,7 @@ template <typename Generator>
         return w == 0 ? bits_per_limb : ((w + bits_per_limb - 1) / bits_per_limb) * bits_per_limb;
     }();
 
-    using source_type = std::remove_cvref_t<decltype(Generator{}())>;
-    using result_type = basic_big_int<target_bits, typename source_type::allocator_type>;
+    using result_type = basic_big_int<target_bits, typename source_type::allocator_type, limb_type>;
 
     auto src = Generator{}();
     return result_type{src, src.get_allocator()};
@@ -3377,8 +3400,8 @@ using big_int = basic_big_int<64, std::allocator<uint_multiprecision_t>>;
 
 namespace pmr {
 
-template <std::size_t b>
-using basic_big_int = beman::big_int::basic_big_int<b, std::pmr::polymorphic_allocator<uint_multiprecision_t>>;
+template <std::size_t b, class Limb = uint_multiprecision_t>
+using basic_big_int = beman::big_int::basic_big_int<b, std::pmr::polymorphic_allocator<Limb>, Limb>;
 
 using big_int = basic_big_int<beman::big_int::big_int::inplace_bits>;
 
@@ -3387,10 +3410,10 @@ using big_int = basic_big_int<beman::big_int::big_int::inplace_bits>;
 } // namespace beman::big_int
 
 // [big.int.hash], hash support
-template <std::size_t b, class A>
-struct std::hash<beman::big_int::basic_big_int<b, A>> {
+template <std::size_t b, class A, class Limb>
+struct std::hash<beman::big_int::basic_big_int<b, A, Limb>> {
 
-    std::size_t operator()(const beman::big_int::basic_big_int<b, A>& x) const noexcept {
+    std::size_t operator()(const beman::big_int::basic_big_int<b, A, Limb>& x) const noexcept {
         return beman::big_int::detail::siphash(x.representation(), x.is_negative());
     }
 };

--- a/include/beman/big_int/charconv.hpp
+++ b/include/beman/big_int/charconv.hpp
@@ -53,11 +53,11 @@ inline constexpr auto digit_value_table = []() consteval {
 
 } // namespace detail
 
-template <size_t b, class A, class Limb>
+template <size_t b, class A, class LimbType>
 constexpr std::to_chars_result
-to_chars(char* const begin, char* const end, const basic_big_int<b, A, Limb>& x, const int base) {
-    using size_type                   = typename basic_big_int<b, A, Limb>::size_type;
-    constexpr size_type bits_per_limb = basic_big_int<b, A, Limb>::bits_per_limb;
+to_chars(char* const begin, char* const end, const basic_big_int<b, A, LimbType>& x, const int base) {
+    using size_type                   = typename basic_big_int<b, A, LimbType>::size_type;
+    constexpr size_type bits_per_limb = basic_big_int<b, A, LimbType>::bits_per_limb;
 
     BEMAN_BIG_INT_DEBUG_ASSERT(begin);
     BEMAN_BIG_INT_DEBUG_ASSERT(end);
@@ -295,10 +295,10 @@ to_chars(char* const begin, char* const end, const basic_big_int<b, A, Limb>& x,
     BEMAN_BIG_INT_ASSERT(false);
 }
 
-template <std::size_t b, class A, class Limb>
+template <std::size_t b, class A, class LimbType>
 [[nodiscard]] constexpr std::from_chars_result
-from_chars(const char* const begin, const char* const end, basic_big_int<b, A, Limb>& out, const int base) {
-    using size_type = typename basic_big_int<b, A, Limb>::size_type;
+from_chars(const char* const begin, const char* const end, basic_big_int<b, A, LimbType>& out, const int base) {
+    using size_type = typename basic_big_int<b, A, LimbType>::size_type;
 
     if (begin == nullptr || begin == end || base < 2 || base > 36) {
         return {end, std::errc::invalid_argument};

--- a/include/beman/big_int/charconv.hpp
+++ b/include/beman/big_int/charconv.hpp
@@ -53,11 +53,11 @@ inline constexpr auto digit_value_table = []() consteval {
 
 } // namespace detail
 
-template <size_t b, class A>
+template <size_t b, class A, class Limb>
 constexpr std::to_chars_result
-to_chars(char* const begin, char* const end, const basic_big_int<b, A>& x, const int base) {
-    using size_type                   = typename basic_big_int<b, A>::size_type;
-    constexpr size_type bits_per_limb = basic_big_int<b, A>::bits_per_limb;
+to_chars(char* const begin, char* const end, const basic_big_int<b, A, Limb>& x, const int base) {
+    using size_type                   = typename basic_big_int<b, A, Limb>::size_type;
+    constexpr size_type bits_per_limb = basic_big_int<b, A, Limb>::bits_per_limb;
 
     BEMAN_BIG_INT_DEBUG_ASSERT(begin);
     BEMAN_BIG_INT_DEBUG_ASSERT(end);
@@ -295,10 +295,10 @@ to_chars(char* const begin, char* const end, const basic_big_int<b, A>& x, const
     BEMAN_BIG_INT_ASSERT(false);
 }
 
-template <std::size_t b, class A>
+template <std::size_t b, class A, class Limb>
 [[nodiscard]] constexpr std::from_chars_result
-from_chars(const char* const begin, const char* const end, basic_big_int<b, A>& out, const int base) {
-    using size_type = typename basic_big_int<b, A>::size_type;
+from_chars(const char* const begin, const char* const end, basic_big_int<b, A, Limb>& out, const int base) {
+    using size_type = typename basic_big_int<b, A, Limb>::size_type;
 
     if (begin == nullptr || begin == end || base < 2 || base > 36) {
         return {end, std::errc::invalid_argument};

--- a/include/beman/big_int/format.hpp
+++ b/include/beman/big_int/format.hpp
@@ -269,8 +269,8 @@ namespace std {
 // Standards-conformant formatter for beman::big_int, mirroring the standard integer
 // formatters: fill/align, sign, '#', sign-aware '0', static and dynamic width, the
 // 'b'/'B'/'o'/'d'/'x'/'X'/'c' types, and the 'L' locale option, for both char and wchar_t.
-template <std::size_t B, class A, class charT>
-struct formatter<beman::big_int::basic_big_int<B, A>, charT> {
+template <std::size_t B, class A, class Limb, class charT>
+struct formatter<beman::big_int::basic_big_int<B, A, Limb>, charT> {
     beman::big_int::detail::format_spec<charT> spec_;
 
     template <class ParseContext>
@@ -404,10 +404,10 @@ struct formatter<beman::big_int::basic_big_int<B, A>, charT> {
     }
 
     template <class FormatContext>
-    typename FormatContext::iterator format(const beman::big_int::basic_big_int<B, A>& value,
-                                            FormatContext&                             fc) const {
+    typename FormatContext::iterator format(const beman::big_int::basic_big_int<B, A, Limb>& value,
+                                            FormatContext&                                   fc) const {
         namespace d    = beman::big_int::detail;
-        using big_type = beman::big_int::basic_big_int<B, A>;
+        using big_type = beman::big_int::basic_big_int<B, A, Limb>;
 
         std::size_t width = spec_.has_width ? spec_.width : std::size_t{0};
         if (spec_.width_is_arg) {

--- a/include/beman/big_int/format.hpp
+++ b/include/beman/big_int/format.hpp
@@ -269,8 +269,8 @@ namespace std {
 // Standards-conformant formatter for beman::big_int, mirroring the standard integer
 // formatters: fill/align, sign, '#', sign-aware '0', static and dynamic width, the
 // 'b'/'B'/'o'/'d'/'x'/'X'/'c' types, and the 'L' locale option, for both char and wchar_t.
-template <std::size_t B, class A, class Limb, class charT>
-struct formatter<beman::big_int::basic_big_int<B, A, Limb>, charT> {
+template <std::size_t B, class A, class LimbType, class charT>
+struct formatter<beman::big_int::basic_big_int<B, A, LimbType>, charT> {
     beman::big_int::detail::format_spec<charT> spec_;
 
     template <class ParseContext>
@@ -404,10 +404,10 @@ struct formatter<beman::big_int::basic_big_int<B, A, Limb>, charT> {
     }
 
     template <class FormatContext>
-    typename FormatContext::iterator format(const beman::big_int::basic_big_int<B, A, Limb>& value,
-                                            FormatContext&                                   fc) const {
+    typename FormatContext::iterator format(const beman::big_int::basic_big_int<B, A, LimbType>& value,
+                                            FormatContext&                                       fc) const {
         namespace d    = beman::big_int::detail;
-        using big_type = beman::big_int::basic_big_int<B, A, Limb>;
+        using big_type = beman::big_int::basic_big_int<B, A, LimbType>;
 
         std::size_t width = spec_.has_width ? spec_.width : std::size_t{0};
         if (spec_.width_is_arg) {

--- a/include/beman/big_int/numeric.hpp
+++ b/include/beman/big_int/numeric.hpp
@@ -25,9 +25,9 @@ constexpr std::remove_cvref_t<T> abs(T&& x) {
 // Casts `x` to `R`, clamping to the range of `R`. If the integer value of `x`
 // is representable as `R`, that value is returned; otherwise the largest or
 // smallest representable value of `R`, whichever is closer to `x`.
-template <class R, std::size_t b, class A>
+template <class R, std::size_t b, class A, class Limb>
     requires detail::signed_or_unsigned<R>
-constexpr R saturating_cast(const basic_big_int<b, A>& x) noexcept {
+constexpr R saturating_cast(const basic_big_int<b, A, Limb>& x) noexcept {
     using U = detail::make_unsigned_t<R>;
 
     constexpr std::size_t width = detail::width_v<R>;

--- a/include/beman/big_int/numeric.hpp
+++ b/include/beman/big_int/numeric.hpp
@@ -25,9 +25,9 @@ constexpr std::remove_cvref_t<T> abs(T&& x) {
 // Casts `x` to `R`, clamping to the range of `R`. If the integer value of `x`
 // is representable as `R`, that value is returned; otherwise the largest or
 // smallest representable value of `R`, whichever is closer to `x`.
-template <class R, std::size_t b, class A, class Limb>
+template <class R, std::size_t b, class A, class LimbType>
     requires detail::signed_or_unsigned<R>
-constexpr R saturating_cast(const basic_big_int<b, A, Limb>& x) noexcept {
+constexpr R saturating_cast(const basic_big_int<b, A, LimbType>& x) noexcept {
     using U = detail::make_unsigned_t<R>;
 
     constexpr std::size_t width = detail::width_v<R>;

--- a/include/beman/big_int/string.hpp
+++ b/include/beman/big_int/string.hpp
@@ -29,8 +29,8 @@ namespace detail {
 // narrow result is widened afterwards. The digit alphabet and the minus sign
 // belong to the basic execution character set, whose member values are
 // preserved by the narrow-to-wide conversion.
-template <class C, std::size_t b, class A>
-[[nodiscard]] constexpr std::basic_string<C> to_basic_string(const basic_big_int<b, A>& x, const int base) {
+template <class C, std::size_t b, class A, class Limb>
+[[nodiscard]] constexpr std::basic_string<C> to_basic_string(const basic_big_int<b, A, Limb>& x, const int base) {
     BEMAN_BIG_INT_ASSERT(base >= 2 && base <= 36);
     constexpr std::size_t minus_sign_size = 1;
 
@@ -66,13 +66,13 @@ template <class C, std::size_t b, class A>
 
 } // namespace detail
 
-template <std::size_t b, class A>
-[[nodiscard]] constexpr std::string to_string(const basic_big_int<b, A>& x, const int base = 10) {
+template <std::size_t b, class A, class Limb>
+[[nodiscard]] constexpr std::string to_string(const basic_big_int<b, A, Limb>& x, const int base = 10) {
     return detail::to_basic_string<char>(x, base);
 }
 
-template <std::size_t b, class A>
-[[nodiscard]] constexpr std::wstring to_wstring(const basic_big_int<b, A>& x, const int base = 10) {
+template <std::size_t b, class A, class Limb>
+[[nodiscard]] constexpr std::wstring to_wstring(const basic_big_int<b, A, Limb>& x, const int base = 10) {
     return detail::to_basic_string<wchar_t>(x, base);
 }
 

--- a/include/beman/big_int/string.hpp
+++ b/include/beman/big_int/string.hpp
@@ -29,8 +29,8 @@ namespace detail {
 // narrow result is widened afterwards. The digit alphabet and the minus sign
 // belong to the basic execution character set, whose member values are
 // preserved by the narrow-to-wide conversion.
-template <class C, std::size_t b, class A, class Limb>
-[[nodiscard]] constexpr std::basic_string<C> to_basic_string(const basic_big_int<b, A, Limb>& x, const int base) {
+template <class C, std::size_t b, class A, class LimbType>
+[[nodiscard]] constexpr std::basic_string<C> to_basic_string(const basic_big_int<b, A, LimbType>& x, const int base) {
     BEMAN_BIG_INT_ASSERT(base >= 2 && base <= 36);
     constexpr std::size_t minus_sign_size = 1;
 
@@ -66,13 +66,13 @@ template <class C, std::size_t b, class A, class Limb>
 
 } // namespace detail
 
-template <std::size_t b, class A, class Limb>
-[[nodiscard]] constexpr std::string to_string(const basic_big_int<b, A, Limb>& x, const int base = 10) {
+template <std::size_t b, class A, class LimbType>
+[[nodiscard]] constexpr std::string to_string(const basic_big_int<b, A, LimbType>& x, const int base = 10) {
     return detail::to_basic_string<char>(x, base);
 }
 
-template <std::size_t b, class A, class Limb>
-[[nodiscard]] constexpr std::wstring to_wstring(const basic_big_int<b, A, Limb>& x, const int base = 10) {
+template <std::size_t b, class A, class LimbType>
+[[nodiscard]] constexpr std::wstring to_wstring(const basic_big_int<b, A, LimbType>& x, const int base = 10) {
     return detail::to_basic_string<wchar_t>(x, base);
 }
 

--- a/tests/beman/big_int/big_int.test.cpp
+++ b/tests/beman/big_int/big_int.test.cpp
@@ -1,5 +1,9 @@
-#include <type_traits>
 #include <cstddef>
+#include <functional>
+#include <memory>
+#include <type_traits>
+
+#include <gtest/gtest.h>
 
 #include <beman/big_int.hpp>
 
@@ -33,7 +37,7 @@ static_assert(std::is_same_v<detail::wider_t<bit_int<32>>, bit_int<64>>);
 static_assert(std::is_same_v<detail::wider_t<bit_uint<32>>, bit_uint<64>>);
 #endif
 
-template class basic_big_int<big_int::inplace_bits, big_int::allocator_type>;
+template class basic_big_int<big_int::inplace_bits, big_int::allocator_type, uint_multiprecision_t>;
 
 static_assert(basic_big_int<128, big_int::allocator_type>::inplace_bits == 128);
 static_assert(basic_big_int<127, big_int::allocator_type>::inplace_bits == 128,
@@ -42,8 +46,9 @@ static_assert(basic_big_int<127, big_int::allocator_type>::inplace_bits == 128,
 template <class T>
 struct is_exact_big_int;
 
-template <std::size_t b, class A>
-struct is_exact_big_int<basic_big_int<b, A>> : std::bool_constant<b == basic_big_int<b, A>::inplace_bits> {};
+template <std::size_t b, class A, class Limb>
+struct is_exact_big_int<basic_big_int<b, A, Limb>> : std::bool_constant<b == basic_big_int<b, A, Limb>::inplace_bits> {
+};
 
 static_assert(is_exact_big_int<big_int>::value,
               "The min_inplace_bits should match inplace_bits exactly for big_int, "
@@ -60,6 +65,21 @@ static_assert(!detail::common_big_int_type_with<big_int, float>,
 static_assert(!detail::common_big_int_type_with<int, int>,
               "There must be no common big_int type between two fundamental types.");
 
+// The limb type is the third template parameter and defaults to uint_multiprecision_t, so the
+// explicit spelling must name the same type as the abbreviated one.
+static_assert(
+    std::is_same_v<big_int, basic_big_int<64, std::allocator<uint_multiprecision_t>, uint_multiprecision_t>>);
+static_assert(std::is_same_v<basic_big_int<256>,
+                             basic_big_int<256, std::allocator<uint_multiprecision_t>, uint_multiprecision_t>>);
+static_assert(std::is_same_v<pmr::big_int,
+                             basic_big_int<big_int::inplace_bits,
+                                           std::pmr::polymorphic_allocator<uint_multiprecision_t>,
+                                           uint_multiprecision_t>>);
+static_assert(std::is_same_v<pmr::basic_big_int<256>, pmr::basic_big_int<256, uint_multiprecision_t>>);
+static_assert(
+    detail::is_basic_big_int_v<basic_big_int<128, std::allocator<uint_multiprecision_t>, uint_multiprecision_t>>);
+static_assert(std::is_same_v<detail::limb_type_of_t<big_int>, uint_multiprecision_t>);
+
 using namespace beman::big_int::literals;
 
 static_assert(0_n == 0_n);
@@ -73,3 +93,24 @@ static_assert(1000_n == 1'0'00_n);
 static_assert(1'000'000'000'000'000'000'000'000'000_n == 0x33b'2e3c'9fd0'803c'e800'0000_n);
 
 } // namespace beman::big_int
+
+// Exercise the fully explicit three-argument spelling, so the limb parameter is instantiated
+// through real arithmetic rather than only named in a type comparison.
+TEST(BigIntType, ExplicitLimbTypeArgument) {
+    using beman::big_int::uint_multiprecision_t;
+    using explicit_big_int =
+        beman::big_int::basic_big_int<256, std::allocator<uint_multiprecision_t>, uint_multiprecision_t>;
+
+    explicit_big_int x{1};
+    for (int i = 0; i < 40; ++i) {
+        x *= 3;
+    }
+
+    EXPECT_EQ(to_string(x), "12157665459056928801"); // 3^40
+    EXPECT_EQ(x % explicit_big_int{3}, explicit_big_int{0});
+    EXPECT_EQ((x / explicit_big_int{3}) * explicit_big_int{3}, x);
+    EXPECT_EQ(-x + x, explicit_big_int{0});
+
+    // The default spelling names the same type, so hashing must agree with it.
+    EXPECT_EQ(std::hash<explicit_big_int>{}(x), std::hash<beman::big_int::basic_big_int<256>>{}(x));
+}

--- a/tests/beman/big_int/big_int.test.cpp
+++ b/tests/beman/big_int/big_int.test.cpp
@@ -46,9 +46,9 @@ static_assert(basic_big_int<127, big_int::allocator_type>::inplace_bits == 128,
 template <class T>
 struct is_exact_big_int;
 
-template <std::size_t b, class A, class Limb>
-struct is_exact_big_int<basic_big_int<b, A, Limb>> : std::bool_constant<b == basic_big_int<b, A, Limb>::inplace_bits> {
-};
+template <std::size_t b, class A, class LimbType>
+struct is_exact_big_int<basic_big_int<b, A, LimbType>>
+    : std::bool_constant<b == basic_big_int<b, A, LimbType>::inplace_bits> {};
 
 static_assert(is_exact_big_int<big_int>::value,
               "The min_inplace_bits should match inplace_bits exactly for big_int, "

--- a/tests/beman/big_int/testing.hpp
+++ b/tests/beman/big_int/testing.hpp
@@ -9,8 +9,8 @@
 
 namespace beman::big_int {
 
-template <std::size_t b, class A, class Limb>
-std::ostream& operator<<(std::ostream& out, const basic_big_int<b, A, Limb>& x) {
+template <std::size_t b, class A, class LimbType>
+std::ostream& operator<<(std::ostream& out, const basic_big_int<b, A, LimbType>& x) {
     return out << to_string(x);
 }
 
@@ -41,9 +41,9 @@ template <class IntegralType>
 // representation_capacity() model, an in-place value has representation_capacity() equal to
 // inplace_capacity (capacity() reports inplace_bits); a heap-allocated value exceeds it.
 // Found by ADL from the tests because basic_big_int lives in this namespace.
-template <std::size_t b, class A, class Limb>
-[[nodiscard]] constexpr bool is_inplace(const basic_big_int<b, A, Limb>& x) noexcept {
-    return x.representation_capacity() == basic_big_int<b, A, Limb>::inplace_capacity;
+template <std::size_t b, class A, class LimbType>
+[[nodiscard]] constexpr bool is_inplace(const basic_big_int<b, A, LimbType>& x) noexcept {
+    return x.representation_capacity() == basic_big_int<b, A, LimbType>::inplace_capacity;
 }
 
 // Returns the number of bytes before the trailing run of zero bytes.

--- a/tests/beman/big_int/testing.hpp
+++ b/tests/beman/big_int/testing.hpp
@@ -9,8 +9,8 @@
 
 namespace beman::big_int {
 
-template <std::size_t b, class A>
-std::ostream& operator<<(std::ostream& out, const basic_big_int<b, A>& x) {
+template <std::size_t b, class A, class Limb>
+std::ostream& operator<<(std::ostream& out, const basic_big_int<b, A, Limb>& x) {
     return out << to_string(x);
 }
 
@@ -41,9 +41,9 @@ template <class IntegralType>
 // representation_capacity() model, an in-place value has representation_capacity() equal to
 // inplace_capacity (capacity() reports inplace_bits); a heap-allocated value exceeds it.
 // Found by ADL from the tests because basic_big_int lives in this namespace.
-template <std::size_t b, class A>
-[[nodiscard]] constexpr bool is_inplace(const basic_big_int<b, A>& x) noexcept {
-    return x.representation_capacity() == basic_big_int<b, A>::inplace_capacity;
+template <std::size_t b, class A, class Limb>
+[[nodiscard]] constexpr bool is_inplace(const basic_big_int<b, A, Limb>& x) noexcept {
+    return x.representation_capacity() == basic_big_int<b, A, Limb>::inplace_capacity;
 }
 
 // Returns the number of bytes before the trailing run of zero bytes.


### PR DESCRIPTION
@eisenwave here's basically what we discussed on WhatsApp yesterday. `LimbType` is defaulted to and `static_assert` on `uint_multiprecision_t`