### PR TITLE
x86_64 assembly for MSVC/MASM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,12 @@ if(
         beman.big_int
         PRIVATE src/multiply_long_runtime_x86_64_generic.s
     )
+elseif(MSVC AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|amd64")
+    enable_language(ASM_MASM)
+    target_sources(
+        beman.big_int
+        PRIVATE src/multiply_long_runtime_x86_64_generic.asm
+    )
 endif()
 
 # Multiplication's FFT tier. By default it is an integer Montgomery NTT

--- a/doc/modules/ROOT/pages/benchmarks.adoc
+++ b/doc/modules/ROOT/pages/benchmarks.adoc
@@ -272,9 +272,9 @@ https://github.com/eisenwave/std-big-int/blob/main/tests/beman/big_int/perf/div_
 [#benchmarks_base_conversion]
 == Base conversion and string representations
 
-Sub-quadratic base conversion underlies the library's `<charconv>` support (the
-`to_chars` and `from_chars` functions and the primitives beneath them), giving a
-convenient interface for converting big integers to and from their string
+Sub-quadratic base conversion is the basis for the library's `<charconv>` support.
+This includes the `to_chars` and `from_chars` functions and the primitives beneath them.
+These functions provide the interface for converting big integers to and from their string
 representations. The performance of these operations is governed primarily by the
 efficiency of the underlying multiplication and division algorithms described
 above. This holds for converting to and from string representations in any
@@ -292,56 +292,71 @@ xref:benchmarks.adoc#benchmarks_small_value[the small-value section] above.
 == Architecture-specific optimizations
 
 Dedicated architecture-specific optimizations using hand-written
-assembly are advantageous regarding runtime performance for this library.
+assembly can be very advantageous regarding runtime performance for this library.
 This is true for both the reference application as well as for potential,
 future adaptions of the library to other architectures.
 
 A particularly effective and straightforward assembly-based optimization
-is to hand-code the long multiplication algorithm in the
+is hand-coding the schoolbook long multiplication algorithm in the
 processor's assembly dialect. The simple optimization of schoolbook long multiplication
 percolates through many algorithms in the library. Not only is schoolbook
-long multiplication itself optimized, but also all the classical multiplication
+long multiplication itself accelerated, but also all the classical multiplication
 splitting-algorithms Karatsuba and all orders of Toom-Cook are optimized as well.
 This is because after the splitting of long limb spans is performed,
-the real work of these algorithms still falls through to basecase long multiplication.
-Simultaneously sub-quadratic large-limb-count long division and base conversion
-are optimized since they are built atop the multiplication algorithms
+the real work of these algorithms still falls through to basecase
+schoolbook long multiplication. Simultaneously sub-quadratic
+large-limb-count long division and base conversion
+directly benefit since they are built atop the multiplication algorithms
 and directly benefit from their optimizations.
 
 Experience shows, with one single assembly file that performs basecase
-schoolbook long multiplication, significant improvements in the performance
+schoolbook long multiplication, stark improvements in the performance
 of nearly the entire library can be achieved.
 
 One proof of concept is included for the popular `x86_64` architecture
 in its generic form. We have implemented basecase schoolbook long multiplication
-in hand-coded assembly for `x86_64` on compiler systems GCC and clang,
+in hand-coded assembly for `x86_64` on compiler systems GCC, clang and MSVC
 the detections of which happen at compile time.
 
-Performance results are shown in the tables below using an Intel(R) Core(TM) i9-11900K
-at 3.50GHz, running Ubuntu 24.04 within WSL2 compiled/assembled with GCC-13.
+An overview of multiplication performance is shown in the table below.
 Multiplication operations performed over a wide range of limb counts
-with and without assembly optimization have been compared with the same calculations for GMP.
-The heats ran 131,072 trials for multiplication with limb counts ranging from 16-2,048
+with and without assembly optimization have been compared with
+the same calculations for GMP (`gmp_int`). The heats ran 131,072 trials
+for multiplication with limb counts ranging from 16-2,048
 and for division with limb counts ranging from 16-3,072. The multiplication
 results are explicitly shown in the table below. Similar performance improvements
-are observed for division.
+are observed for division. For this measurement, an Intel(R) Core(TM) i9-11900K
+at 3.50GHz has been used.
 
 [cols="1,1,1,1,1", options="header"]
 |===
-|  long mul impl  | `beman::big_int` [us/mul] | `boost::gmp_int` [us/mul] |  ratio   | improvement [percent]
+|  system               | time C++ [us/mul] | time ASM [us/mul] | improvement [percent] | ratio ASM/`gmp_int`
 
-| C++             |  305   |  95[1]   |  3.2  | ---
-| hand-coded asm  |  210   |  95[1]   |  2.2  | 32
+| `big_int` (GCC/GAS)   |  305              |  210              | 32                    | 2.2
+| `big_int` (MSVC/MASM) |  380              |  230              | 60                    | 2.4
+| `gmp_int` (GCC/GAS)   |  ---              |   95              | ---                   |   1
 |===
 
-The relative performance improvement is almost one third, simply via creation
-and inclusion of a single hand-coded assembly routine for long multiplication.
+The relative performance improvement is significant;
+simply via creation of and inclusion of a single hand-coded assembly
+routine for schoolbook long multiplication.
 
 An adaption of the program
 https://github.com/eisenwave/std-big-int/blob/main/tests/beman/big_int/perf/mul_big_int_vs_gmp_cpp.limbs.cpp[mul_big_int_vs_gmp_cpp.limbs.cpp]
-has been used for this local result. The implementation of the assembly subroutine
-`beman_big_int_multiply_long_runtime` for `x86_64` on GCC/clang can be found in
-https://github.com/eisenwave/std-big-int/blob/main/src/multiply_long_runtime_x86_64_generic.s[multiply_long_runtime_x86_64_generic.s].
+has been used for this runtime result. The implementations of the assembly subroutines
+`beman_big_int_multiply_long_runtime` for `x86_64` use with GCC(clang)/GAS and use with MSVC/MASM
+can be found in
+https://github.com/eisenwave/std-big-int/blob/main/src/multiply_long_runtime_x86_64_generic.s[multiply_long_runtime_x86_64_generic.s]
+and
+https://github.com/eisenwave/std-big-int/blob/main/src/multiply_long_runtime_x86_64_generic.asm[multiply_long_runtime_x86_64_generic.asm],
+respectively.
+
+. At the moment, the assembly optimized routines can not be used within
+a `constexpr` context (nor with `consteval`). The use of
+`beman_big_int_multiply_long_runtime` has been isolated exclusively
+to the runtime path. The `constexpr` path, however, remains available
+when compile-time evaluation is possible with no additional limitations
+imposed by the use of hand-coded assembly.
 
 [#benchmarks_sources]
 == Source programs

--- a/include/beman/big_int/detail/config.hpp
+++ b/include/beman/big_int/detail/config.hpp
@@ -23,21 +23,14 @@
 #endif // __GNUC__
 
 // Special architecture assembly long-multiplication optimization ==============
-// This is only available for x86_64 on GCC/clang at the moment ================
+// It is available for generic x86_64 on GCC/clang/MSVC ========================
 
-#if defined(BEMAN_BIG_INT_CLANG) && (defined(__x86_64__) || defined(_M_X64))
-    #define BEMAN_BIG_INT_ARCH_X86_64_CLANG
+#if (defined(BEMAN_BIG_INT_CLANG) && (defined(__x86_64__) || defined(_M_X64))) || \
+    (defined(BEMAN_BIG_INT_GCC) && defined(__x86_64__)) || (defined(BEMAN_BIG_INT_MSVC) && defined(_M_X64))
+    #define BEMAN_BIG_INT_ARCH_X86_64
 #endif
 
-#if defined(BEMAN_BIG_INT_GCC) && defined(__x86_64__)
-    #define BEMAN_BIG_INT_ARCH_X86_64_GCC
-#endif
-
-#if defined(BEMAN_BIG_INT_ARCH_X86_64_GCC) || defined(BEMAN_BIG_INT_ARCH_X86_64_CLANG)
-    #define BEMAN_BIG_INT_ARCH_X86_64_GCC_OR_CLANG
-#endif
-
-#if defined(BEMAN_BIG_INT_ARCH_X86_64_GCC_OR_CLANG)
+#if defined(BEMAN_BIG_INT_ARCH_X86_64)
     #define BEMAN_BIG_INT_ARCH_X86_64_INLINE
 #else
     #define BEMAN_BIG_INT_ARCH_X86_64_INLINE inline

--- a/include/beman/big_int/detail/multiply_long_runtime.hpp
+++ b/include/beman/big_int/detail/multiply_long_runtime.hpp
@@ -12,7 +12,7 @@ beman_big_int_multiply_long_runtime(beman::big_int::uint_multiprecision_t*      
                                     const std::size_t                            len_a,
                                     const beman::big_int::uint_multiprecision_t* p_b,
                                     const std::size_t                            len_b) noexcept
-#if defined(BEMAN_BIG_INT_ARCH_X86_64_GCC_OR_CLANG)
+#if defined(BEMAN_BIG_INT_ARCH_X86_64)
     ;
 #else
 {
@@ -42,6 +42,6 @@ beman_big_int_multiply_long_runtime(beman::big_int::uint_multiprecision_t*      
     }
 }
 
-#endif // !defined(BEMAN_BIG_INT_ARCH_X86_64_GCC_OR_CLANG)
+#endif // !defined(BEMAN_BIG_INT_ARCH_X86_64)
 
 #endif // BEMAN_BIG_INT_MULTIPLY_LONG_RUNTIME_HPP

--- a/src/multiply_long_runtime_x86_64_generic.asm
+++ b/src/multiply_long_runtime_x86_64_generic.asm
@@ -1,0 +1,217 @@
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+; SPDX-License-Identifier: BSL-1.0
+
+.code
+
+; Schoolbook long multiplication, baseline x86-64 only (no SSE/AVX, no BMI2/ADX).
+
+; Microsoft x64 calling convention: rcx, rdx, r8, r9 for first four args
+;
+;   rcx -> p_result
+;   rdx -> p_a
+;   r8  -> len_a
+;   r9  -> p_b
+;   [rsp+40] -> len_b (5th argument; read before sub rsp 8, so offset = 40 + 4*8 = 72 at time of read)
+;
+; Writes exactly len_a + len_b limbs. The first row stores instead of
+; accumulating, so p_result need not be pre-zeroed (matching multiply_long).
+;
+; Register allocation during execution:
+;
+;   rcx -> result + len_a, walking forward one limb per row
+;   r8  -> a + len_a, fixed (rdx is kept free for the mul rdx:rax output)
+;   r9  -> b, walking forward one limb per row
+;   r10 -> len_b / rows left to do
+;   r11 -> b[j], the row's multiplier
+;   r12 -> the row's running carry
+;   rbx -> inner loop index, running -len_a .. 0
+;   r13 -> -(len_a & ~3), the index where the 4x unrolled body takes over
+;   rsi -> -len_a, the index each row starts from
+;
+; Both arrays are addressed as [ptr + rbx * 8], so no pointer has to be rewound
+; between rows: the index is just reloaded from rsi.
+
+; One limb of the first row: result[i] = a[i] * b[0] + carry.
+GENERIC_X64_MUL_LIMB MACRO off
+
+    mov     rax, QWORD PTR [r8 + rbx * 8 + off]     ; rax = a[i]
+    mul     r11                                     ; rdx : rax = a[i] * b[j]
+
+    add     rax, r12                                ; low64 += temp
+    adc     rdx, 0                                  ; high64 += carry_flag
+
+    mov     QWORD PTR [rcx + rbx * 8 + off], rax    ; result[i + j] = low64
+    mov     r12, rdx                                ; temp = high64
+
+ENDM
+
+; One limb of a later row: result[i + j] += a[i] * b[j] + carry.
+;
+; The stored product goes in first and the incoming carry last, which leaves
+; just the final add/adc pair loop-carried (two cycles); the widening multiply
+; and the load of result[i + j] hang off that chain instead of sitting on it.
+; a[i] * b[j] + result[i + j] + temp is at most 2^128 - 1, so neither adc can
+; carry out of high64.
+GENERIC_X64_ADDMUL_LIMB MACRO off
+
+    mov     rax, QWORD PTR [r8 + rbx * 8 + off]     ; rax = a[i]
+    mul     r11                                     ; rdx : rax = a[i] * b[j]
+
+    add     rax, QWORD PTR [rcx + rbx * 8 + off]    ; low64 += result[i + j]
+    adc     rdx, 0                                  ; high64 += carry_flag
+    add     rax, r12                                ; low64 += temp
+    adc     rdx, 0                                  ; high64 += carry_flag
+
+    mov     QWORD PTR [rcx + rbx * 8 + off], rax    ; result[i + j] = low64
+    mov     r12, rdx                                ; temp = high64
+
+ENDM
+
+beman_big_int_multiply_long_runtime PROC
+
+    ; Microsoft x64 calling convention:
+    ; rcx = p_result, rdx = p_a, r8 = len_a, r9 = p_b
+    ; 5th parameter at [rsp+40]
+
+    push    rbx
+    push    r12
+    push    r13
+    push    rsi
+
+    ; After 4 pushes (32 bytes), the 5th argument is at [rsp + 40 + 32] = [rsp + 72]
+    mov     r10, QWORD PTR [rsp + 72]
+
+    sub     rsp, 8
+
+    ; a * b is symmetric, so run the inner loop over the longer operand
+
+    ; a * b is symmetric, so run the inner loop over the longer operand: that
+    ; makes the number of rows, and with it all per-row overhead, min(len_a, len_b).
+
+    cmp     r8, r10                 ; compare len_a with len_b
+    jae     generic_x64_sizes_ordered
+
+    xchg    rdx, r9                 ; swap p_a and p_b
+    xchg    r8, r10                 ; swap len_a and len_b
+
+generic_x64_sizes_ordered:
+
+    test    r10, r10                ; an empty operand leaves nothing to do
+    jz      generic_x64_end
+
+    ; Now: r8 = len_a (the longer length), r10 = len_b (rows to process)
+    ;      rdx = p_a, r9 = p_b, rcx = p_result
+
+    mov     rsi, r8                 ; rsi = len_a (r8 free to hold a-pointer; rdx freed for mul)
+
+    ; now len_a in rsi, r8 will hold a + len_a (safe from mul clobber)
+
+    lea     r8, [rdx + rsi * 8]     ; r8 = a + len_a  (rdx left free for mul rdx:rax output)
+    lea     rcx, [rcx + rsi * 8]    ; rcx = result + len_a
+
+    mov     r13, rsi
+    and     r13, -4                 ; r13 = len_a & ~3
+    neg     r13                     ; r13 = -(len_a & ~3)
+    neg     rsi                     ; rsi = -len_a
+
+    ; rsi now contains -len_a (for the loop index)
+
+    ; First row (j = 0) stores instead of accumulating. That drops a load and
+    ; an add/adc pair per limb, and it is what lets the caller hand over a
+    ; buffer it has not zeroed.
+
+    mov     r11, QWORD PTR [r9]     ; r11 = b[0]
+    mov     rbx, rsi                ; rbx = i = -len_a
+    xor     r12d, r12d              ; r12 = temp = 0
+
+    cmp     rbx, r13
+    je      generic_x64_mul_row_4x
+
+generic_x64_mul_row_rmdr:
+
+    GENERIC_X64_MUL_LIMB 0
+
+    add     rbx, 1                                  ; i++
+    cmp     rbx, r13
+    jne     generic_x64_mul_row_rmdr                ; if (i != -(len_a & ~3)) { goto rmdr_loop_start; }
+
+generic_x64_mul_row_4x:
+
+    test    rbx, rbx
+    jz      generic_x64_mul_row_end
+
+    align 16
+generic_x64_mul_row_4x_unroll:
+
+    GENERIC_X64_MUL_LIMB 0
+    GENERIC_X64_MUL_LIMB 8
+    GENERIC_X64_MUL_LIMB 16
+    GENERIC_X64_MUL_LIMB 24
+
+    add     rbx, 4                                  ; i += 4
+    jnz     generic_x64_mul_row_4x_unroll           ; if (i != 0) { goto unroll_loop_start; }
+
+generic_x64_mul_row_end:
+
+    mov     QWORD PTR [rcx], r12    ; result[len_a] = temp
+
+    add     rcx, 8                  ; increment the result ptr for next iter
+    add     r9, 8                   ; increment the b ptr for next iter
+    sub     r10, 1                  ; len_b--
+    jz      generic_x64_end
+
+    align 16
+generic_x64_outer_loop_start:
+
+    mov     r11, QWORD PTR [r9]     ; r11 = b[j]
+    mov     rbx, rsi                ; rbx = i = -len_a
+    xor     r12d, r12d              ; r12 = temp = 0
+
+    cmp     rbx, r13
+    je      generic_x64_inner_loop_4x
+
+generic_x64_inner_loop_rmdr:
+
+    GENERIC_X64_ADDMUL_LIMB 0
+
+    add     rbx, 1                                  ; i++
+    cmp     rbx, r13
+    jne     generic_x64_inner_loop_rmdr             ; if (i != -(len_a & ~3)) { goto rmdr_loop_start; }
+
+generic_x64_inner_loop_4x:
+
+    test    rbx, rbx
+    jz      generic_x64_outer_loop_end
+
+    align 16
+generic_x64_inner_loop_4x_unroll:
+
+    GENERIC_X64_ADDMUL_LIMB 0
+    GENERIC_X64_ADDMUL_LIMB 8
+    GENERIC_X64_ADDMUL_LIMB 16
+    GENERIC_X64_ADDMUL_LIMB 24
+
+    add     rbx, 4                                  ; i += 4
+    jnz     generic_x64_inner_loop_4x_unroll        ; if (i != 0) { goto unroll_loop_start; }
+
+generic_x64_outer_loop_end:
+
+    mov     QWORD PTR [rcx], r12    ; result[len_a + j] = temp
+
+    add     rcx, 8                                  ; increment the result ptr for next iter
+    add     r9, 8                                   ; increment the b ptr for next iter
+    sub     r10, 1                                  ; len_b--
+    jnz     generic_x64_outer_loop_start            ; if (len_b != 0) { goto outer_loop_start; }
+
+generic_x64_end:
+
+    add     rsp, 8                  ; Unwind padding
+    pop     rsi                     ; restore in reverse push order (push was rbx,r12,r13,rsi)
+    pop     r13
+    pop     r12
+    pop     rbx
+    ret
+
+beman_big_int_multiply_long_runtime ENDP
+
+END


### PR DESCRIPTION
Add `x86_64` assembly optimization for MSVC/MASM-64. See also #310.
