### PR TITLE
Change hash to match `std::hash<_BitInt(N)>(static_cast<_BitInt(N)>(x))`

### DIFF
--- a/.github/workflows/metal.yml
+++ b/.github/workflows/metal.yml
@@ -19,7 +19,6 @@ jobs:
           fetch-depth: '0'
       - name: update-tools
         run: |
-          sudo apt update
           sudo apt install libncurses5-dev
           mkdir -p emu_env && cd emu_env
           wget --no-check-certificate https://gitlab.arm.com/api/v4/projects/tooling%2Fgnu-toolchains-for-arm/packages/generic/gnu-toolchain/15.3.rel1/arm-gnu-toolchain-15.3.rel1-x86_64-arm-none-eabi.tar.xz

--- a/doc/modules/ROOT/pages/big_int_type.adoc
+++ b/doc/modules/ROOT/pages/big_int_type.adoc
@@ -854,20 +854,32 @@ Where a signed bit-precise integer type can represent `x` and the implementation
 that type a digest, the digest is
 `std::hash<pass:[_BitInt(N)]>()(static_cast<pass:[_BitInt(N)]>(x))` for the narrowest
 such `N`, so a `basic_big_int` key and a `pass:[_BitInt(N)]` key of the same value hash
-alike and can be hashed interchangeably. The widths tried are 64, 128, 192, and 256
-bits, and one the target cannot form, or whose `std::hash` the implementation does not
-provide, is passed over. Those widths are one per object size, since a
-`pass:[_BitInt(N)]` past 64 bits occupies `ceil(N / 64)` words: on an implementation
-that hashes a scalar by its object representation, every `pass:[_BitInt]` of a given
-size has one digest, so a rung at each size covers every width that shares it. A value
-hashed on the 192-bit rung therefore also matches a `pass:[_BitInt(160)]` key of the
-same value. Where none is available every value takes the fallback below;
-that is the case on an implementation that hashes no `pass:[_BitInt]`, and on one whose
-compiler has no `pass:[_BitInt]` at all.
+alike and can be hashed interchangeably.
+
+The widths tried are one per object size: a `pass:[_BitInt(N)]` past one machine word
+occupies `ceil(N / word_bits)` words, and on an implementation that hashes a scalar by
+its object representation every `pass:[_BitInt]` of a given size has one digest, so a
+rung at each size covers every width that shares that size. A value hashed on the
+192-bit rung therefore also matches a `pass:[_BitInt(160)]` key of the same value, and
+one hashed on the narrowest rung matches every `pass:[_BitInt]` no wider than a word.
+The ladder runs from one word up to the widest object the implementation's own
+`std::hash` covers, which on a 64-bit target with libc++ is four words, so 64, 128,
+192, and 256 bits; a rung the target cannot form, or whose `std::hash` the
+implementation does not provide, is passed over. The reach is the
+`BEMAN_BIG_INT_HASH_MAX_OBJECT_WORDS` macro, counted in `std::size_t` words and
+defaulting to four, because libc++ hashes a scalar past that size with a helper it only
+declares, which is a hard error rather than something a concept can reject. Defining
+that macro to a larger value is the whole change needed to hash on wider rungs once a
+standard library covers them.
+
+Where no rung is available every value takes the fallback below; that is the case on an
+implementation that hashes no `pass:[_BitInt]`, and on one whose compiler has no
+`pass:[_BitInt]` at all.
 
 An implementation that hashes a scalar by its object representation gives
 `pass:[_BitInt(64)]` and `std::int64_t` the same digest, since they share one. On such
-an implementation a value in the range of `std::int64_t` therefore also hashes as
+an implementation, where a machine word is 64 bits, a value in the range of
+`std::int64_t` therefore also hashes as
 `std::hash<std::int64_t>()(static_cast<std::int64_t>(x))`.
 
 Beyond the widest available width the digest is not itself part of the interface and may change

--- a/doc/modules/ROOT/pages/big_int_type.adoc
+++ b/doc/modules/ROOT/pages/big_int_type.adoc
@@ -850,12 +850,23 @@ xref:big_int_type.adoc#big_int_type_unit_multi_t[`uint_multiprecision_t`] on the
 target: a value hashes the same where limbs are 32 bits wide as it does where
 they are 64 bits wide.
 
-Where `x` is a value that `std::int64_t` can represent, the digest is
-`std::hash<std::int64_t>()(static_cast<std::int64_t>(x))`. A `basic_big_int` key and
-an `std::int64_t` key of the same value therefore hash alike, so the two can be
-hashed interchangeably over that range.
+Where a builtin signed integer type can represent `x`, the digest is that of the
+narrowest such type, so a `basic_big_int` key and a builtin integer key of the same
+value hash alike and can be hashed interchangeably. The types are tried in the order
+`std::int64_t`, a 128-bit integer type, then a 256-bit bit-precise integer type, and
+one whose `std::hash` the implementation does not provide is passed over: the reach of
+the ladder therefore depends on the target and the standard library. `std::int64_t` is
+always available, `__int128` wherever the compiler has it, and `_BitInt` only where
+both the compiler and the library support it, which today means libc++ and no wider
+than 256 bits.
 
-Outside that range the digest is not itself part of the interface and may change
+Because the digest of such a value is the builtin's own, it carries whatever
+properties that digest has, including its collisions. An implementation whose hash of
+a wide integer type discards the bits above `std::size_t`, as libstdc++ does, gives
+`2^64^` and `0` the same digest here as well. Equality still separates them, so
+containers keyed on `basic_big_int` behave correctly.
+
+Beyond the widest rung the digest is not itself part of the interface and may change
 between releases. It is currently SipHash-2-4 over the little-endian byte string of
 the magnitude, trimmed of its most significant zero bytes. That string is
 `width_mag()` bits rounded up to a whole number of bytes. A negative value is

--- a/doc/modules/ROOT/pages/big_int_type.adoc
+++ b/doc/modules/ROOT/pages/big_int_type.adoc
@@ -850,23 +850,27 @@ xref:big_int_type.adoc#big_int_type_unit_multi_t[`uint_multiprecision_t`] on the
 target: a value hashes the same where limbs are 32 bits wide as it does where
 they are 64 bits wide.
 
-Where a builtin signed integer type can represent `x`, the digest is that of the
-narrowest such type, so a `basic_big_int` key and a builtin integer key of the same
-value hash alike and can be hashed interchangeably. The types are tried in the order
-`std::int64_t`, a 128-bit integer type, then a 256-bit bit-precise integer type, and
-one whose `std::hash` the implementation does not provide is passed over: the reach of
-the ladder therefore depends on the target and the standard library. `std::int64_t` is
-always available, `__int128` wherever the compiler has it, and `_BitInt` only where
-both the compiler and the library support it, which today means libc++ and no wider
-than 256 bits.
+Where a signed bit-precise integer type can represent `x` and the implementation gives
+that type a digest, the digest is
+`std::hash<pass:[_BitInt(N)]>()(static_cast<pass:[_BitInt(N)]>(x))` for the narrowest
+such `N`, so a `basic_big_int` key and a `pass:[_BitInt(N)]` key of the same value hash
+alike and can be hashed interchangeably. The widths tried are 64, 128, 192, and 256
+bits, and one the target cannot form, or whose `std::hash` the implementation does not
+provide, is passed over. Those widths are one per object size, since a
+`pass:[_BitInt(N)]` past 64 bits occupies `ceil(N / 64)` words: on an implementation
+that hashes a scalar by its object representation, every `pass:[_BitInt]` of a given
+size has one digest, so a rung at each size covers every width that shares it. A value
+hashed on the 192-bit rung therefore also matches a `pass:[_BitInt(160)]` key of the
+same value. Where none is available every value takes the fallback below;
+that is the case on an implementation that hashes no `pass:[_BitInt]`, and on one whose
+compiler has no `pass:[_BitInt]` at all.
 
-Because the digest of such a value is the builtin's own, it carries whatever
-properties that digest has, including its collisions. An implementation whose hash of
-a wide integer type discards the bits above `std::size_t`, as libstdc++ does, gives
-`2^64^` and `0` the same digest here as well. Equality still separates them, so
-containers keyed on `basic_big_int` behave correctly.
+An implementation that hashes a scalar by its object representation gives
+`pass:[_BitInt(64)]` and `std::int64_t` the same digest, since they share one. On such
+an implementation a value in the range of `std::int64_t` therefore also hashes as
+`std::hash<std::int64_t>()(static_cast<std::int64_t>(x))`.
 
-Beyond the widest rung the digest is not itself part of the interface and may change
+Beyond the widest available width the digest is not itself part of the interface and may change
 between releases. It is currently SipHash-2-4 over the little-endian byte string of
 the magnitude, trimmed of its most significant zero bytes. That string is
 `width_mag()` bits rounded up to a whole number of bytes. A negative value is

--- a/doc/modules/ROOT/pages/big_int_type.adoc
+++ b/doc/modules/ROOT/pages/big_int_type.adoc
@@ -850,13 +850,17 @@ xref:big_int_type.adoc#big_int_type_unit_multi_t[`uint_multiprecision_t`] on the
 target: a value hashes the same where limbs are 32 bits wide as it does where
 they are 64 bits wide.
 
-The digest is not itself part of the interface and may change between releases.
-It is currently SipHash-2-4 over the little-endian byte string of the magnitude,
-trimmed of its most significant zero bytes. That string is `width_mag()` bits
-rounded up to a whole number of bytes, so zero is hashed as the empty input. A
-negative value is distinguished from its magnitude before the string is absorbed.
-Where `std::size_t` is narrower than 64 bits, the digest is folded down to its
-width.
+Where `x` is a value that `std::int64_t` can represent, the digest is
+`std::hash<std::int64_t>()(static_cast<std::int64_t>(x))`. A `basic_big_int` key and
+an `std::int64_t` key of the same value therefore hash alike, so the two can be
+hashed interchangeably over that range.
+
+Outside that range the digest is not itself part of the interface and may change
+between releases. It is currently SipHash-2-4 over the little-endian byte string of
+the magnitude, trimmed of its most significant zero bytes. That string is
+`width_mag()` bits rounded up to a whole number of bytes. A negative value is
+distinguished from its magnitude before the string is absorbed. Where `std::size_t`
+is narrower than 64 bits, the digest is folded down to its width.
 
 * *Preconditions:* None.
 * *Postconditions:* None.

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -13,6 +13,8 @@
 #include <concepts>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <limits>
 #include <memory>
 #include <memory_resource>
 #include <ranges>
@@ -3426,6 +3428,12 @@ template <std::size_t b, class L, class A>
 struct std::hash<beman::big_int::basic_big_int<b, L, A>> {
 
     std::size_t operator()(const beman::big_int::basic_big_int<b, L, A>& x) const noexcept {
+        // A value that `std::int64_t` can represent is hashed as a `std::int64_t`
+        const auto width = x.width_mag();
+        if (width < 64 || (width == 64 && x == std::numeric_limits<std::int64_t>::min())) {
+            return std::hash<std::int64_t>{}(static_cast<std::int64_t>(x));
+        }
+
         return beman::big_int::detail::siphash(x.representation(), x.is_negative());
     }
 };

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -3423,18 +3423,92 @@ using big_int = basic_big_int<beman::big_int::big_int::inplace_bits>;
 
 } // namespace beman::big_int
 
+namespace beman::big_int::detail {
+
+// Occupies a rung of the hash ladder below whose builtin type the target lacks.
+// `std::hash` is disabled for it, so that rung is skipped.
+struct absent_hash_rung {};
+
+#if defined(__SIZEOF_INT128__)
+__extension__ using hash_extended_128 = __int128;
+#else
+using hash_extended_128 = absent_hash_rung;
+#endif
+
+// Try and use bit_int<128> if we don't have __int128
+#if BEMAN_BIG_INT_BITINT_MAXWIDTH >= 128
+using hash_bit_precise_128 = bit_int<128>;
+#else
+using hash_bit_precise_128 = absent_hash_rung;
+#endif
+
+// The known cap right now (19 Aug 26) is _BitInt(256)
+#if BEMAN_BIG_INT_BITINT_MAXWIDTH >= 256
+using hash_rung_256 = bit_int<256>;
+#else
+using hash_rung_256 = absent_hash_rung;
+#endif
+
+template <class T>
+concept std_hashable = sizeof(T) <= 4 * sizeof(std::size_t) && requires(const T& v) {
+    { std::hash<T>{}(v) } -> std::convertible_to<std::size_t>;
+};
+
+// One rung per width
+using hash_rung_128 = std::conditional_t<std_hashable<hash_extended_128>, hash_extended_128, hash_bit_precise_128>;
+
+// The width of a rung, or zero where the target lacks the type or the implementation does not hash it.
+template <class T>
+[[nodiscard]] consteval std::size_t hash_rung_bits() {
+    if constexpr (std_hashable<T>) {
+        return width_v<T>;
+    } else {
+        return 0;
+    }
+}
+
+// Past this width no rung can hold the value, so the ladder is skipped outright.
+inline constexpr std::size_t widest_hash_rung_bits =
+    std::max({hash_rung_bits<std::int64_t>(), hash_rung_bits<hash_rung_128>(), hash_rung_bits<hash_rung_256>()});
+
+// Hashes `x` as `T` where `T` can represent it, reporting whether it did.
+// A magnitude narrower than `T` is in range whatever its sign, and one of exactly `T`'s
+// width only for the most negative value of `T`, whose magnitude is a single bit. The
+// width therefore selects the rung, and only the rung that wins pays for a conversion.
+template <class T, class BigInt>
+[[nodiscard]] bool
+hash_as_builtin(const BigInt& x, const std::size_t width, const bool negative, std::size_t& digest) noexcept {
+    if constexpr (std_hashable<T>) {
+        if (width < width_v<T> || (width == width_v<T> && negative && is_power_of_two_span(x.representation()))) {
+            digest = std::hash<T>{}(static_cast<T>(x));
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace beman::big_int::detail
+
 // [big.int.hash], hash support
 template <std::size_t b, class L, class A>
 struct std::hash<beman::big_int::basic_big_int<b, L, A>> {
 
     std::size_t operator()(const beman::big_int::basic_big_int<b, L, A>& x) const noexcept {
-        // A value that `std::int64_t` can represent is hashed as a `std::int64_t`
-        const auto width = x.width_mag();
-        if (width < 64 || (width == 64 && x == std::numeric_limits<std::int64_t>::min())) {
-            return std::hash<std::int64_t>{}(static_cast<std::int64_t>(x));
+        namespace detail = beman::big_int::detail;
+
+        // A value a builtin signed integer type can represent is hashed as the narrowest such type
+        const auto width    = x.width_mag();
+        const bool negative = x.is_negative();
+        if (width <= detail::widest_hash_rung_bits) {
+            std::size_t digest{};
+            if (detail::hash_as_builtin<std::int64_t>(x, width, negative, digest) ||
+                detail::hash_as_builtin<detail::hash_rung_128>(x, width, negative, digest) ||
+                detail::hash_as_builtin<detail::hash_rung_256>(x, width, negative, digest)) {
+                return digest;
+            }
         }
 
-        return beman::big_int::detail::siphash(x.representation(), x.is_negative());
+        return detail::siphash(x.representation(), negative);
     }
 };
 

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -3429,36 +3429,30 @@ namespace beman::big_int::detail {
 // `std::hash` is disabled for it, so that rung is skipped.
 struct absent_hash_rung {};
 
-#if BEMAN_BIG_INT_BITINT_MAXWIDTH >= 64
-using hash_rung_64 = bit_int<64>;
+// One rung per object size rather than per width: a `_BitInt` past a word occupies
+inline constexpr std::size_t hash_rung_step = BEMAN_BIG_INT_WORD_BITS;
+
+// The rung `i` object sizes up from the narrowest.
+#if BEMAN_BIG_INT_BITINT_MAXWIDTH > 0
+template <std::size_t i>
+using hash_rung_t = bit_int<static_cast<int>((i + 1) * hash_rung_step)>;
 #else
-using hash_rung_64 = absent_hash_rung;
+template <std::size_t i>
+using hash_rung_t = absent_hash_rung;
 #endif
 
-#if BEMAN_BIG_INT_BITINT_MAXWIDTH >= 128
-using hash_rung_128 = bit_int<128>;
-#else
-using hash_rung_128 = absent_hash_rung;
-#endif
+// How many rungs there are to try: as many object sizes as both the target's `_BitInt` and
+// the reach of the standard library's own hash allow.
+inline constexpr std::size_t hash_rung_count =
+    std::min<std::size_t>(BEMAN_BIG_INT_HASH_MAX_OBJECT_WORDS, BEMAN_BIG_INT_BITINT_MAXWIDTH / hash_rung_step);
 
-// One rung per object size rather than per width: an implementation that hashes a scalar
-// by its object representation gives every `_BitInt` of the same size one digest, and a
-// `_BitInt` past 64 bits occupies `ceil(N / 64)` words.
-#if BEMAN_BIG_INT_BITINT_MAXWIDTH >= 192
-using hash_rung_192 = bit_int<192>;
-#else
-using hash_rung_192 = absent_hash_rung;
-#endif
+using hash_rung_indices = std::make_index_sequence<hash_rung_count>;
 
-// The known cap right now (19 Aug 26) is _BitInt(256)
-#if BEMAN_BIG_INT_BITINT_MAXWIDTH >= 256
-using hash_rung_256 = bit_int<256>;
-#else
-using hash_rung_256 = absent_hash_rung;
-#endif
-
+// Whether the standard library gives `T` a digest. The size test is not an optimization:
+// past the size its hash covers libc++ fails to compile rather than failing this
+// requirement, so the size has to be asked first.
 template <class T>
-concept std_hashable = sizeof(T) <= 4 * sizeof(std::size_t) && requires(const T& v) {
+concept std_hashable = sizeof(T) <= BEMAN_BIG_INT_HASH_MAX_OBJECT_WORDS * sizeof(std::size_t) && requires(const T& v) {
     { std::hash<T>{}(v) } -> std::convertible_to<std::size_t>;
 };
 
@@ -3472,11 +3466,16 @@ template <class T>
     }
 }
 
+// The widest rung the standard library will hash, or zero where it hashes none.
+template <std::size_t... i>
+[[nodiscard]] consteval std::size_t widest_hash_rung(std::index_sequence<i...>) {
+    std::size_t widest = 0;
+    ((widest = std::max(widest, hash_rung_bits<hash_rung_t<i>>())), ...);
+    return widest;
+}
+
 // Past this width no rung can hold the value, so the ladder is skipped outright.
-inline constexpr std::size_t widest_hash_rung_bits = std::max({hash_rung_bits<hash_rung_64>(),
-                                                               hash_rung_bits<hash_rung_128>(),
-                                                               hash_rung_bits<hash_rung_192>(),
-                                                               hash_rung_bits<hash_rung_256>()});
+inline constexpr std::size_t widest_hash_rung_bits = widest_hash_rung(hash_rung_indices{});
 
 // Hashes `x` as `T` where `T` can represent it, reporting whether it did.
 // A magnitude narrower than `T` is in range whatever its sign, and one of exactly `T`'s
@@ -3494,6 +3493,17 @@ hash_as_bit_int(const BigInt& x, const std::size_t width, const bool negative, s
     return false;
 }
 
+// Hashes `x` on the narrowest rung that can represent it, reporting whether one could. The
+// fold short-circuits, so the rungs are tried narrowest first and stop at the one that wins.
+template <class BigInt, std::size_t... i>
+[[nodiscard]] bool hash_on_rung_ladder(const BigInt&     x,
+                                       const std::size_t width,
+                                       const bool        negative,
+                                       std::size_t&      digest,
+                                       std::index_sequence<i...>) noexcept {
+    return (hash_as_bit_int<hash_rung_t<i>>(x, width, negative, digest) || ...);
+}
+
 } // namespace beman::big_int::detail
 
 // [big.int.hash], hash support
@@ -3503,16 +3513,16 @@ struct std::hash<beman::big_int::basic_big_int<b, L, A>> {
     std::size_t operator()(const beman::big_int::basic_big_int<b, L, A>& x) const noexcept {
         namespace detail = beman::big_int::detail;
 
-        // A value a builtin signed integer type can represent is hashed as the narrowest such type
-        const auto width    = x.width_mag();
         const bool negative = x.is_negative();
-        if (width <= detail::widest_hash_rung_bits) {
-            std::size_t digest{};
-            if (detail::hash_as_bit_int<detail::hash_rung_64>(x, width, negative, digest) ||
-                detail::hash_as_bit_int<detail::hash_rung_128>(x, width, negative, digest) ||
-                detail::hash_as_bit_int<detail::hash_rung_192>(x, width, negative, digest) ||
-                detail::hash_as_bit_int<detail::hash_rung_256>(x, width, negative, digest)) {
-                return digest;
+
+        // A value a signed bit-precise integer type can represent is hashed as the narrowest such type
+        if constexpr (detail::widest_hash_rung_bits != 0) {
+            const auto width = x.width_mag();
+            if (width <= detail::widest_hash_rung_bits) {
+                std::size_t digest{};
+                if (detail::hash_on_rung_ladder(x, width, negative, digest, detail::hash_rung_indices{})) {
+                    return digest;
+                }
             }
         }
 

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -3425,21 +3425,29 @@ using big_int = basic_big_int<beman::big_int::big_int::inplace_bits>;
 
 namespace beman::big_int::detail {
 
-// Occupies a rung of the hash ladder below whose builtin type the target lacks.
+// Occupies a rung of the hash ladder whose width the target's `_BitInt` cannot reach.
 // `std::hash` is disabled for it, so that rung is skipped.
 struct absent_hash_rung {};
 
-#if defined(__SIZEOF_INT128__)
-__extension__ using hash_extended_128 = __int128;
+#if BEMAN_BIG_INT_BITINT_MAXWIDTH >= 64
+using hash_rung_64 = bit_int<64>;
 #else
-using hash_extended_128 = absent_hash_rung;
+using hash_rung_64 = absent_hash_rung;
 #endif
 
-// Try and use bit_int<128> if we don't have __int128
 #if BEMAN_BIG_INT_BITINT_MAXWIDTH >= 128
-using hash_bit_precise_128 = bit_int<128>;
+using hash_rung_128 = bit_int<128>;
 #else
-using hash_bit_precise_128 = absent_hash_rung;
+using hash_rung_128 = absent_hash_rung;
+#endif
+
+// One rung per object size rather than per width: an implementation that hashes a scalar
+// by its object representation gives every `_BitInt` of the same size one digest, and a
+// `_BitInt` past 64 bits occupies `ceil(N / 64)` words.
+#if BEMAN_BIG_INT_BITINT_MAXWIDTH >= 192
+using hash_rung_192 = bit_int<192>;
+#else
+using hash_rung_192 = absent_hash_rung;
 #endif
 
 // The known cap right now (19 Aug 26) is _BitInt(256)
@@ -3454,9 +3462,6 @@ concept std_hashable = sizeof(T) <= 4 * sizeof(std::size_t) && requires(const T&
     { std::hash<T>{}(v) } -> std::convertible_to<std::size_t>;
 };
 
-// One rung per width
-using hash_rung_128 = std::conditional_t<std_hashable<hash_extended_128>, hash_extended_128, hash_bit_precise_128>;
-
 // The width of a rung, or zero where the target lacks the type or the implementation does not hash it.
 template <class T>
 [[nodiscard]] consteval std::size_t hash_rung_bits() {
@@ -3468,8 +3473,10 @@ template <class T>
 }
 
 // Past this width no rung can hold the value, so the ladder is skipped outright.
-inline constexpr std::size_t widest_hash_rung_bits =
-    std::max({hash_rung_bits<std::int64_t>(), hash_rung_bits<hash_rung_128>(), hash_rung_bits<hash_rung_256>()});
+inline constexpr std::size_t widest_hash_rung_bits = std::max({hash_rung_bits<hash_rung_64>(),
+                                                               hash_rung_bits<hash_rung_128>(),
+                                                               hash_rung_bits<hash_rung_192>(),
+                                                               hash_rung_bits<hash_rung_256>()});
 
 // Hashes `x` as `T` where `T` can represent it, reporting whether it did.
 // A magnitude narrower than `T` is in range whatever its sign, and one of exactly `T`'s
@@ -3477,7 +3484,7 @@ inline constexpr std::size_t widest_hash_rung_bits =
 // width therefore selects the rung, and only the rung that wins pays for a conversion.
 template <class T, class BigInt>
 [[nodiscard]] bool
-hash_as_builtin(const BigInt& x, const std::size_t width, const bool negative, std::size_t& digest) noexcept {
+hash_as_bit_int(const BigInt& x, const std::size_t width, const bool negative, std::size_t& digest) noexcept {
     if constexpr (std_hashable<T>) {
         if (width < width_v<T> || (width == width_v<T> && negative && is_power_of_two_span(x.representation()))) {
             digest = std::hash<T>{}(static_cast<T>(x));
@@ -3501,9 +3508,10 @@ struct std::hash<beman::big_int::basic_big_int<b, L, A>> {
         const bool negative = x.is_negative();
         if (width <= detail::widest_hash_rung_bits) {
             std::size_t digest{};
-            if (detail::hash_as_builtin<std::int64_t>(x, width, negative, digest) ||
-                detail::hash_as_builtin<detail::hash_rung_128>(x, width, negative, digest) ||
-                detail::hash_as_builtin<detail::hash_rung_256>(x, width, negative, digest)) {
+            if (detail::hash_as_bit_int<detail::hash_rung_64>(x, width, negative, digest) ||
+                detail::hash_as_bit_int<detail::hash_rung_128>(x, width, negative, digest) ||
+                detail::hash_as_bit_int<detail::hash_rung_192>(x, width, negative, digest) ||
+                detail::hash_as_bit_int<detail::hash_rung_256>(x, width, negative, digest)) {
                 return digest;
             }
         }

--- a/include/beman/big_int/detail/config.hpp
+++ b/include/beman/big_int/detail/config.hpp
@@ -143,6 +143,15 @@ using bit_uint = unsigned _BitInt(N);
     #define BEMAN_BIG_INT_BITINT_MAXWIDTH 128
 #endif
 
+// std::hash reach over bit-precise integers ===================================
+//
+// libc++ currently supports 4 words (20 Aug 2026)
+// If this value increases or needs tested a user can change it on the command line,
+// or simply PR this one spot to increase the availability
+#ifndef BEMAN_BIG_INT_HASH_MAX_OBJECT_WORDS
+    #define BEMAN_BIG_INT_HASH_MAX_OBJECT_WORDS 4
+#endif
+
 // 32-bit/64-bit ===============================================================
 
 #include <cstdint>

--- a/tests/beman/big_int/hash.test.cpp
+++ b/tests/beman/big_int/hash.test.cpp
@@ -728,8 +728,9 @@ constexpr std::size_t narrowest_bit_int_bits = 2;
 // `big_int` key of the same value exactly where that value needs `N`'s object size: one small
 // enough for a narrower rung takes the narrower rung's digest, which past the first step is a
 // digest over fewer bytes. Below the first step there is no narrower rung, so the whole range
-// of `_BitInt(N)` qualifies.
-[[nodiscard]] bool needs_own_object_size(const big_int& x, const std::size_t bits) {
+// of `_BitInt(N)` qualifies. Where the standard library hashes no `_BitInt` the sweep below
+// has no width to check, so this helper goes unused there.
+[[nodiscard, maybe_unused]] bool needs_own_object_size(const big_int& x, const std::size_t bits) {
     const std::size_t narrower = rung_below(bits);
     if (narrower == 0) {
         return true;
@@ -741,10 +742,12 @@ constexpr std::size_t narrowest_bit_int_bits = 2;
 // Checks a `big_int` against a `_BitInt(bits)` holding the same value, over both ends of that
 // type's range, both ends of the band of values it is the narrowest of its object size for,
 // and a spread in between. Reports how many values were checked, which is none where the
-// implementation does not hash the type.
-template <std::size_t bits>
+// implementation does not hash the type. `T` is a template parameter rather than a local
+// alias so that `std::hash<T>` stays dependent: on a target without `_BitInt` every width
+// names the same placeholder, and a compiler is free to reject a non-dependent use of it
+// even in the branch discarded below.
+template <std::size_t bits, class T = bit_int_of<bits>>
 [[nodiscard]] std::size_t check_width() {
-    using T = bit_int_of<bits>;
     if constexpr (!detail::std_hashable<T>) {
         return 0;
     } else {

--- a/tests/beman/big_int/hash.test.cpp
+++ b/tests/beman/big_int/hash.test.cpp
@@ -515,13 +515,16 @@ static constexpr std::int64_t sweep_values[]{int64_min,
                                              int64_max - 1,
                                              int64_max};
 
-TEST(Hash, MatchesBitPreciseHashInTheNarrowestRung) {
-    if constexpr (!detail::std_hashable<detail::hash_rung_64>) {
+// The bodies below are templates so that `if constexpr` really does discard the rung half
+// where the implementation hashes no `_BitInt`. In a non-template function both halves are
+// still checked, and naming `std::hash<rung>` there is an error rather than dead code.
+template <class rung>
+void check_narrowest_rung() {
+    if constexpr (!detail::std_hashable<rung>) {
         GTEST_SKIP() << "this implementation does not hash a 64-bit _BitInt";
     } else {
         // A `big_int` and a `_BitInt(64)` of the same value must agree, so that a program
         // can hash the two interchangeably.
-        using rung = detail::hash_rung_64;
         const std::hash<big_int> h{};
         const std::hash<rung>    builtin{};
 
@@ -544,15 +547,17 @@ TEST(Hash, MatchesBitPreciseHashInTheNarrowestRung) {
     }
 }
 
-TEST(Hash, AgreesWithInt64WhereTheTwoBuiltinDigestsAgree) {
-    // The narrowest rung and `std::int64_t` hold the same values, so wherever the
-    // implementation gives the two the same digest, which libc++ does since it hashes a
-    // scalar by its object representation, a `big_int` agrees with `std::int64_t` as well.
-    // Nothing to check where the implementation makes them differ, or hashes no `_BitInt`.
-    if constexpr (!detail::std_hashable<detail::hash_rung_64>) {
+TEST(Hash, MatchesBitPreciseHashInTheNarrowestRung) { check_narrowest_rung<detail::hash_rung_64>(); }
+
+// The narrowest rung and `std::int64_t` hold the same values, so wherever the implementation
+// gives the two the same digest, which libc++ does since it hashes a scalar by its object
+// representation, a `big_int` agrees with `std::int64_t` as well. Nothing to check where the
+// implementation makes them differ, or hashes no `_BitInt`.
+template <class rung>
+void check_int64_agreement() {
+    if constexpr (!detail::std_hashable<rung>) {
         GTEST_SKIP() << "this implementation does not hash a 64-bit _BitInt";
     } else {
-        using rung = detail::hash_rung_64;
         if (std::hash<rung>{}(rung{42}) != std::hash<std::int64_t>{}(42)) {
             GTEST_SKIP() << "this implementation hashes _BitInt(64) and std::int64_t differently";
         }
@@ -564,15 +569,16 @@ TEST(Hash, AgreesWithInt64WhereTheTwoBuiltinDigestsAgree) {
     }
 }
 
-TEST(Hash, MatchesBitPreciseHashAcrossInplaceBits) {
-    // The rung is chosen on the value, not on where the value is stored, so a value that
-    // is in place for one parameterization and heap-allocated for another still lands on
-    // the same digest.
-    if constexpr (!detail::std_hashable<detail::hash_rung_64>) {
+TEST(Hash, AgreesWithInt64WhereTheTwoBuiltinDigestsAgree) { check_int64_agreement<detail::hash_rung_64>(); }
+
+// The rung is chosen on the value, not on where the value is stored, so a value that is in
+// place for one parameterization and heap-allocated for another still lands on the same
+// digest.
+template <class rung>
+void check_rung_across_inplace_bits() {
+    if constexpr (!detail::std_hashable<rung>) {
         GTEST_SKIP() << "this implementation does not hash a 64-bit _BitInt";
     } else {
-        using rung = detail::hash_rung_64;
-
         static constexpr std::int64_t values[]{int64_min, -1, 0, 42, int64_max};
 
         for (const std::int64_t v : values) {
@@ -584,6 +590,8 @@ TEST(Hash, MatchesBitPreciseHashAcrossInplaceBits) {
         }
     }
 }
+
+TEST(Hash, MatchesBitPreciseHashAcrossInplaceBits) { check_rung_across_inplace_bits<detail::hash_rung_64>(); }
 
 TEST(Hash, BitPrecisePathEndsAtTheWidestRung) {
     // The value just past each end of the widest rung is hashed the other way, and must

--- a/tests/beman/big_int/hash.test.cpp
+++ b/tests/beman/big_int/hash.test.cpp
@@ -123,6 +123,23 @@ using namespace beman::big_int::literals;
 
 namespace detail = beman::big_int::detail;
 
+// The rungs as the implementation generates them, narrowest first.
+template <std::size_t i>
+using rung = detail::hash_rung_t<i>;
+
+using rung_indices = detail::hash_rung_indices;
+
+// A signed `_BitInt` of an arbitrary width, for the widths swept between the rungs.
+// `bit_int` is only declared where the target has `_BitInt` at all, so the alias stands in
+// for the widths of a target that has none.
+#if BEMAN_BIG_INT_BITINT_MAXWIDTH > 0
+template <std::size_t bits>
+using bit_int_of = ::bit_int<static_cast<int>(bits)>;
+#else
+template <std::size_t bits>
+using bit_int_of = detail::absent_hash_rung;
+#endif
+
 // The width of a rung, or zero where the target lacks the type or the implementation does
 // not hash it. `detail::absent_hash_rung` stands in for a type the target lacks.
 template <class T>
@@ -134,7 +151,6 @@ template <class T>
     }
 }
 
-constexpr std::size_t bits_128_rung    = rung_bits<detail::hash_rung_128>();
 constexpr std::size_t widest_rung_bits = detail::widest_hash_rung_bits;
 
 // Whether `T` can represent `x`, from value-level bounds rather than the round trip
@@ -150,7 +166,7 @@ template <class T>
 }
 
 template <class T>
-[[nodiscard]] bool expected_builtin_digest(const big_int& x, std::size_t& digest) {
+[[nodiscard]] bool rung_digest(const big_int& x, std::size_t& digest) {
     if constexpr (detail::std_hashable<T>) {
         if (representable<T>(x)) {
             digest = std::hash<T>{}(static_cast<T>(x));
@@ -160,8 +176,14 @@ template <class T>
     return false;
 }
 
-// The rungs are nested ranges, so the widest one decides which path a value takes. Where
-// the implementation hashes no `_BitInt` at all, every value takes SipHash.
+// The rungs are nested ranges, so the narrowest one that can represent `x` gives its digest.
+template <std::size_t... i>
+[[nodiscard]] bool expected_builtin_digest(const big_int& x, std::size_t& digest, std::index_sequence<i...>) {
+    return (rung_digest<rung<i>>(x, digest) || ...);
+}
+
+// The widest rung decides which path a value takes. Where the implementation hashes no
+// `_BitInt` at all, every value takes SipHash.
 [[nodiscard]] bool takes_builtin_path(const big_int& x) {
     if constexpr (widest_rung_bits == 0) {
         return false;
@@ -176,10 +198,7 @@ template <class T>
 // bytes of the magnitude.
 [[nodiscard]] std::size_t expected_hash(const big_int& x) {
     std::size_t digest{};
-    if (expected_builtin_digest<detail::hash_rung_64>(x, digest) ||  //
-        expected_builtin_digest<detail::hash_rung_128>(x, digest) || //
-        expected_builtin_digest<detail::hash_rung_192>(x, digest) || //
-        expected_builtin_digest<detail::hash_rung_256>(x, digest)) {
+    if (expected_builtin_digest(x, digest, rung_indices{})) {
         return digest;
     }
     return fold_to_size_t(reference_siphash24(magnitude_bytes(x), std::is_lt(x <=> 0)));
@@ -517,49 +536,57 @@ static constexpr std::int64_t sweep_values[]{int64_min,
 
 // The bodies below are templates so that `if constexpr` really does discard the rung half
 // where the implementation hashes no `_BitInt`. In a non-template function both halves are
-// still checked, and naming `std::hash<rung>` there is an error rather than dead code.
-template <class rung>
+// still checked, and naming `std::hash<narrowest>` there is an error rather than dead code.
+template <class narrowest>
 void check_narrowest_rung() {
-    if constexpr (!detail::std_hashable<rung>) {
-        GTEST_SKIP() << "this implementation does not hash a 64-bit _BitInt";
+    if constexpr (!detail::std_hashable<narrowest>) {
+        GTEST_SKIP() << "this implementation hashes no _BitInt";
     } else {
-        // A `big_int` and a `_BitInt(64)` of the same value must agree, so that a program
-        // can hash the two interchangeably.
-        const std::hash<big_int> h{};
-        const std::hash<rung>    builtin{};
+        // A `big_int` and a `_BitInt` of the narrowest rung's width, holding the same value,
+        // must agree, so that a program can hash the two interchangeably.
+        const std::hash<big_int>   h{};
+        const std::hash<narrowest> builtin{};
 
+        // A value the rung cannot represent is hashed further up the ladder, so it says
+        // nothing about this rung.
         for (const std::int64_t v : sweep_values) {
-            EXPECT_EQ(h(big_int{v}), builtin(static_cast<rung>(v))) << "value " << v;
+            if (!representable<narrowest>(big_int{v})) {
+                continue;
+            }
+            EXPECT_EQ(h(big_int{v}), builtin(static_cast<narrowest>(v))) << "value " << v;
         }
 
         for (std::int64_t v = -300; v <= 300; ++v) {
-            EXPECT_EQ(h(big_int{v}), builtin(static_cast<rung>(v))) << "value " << v;
+            EXPECT_EQ(h(big_int{v}), builtin(static_cast<narrowest>(v))) << "value " << v;
         }
 
         // Every power of two in range, and its neighbours, so both sides of each limb and
         // byte boundary of the rung are covered.
-        for (int bit = 0; bit < 63; ++bit) {
+        const int top = static_cast<int>(std::min<std::size_t>(detail::width_v<narrowest>, 64U)) - 1;
+        for (int bit = 0; bit < top; ++bit) {
             const std::int64_t power = std::int64_t{1} << bit;
             for (const std::int64_t v : {power, power - 1, -power, -power + 1}) {
-                EXPECT_EQ(h(big_int{v}), builtin(static_cast<rung>(v))) << "value " << v;
+                EXPECT_EQ(h(big_int{v}), builtin(static_cast<narrowest>(v))) << "value " << v;
             }
         }
     }
 }
 
-TEST(Hash, MatchesBitPreciseHashInTheNarrowestRung) { check_narrowest_rung<detail::hash_rung_64>(); }
+TEST(Hash, MatchesBitPreciseHashInTheNarrowestRung) { check_narrowest_rung<rung<0>>(); }
 
-// The narrowest rung and `std::int64_t` hold the same values, so wherever the implementation
-// gives the two the same digest, which libc++ does since it hashes a scalar by its object
-// representation, a `big_int` agrees with `std::int64_t` as well. Nothing to check where the
-// implementation makes them differ, or hashes no `_BitInt`.
-template <class rung>
+// Where the narrowest rung is as wide as `std::int64_t` the two hold the same values, so
+// wherever the implementation gives them the same digest, which libc++ does since it hashes
+// a scalar by its object representation, a `big_int` agrees with `std::int64_t` as well.
+// Nothing to check where the implementation makes them differ, or hashes no `_BitInt`.
+template <class narrowest>
 void check_int64_agreement() {
-    if constexpr (!detail::std_hashable<rung>) {
-        GTEST_SKIP() << "this implementation does not hash a 64-bit _BitInt";
+    if constexpr (!detail::std_hashable<narrowest>) {
+        GTEST_SKIP() << "this implementation hashes no _BitInt";
+    } else if constexpr (detail::width_v<narrowest> < detail::width_v<std::int64_t>) {
+        GTEST_SKIP() << "the narrowest rung is narrower than std::int64_t";
     } else {
-        if (std::hash<rung>{}(rung{42}) != std::hash<std::int64_t>{}(42)) {
-            GTEST_SKIP() << "this implementation hashes _BitInt(64) and std::int64_t differently";
+        if (std::hash<narrowest>{}(narrowest{42}) != std::hash<std::int64_t>{}(42)) {
+            GTEST_SKIP() << "this implementation hashes the narrowest rung and std::int64_t differently";
         }
 
         const std::hash<big_int> h{};
@@ -569,20 +596,22 @@ void check_int64_agreement() {
     }
 }
 
-TEST(Hash, AgreesWithInt64WhereTheTwoBuiltinDigestsAgree) { check_int64_agreement<detail::hash_rung_64>(); }
+TEST(Hash, AgreesWithInt64WhereTheTwoBuiltinDigestsAgree) { check_int64_agreement<rung<0>>(); }
 
 // The rung is chosen on the value, not on where the value is stored, so a value that is in
 // place for one parameterization and heap-allocated for another still lands on the same
 // digest.
-template <class rung>
+template <class narrowest>
 void check_rung_across_inplace_bits() {
-    if constexpr (!detail::std_hashable<rung>) {
-        GTEST_SKIP() << "this implementation does not hash a 64-bit _BitInt";
+    if constexpr (!detail::std_hashable<narrowest>) {
+        GTEST_SKIP() << "this implementation hashes no _BitInt";
+    } else if constexpr (detail::width_v<narrowest> < detail::width_v<std::int64_t>) {
+        GTEST_SKIP() << "the narrowest rung is narrower than std::int64_t";
     } else {
         static constexpr std::int64_t values[]{int64_min, -1, 0, 42, int64_max};
 
         for (const std::int64_t v : values) {
-            const std::size_t expected = std::hash<rung>{}(static_cast<rung>(v));
+            const std::size_t expected = std::hash<narrowest>{}(static_cast<narrowest>(v));
             EXPECT_EQ(std::hash<basic_big_int<32>>{}(basic_big_int<32>{v}), expected) << "value " << v;
             EXPECT_EQ(std::hash<basic_big_int<64>>{}(basic_big_int<64>{v}), expected) << "value " << v;
             EXPECT_EQ(std::hash<basic_big_int<256>>{}(basic_big_int<256>{v}), expected) << "value " << v;
@@ -591,7 +620,7 @@ void check_rung_across_inplace_bits() {
     }
 }
 
-TEST(Hash, MatchesBitPreciseHashAcrossInplaceBits) { check_rung_across_inplace_bits<detail::hash_rung_64>(); }
+TEST(Hash, MatchesBitPreciseHashAcrossInplaceBits) { check_rung_across_inplace_bits<rung<0>>(); }
 
 TEST(Hash, BitPrecisePathEndsAtTheWidestRung) {
     // The value just past each end of the widest rung is hashed the other way, and must
@@ -623,8 +652,8 @@ TEST(Hash, BitPrecisePathEndsAtTheWidestRung) {
     }
 }
 
-// Checks the values that only rung `T` can represent, `T` being the rung above one of
-// `narrower_bits` bits, or the narrowest rung where that is zero. Does nothing where the
+// Checks the values that only rung `T` can represent, `T` sitting above a rung of
+// `narrower_bits` bits, or above nothing where that is zero. Does nothing where the
 // implementation does not hash `T`.
 template <class T>
 [[nodiscard]] std::size_t check_rung(const std::size_t narrower_bits) {
@@ -653,25 +682,124 @@ template <class T>
     return checked;
 }
 
+// Walks the ladder narrowest first, carrying the width of the widest rung below the one
+// being checked, and reports how many rungs contributed a check.
+template <std::size_t... i>
+[[nodiscard]] std::size_t check_every_rung(std::index_sequence<i...>) {
+    std::size_t narrower = 0;
+    std::size_t checked  = 0;
+    ((checked += check_rung<rung<i>>(narrower) != 0 ? 1U : 0U, narrower = std::max(narrower, rung_bits<rung<i>>())),
+     ...);
+    return checked;
+}
+
+// An object size the implementation hashes is one every narrower size is hashed too, so the
+// widest rung tells how many rungs there are to check.
+constexpr std::size_t hashable_rungs = widest_rung_bits / detail::hash_rung_step;
+
 TEST(Hash, MatchesBitPreciseHashOnEveryRung) {
     if constexpr (widest_rung_bits == 0) {
         GTEST_SKIP() << "this implementation hashes no _BitInt, so every value takes SipHash";
     } else {
-        // Each rung is checked against the widest rung narrower than it, skipping the ones
-        // this implementation does not hash.
-        constexpr std::size_t bits_64_rung  = rung_bits<detail::hash_rung_64>();
-        constexpr std::size_t bits_192_rung = rung_bits<detail::hash_rung_192>();
-        constexpr std::size_t below_128     = bits_64_rung;
-        constexpr std::size_t below_192     = bits_128_rung != 0 ? bits_128_rung : below_128;
-        constexpr std::size_t below_256     = bits_192_rung != 0 ? bits_192_rung : below_192;
+        // Every rung must have been checked, not merely some of them.
+        EXPECT_EQ(check_every_rung(rung_indices{}), hashable_rungs) << "widest rung " << widest_rung_bits << " bits";
+    }
+}
 
-        std::size_t checked = check_rung<detail::hash_rung_64>(0);
-        checked += check_rung<detail::hash_rung_128>(below_128);
-        checked += check_rung<detail::hash_rung_192>(below_192);
-        checked += check_rung<detail::hash_rung_256>(below_256);
+// ----- Parity with `_BitInt(N)` at every width, not only at the rungs -----
 
-        // A rung was reported, so something must have been checked.
-        EXPECT_GT(checked, 0U) << "widest rung " << widest_rung_bits << " bits";
+// A signed `_BitInt` is at least two bits wide, so a sweep of widths starts there.
+constexpr std::size_t narrowest_bit_int_bits = 2;
+
+// The rung a `_BitInt(bits)` shares an object size with: the ladder steps one object size at
+// a time, so it is `bits` rounded up to a whole number of steps.
+[[nodiscard]] constexpr std::size_t rung_covering(const std::size_t bits) {
+    return detail::div_to_pos_inf(bits, detail::hash_rung_step) * detail::hash_rung_step;
+}
+
+// The width of the rung below the one covering `bits`, or zero where there is none.
+[[nodiscard]] constexpr std::size_t rung_below(const std::size_t bits) {
+    return rung_covering(bits) - detail::hash_rung_step;
+}
+
+// `std::hash<big_int>` gives a value the digest of the narrowest rung that can represent it,
+// and an implementation that hashes a scalar by its object representation gives every
+// `_BitInt` of one object size a single digest. A `_BitInt(N)` key therefore hashes as a
+// `big_int` key of the same value exactly where that value needs `N`'s object size: one small
+// enough for a narrower rung takes the narrower rung's digest, which past the first step is a
+// digest over fewer bytes. Below the first step there is no narrower rung, so the whole range
+// of `_BitInt(N)` qualifies.
+[[nodiscard]] bool needs_own_object_size(const big_int& x, const std::size_t bits) {
+    const std::size_t narrower = rung_below(bits);
+    if (narrower == 0) {
+        return true;
+    }
+    const big_int bound = big_int{1} << (narrower - 1);
+    return std::is_lt(x <=> -bound) || std::is_gt(x <=> bound - big_int{1});
+}
+
+// Checks a `big_int` against a `_BitInt(bits)` holding the same value, over both ends of that
+// type's range, both ends of the band of values it is the narrowest of its object size for,
+// and a spread in between. Reports how many values were checked, which is none where the
+// implementation does not hash the type.
+template <std::size_t bits>
+[[nodiscard]] std::size_t check_width() {
+    using T = bit_int_of<bits>;
+    if constexpr (!detail::std_hashable<T>) {
+        return 0;
+    } else {
+        const std::hash<big_int> h{};
+
+        const big_int max    = (big_int{1} << (bits - 1)) - big_int{1};
+        const big_int min    = -max - big_int{1};
+        const big_int first  = rung_below(bits) == 0 ? big_int{0} : big_int{1} << (rung_below(bits) - 1);
+        const big_int middle = first + ((max - first) >> 1);
+        const big_int third  = max / big_int{3};
+
+        std::size_t checked = 0;
+        for (const big_int& x : {min,
+                                 min + big_int{1},
+                                 max,
+                                 max - big_int{1},
+                                 first,
+                                 first + big_int{1},
+                                 -first - big_int{1},
+                                 middle,
+                                 -middle - big_int{1},
+                                 third,
+                                 -third - big_int{1}}) {
+            // A candidate outside this width's range, or one a narrower rung already covers,
+            // says nothing about this width.
+            if (std::is_lt(x <=> min) || std::is_gt(x <=> max) || !needs_own_object_size(x, bits)) {
+                continue;
+            }
+            EXPECT_EQ(h(x), std::hash<T>{}(static_cast<T>(x))) << "width " << bits << " value " << x;
+            ++checked;
+        }
+        return checked;
+    }
+}
+
+// Every width from the narrowest signed `_BitInt` up to the widest rung, so that parity is
+// pinned across the board rather than only at the widths the ladder names.
+constexpr std::size_t swept_widths =
+    widest_rung_bits >= narrowest_bit_int_bits ? widest_rung_bits - narrowest_bit_int_bits + 1 : 0;
+
+// Reports how many of the swept widths contributed a check.
+template <std::size_t... i>
+[[nodiscard]] std::size_t check_every_width(std::index_sequence<i...>) {
+    std::size_t checked = 0;
+    ((checked += check_width<i + narrowest_bit_int_bits>() != 0 ? 1U : 0U), ...);
+    return checked;
+}
+
+TEST(Hash, MatchesBitPreciseHashAtEveryWidth) {
+    if constexpr (swept_widths == 0) {
+        GTEST_SKIP() << "this implementation hashes no _BitInt, so every value takes SipHash";
+    } else {
+        // Every width up to the widest rung must have been checked, not merely the rungs.
+        EXPECT_EQ(check_every_width(std::make_index_sequence<swept_widths>{}), swept_widths)
+            << "widest rung " << widest_rung_bits << " bits";
     }
 }
 

--- a/tests/beman/big_int/hash.test.cpp
+++ b/tests/beman/big_int/hash.test.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-License-Identifier: BSL-1.0
 
+#include <algorithm>
 #include <bit>
 #include <cstddef>
 #include <cstdint>
@@ -117,16 +118,61 @@ using namespace beman::big_int::literals;
     }
 }
 
-// Whether `x` is one of the values std::hash hands to the builtin std::int64_t hash.
-[[nodiscard]] bool fits_int64(const big_int& x) {
-    return x >= std::numeric_limits<std::int64_t>::min() && x <= std::numeric_limits<std::int64_t>::max();
+// ----- The ladder of builtin signed integer types std::hash defers to -----
+
+namespace detail = beman::big_int::detail;
+
+// The width of a rung, or zero where the target lacks the type or the implementation does
+// not hash it. `detail::absent_hash_rung` stands in for a type the target lacks.
+template <class T>
+[[nodiscard]] constexpr std::size_t rung_bits() {
+    if constexpr (detail::std_hashable<T>) {
+        return detail::width_v<T>;
+    } else {
+        return 0;
+    }
 }
 
-// Values that `std::int64_t` can represent take the digest of that `std::int64_t`;
-// everything else takes SipHash-2-4 over the trimmed bytes of the magnitude.
+constexpr std::size_t bits_128_rung    = rung_bits<detail::hash_rung_128>();
+constexpr std::size_t widest_rung_bits = detail::widest_hash_rung_bits;
+
+// Whether `T` can represent `x`, from value-level bounds rather than the round trip
+// through `T` that the implementation uses.
+template <class T>
+[[nodiscard]] bool representable(const big_int& x) {
+    if constexpr (!detail::std_hashable<T>) {
+        return false;
+    } else {
+        const big_int bound = big_int{1} << (detail::width_v<T> - 1);
+        return x >= -bound && x < bound;
+    }
+}
+
+template <class T>
+[[nodiscard]] bool expected_builtin_digest(const big_int& x, std::size_t& digest) {
+    if constexpr (detail::std_hashable<T>) {
+        if (representable<T>(x)) {
+            digest = std::hash<T>{}(static_cast<T>(x));
+            return true;
+        }
+    }
+    return false;
+}
+
+// The rungs are nested ranges, so the widest one decides which path a value takes.
+[[nodiscard]] bool takes_builtin_path(const big_int& x) {
+    const big_int bound = big_int{1} << (widest_rung_bits - 1);
+    return x >= -bound && x < bound;
+}
+
+// A value a builtin signed integer type can represent takes the digest of the narrowest
+// such type; everything else takes SipHash-2-4 over the trimmed bytes of the magnitude.
 [[nodiscard]] std::size_t expected_hash(const big_int& x) {
-    if (fits_int64(x)) {
-        return std::hash<std::int64_t>{}(static_cast<std::int64_t>(x));
+    std::size_t digest{};
+    if (expected_builtin_digest<std::int64_t>(x, digest) ||          //
+        expected_builtin_digest<detail::hash_rung_128>(x, digest) || //
+        expected_builtin_digest<detail::hash_rung_256>(x, digest)) {
+        return digest;
     }
     return fold_to_size_t(reference_siphash24(magnitude_bytes(x), x < 0));
 }
@@ -359,9 +405,10 @@ TEST(Hash, MatchesSipHash24OverTrimmedValueBytes) {
     // is given the value and those bytes, so it cannot observe the limb width either.
     const std::hash<big_int> h{};
 
-    // Every magnitude width up to 264 bits, so every limb and block boundary of both
-    // limb widths is crossed, together with its neighbours and its negation.
-    for (unsigned width = 0; width <= 264; ++width) {
+    // Every magnitude width up to 520 bits, so every limb and block boundary of both
+    // limb widths is crossed, along with every rung of the builtin ladder and the widths
+    // past its end, together with each width's neighbours and its negation.
+    for (unsigned width = 0; width <= 520; ++width) {
         const big_int power = width == 0 ? big_int{0} : (big_int{1} << (width - 1));
         for (const big_int& x : {power, power + big_int{1}, power - big_int{1}, -power}) {
             EXPECT_EQ(h(x), expected_hash(x)) << "width " << width;
@@ -387,29 +434,30 @@ TEST(Hash, MatchesPublishedSipHash24Vectors) {
     // The integer whose trimmed little-endian byte string is {0x00, 0x01, ..., k-1}
     // is exactly the k-byte input of the published SipHash-2-4 test vectors, under the
     // key detail::siphash uses. These digests are fixed by a reference outside this
-    // library, and so cannot follow the limb width. Lengths nine through sixteen are the
-    // shortest that carry a magnitude beyond the range of `std::int64_t`, so they take
-    // the SipHash path, and between them they cover every block and tail length.
+    // library, and so cannot follow the limb width. Lengths 33 through 40 are the
+    // shortest that exceed the widest rung of the builtin ladder, 256 bits, so they take
+    // the SipHash path on every target, and between them they cover every block and tail
+    // length.
     const std::hash<big_int> h{};
 
     static constexpr std::uint64_t digests[] = {
-        0x9e0082df0ba9e4b0ULL, // {0x00, 0x01, ..., 0x08}
-        0x7a5dbbc594ddb9f3ULL, // {0x00, 0x01, ..., 0x09}
-        0xf4b32f46226bada7ULL, // and so on up to
-        0x751e8fbc860ee5fbULL,
-        0x14ea5627c0843d90ULL,
-        0xf723ca908e7af2eeULL,
-        0xa129ca6149be45e5ULL,
-        0x3f2acc7f57c29bdbULL, // {0x00, 0x01, ..., 0x0F}
+        0xa7f32346f95978e3ULL, // {0x00, 0x01, ..., 0x20}
+        0x12e0b01abb051238ULL, // {0x00, 0x01, ..., 0x21}
+        0x15e034d40fa197aeULL, // and so on up to
+        0x314dffbe0815a3b4ULL,
+        0x027990f029623981ULL,
+        0xcadcd4e59ef40c4dULL,
+        0x9abfd8766a33735cULL,
+        0x0e3ea96b5304a7d0ULL, // {0x00, 0x01, ..., 0x27}
     };
 
-    for (std::size_t k = 9; k <= 16; ++k) {
+    for (std::size_t k = 33; k <= 40; ++k) {
         big_int x{0};
         for (std::size_t i = k; i-- > 0;) {
             x = (x << 8) + big_int{i};
         }
-        ASSERT_FALSE(fits_int64(x)) << "length " << k;
-        EXPECT_EQ(h(x), fold_to_size_t(digests[k - 9])) << "length " << k;
+        ASSERT_FALSE(takes_builtin_path(x)) << "length " << k;
+        EXPECT_EQ(h(x), fold_to_size_t(digests[k - 33])) << "length " << k;
     }
 
     // The digest of the magnitude alone is still the published vector for the shorter
@@ -490,20 +538,21 @@ TEST(Hash, MatchesBuiltinHashAcrossInplaceBits) {
     }
 }
 
-TEST(Hash, BuiltinPathEndsAtTheInt64Boundary) {
-    // The value just past each end of the range is hashed the other way, and must not
-    // collide with the boundary value it neighbours.
+TEST(Hash, BuiltinPathEndsAtTheWidestRung) {
+    // The value just past each end of the widest rung is hashed the other way, and must
+    // not collide with the boundary value it neighbours.
     const std::hash<big_int> h{};
 
-    const big_int max{std::numeric_limits<std::int64_t>::max()};
-    const big_int min{std::numeric_limits<std::int64_t>::min()};
+    const big_int bound    = big_int{1} << (widest_rung_bits - 1);
+    const big_int max      = bound - big_int{1};
+    const big_int min      = -bound;
     const big_int past_max = max + big_int{1};
     const big_int past_min = min - big_int{1};
 
-    ASSERT_TRUE(fits_int64(max));
-    ASSERT_TRUE(fits_int64(min));
-    ASSERT_FALSE(fits_int64(past_max));
-    ASSERT_FALSE(fits_int64(past_min));
+    ASSERT_TRUE(takes_builtin_path(max));
+    ASSERT_TRUE(takes_builtin_path(min));
+    ASSERT_FALSE(takes_builtin_path(past_max));
+    ASSERT_FALSE(takes_builtin_path(past_min));
 
     EXPECT_EQ(h(max), expected_hash(max));
     EXPECT_EQ(h(min), expected_hash(min));
@@ -513,13 +562,46 @@ TEST(Hash, BuiltinPathEndsAtTheInt64Boundary) {
     EXPECT_NE(h(max), h(past_max));
     EXPECT_NE(h(min), h(past_min));
     EXPECT_NE(h(past_max), h(past_min));
+}
 
-    // -2^63 is the one magnitude of full 64-bit width that stays on the builtin path;
-    // +2^63 has the same magnitude and must not follow it there.
-    const big_int negative_pow63 = min;
-    const big_int positive_pow63 = past_max;
-    EXPECT_EQ(h(negative_pow63), std::hash<std::int64_t>{}(std::numeric_limits<std::int64_t>::min()));
-    EXPECT_NE(h(positive_pow63), h(negative_pow63));
+// Checks the values that can only be represented by rung `T`, which is the rung above one
+// of `narrower_bits` bits. Does nothing where the target has no such rung.
+template <class T>
+[[nodiscard]] std::size_t check_rung(const std::size_t narrower_bits) {
+    std::size_t checked = 0;
+    if constexpr (detail::std_hashable<T>) {
+        constexpr std::size_t bits = detail::width_v<T>;
+        if (bits <= narrower_bits) {
+            return checked;
+        }
+
+        const std::hash<big_int> h{};
+
+        // The narrower rung stops at a magnitude of 2^(narrower_bits - 1), so these are
+        // the first values past it, and the last this rung reaches.
+        const big_int first_beyond = big_int{1} << (narrower_bits - 1);
+        const big_int largest      = (big_int{1} << (bits - 1)) - big_int{1};
+
+        for (const big_int& x :
+             {first_beyond, first_beyond + big_int{1}, largest, -largest - big_int{1}, -first_beyond - big_int{1}}) {
+            EXPECT_TRUE(takes_builtin_path(x)) << "bits " << bits;
+            EXPECT_EQ(h(x), std::hash<T>{}(static_cast<T>(x))) << "bits " << bits;
+            ++checked;
+        }
+    }
+    return checked;
+}
+
+TEST(Hash, MatchesBuiltinHashOnTheWiderRungs) {
+    if constexpr (widest_rung_bits <= 64) {
+        GTEST_SKIP() << "no integer type wider than 64 bits is hashable on this target";
+    } else {
+        std::size_t checked = check_rung<detail::hash_rung_128>(64);
+        checked += check_rung<detail::hash_rung_256>(bits_128_rung != 0 ? bits_128_rung : 64);
+
+        // A rung was reported wider than 64 bits, so something must have been checked.
+        EXPECT_GT(checked, 0U) << "widest rung " << widest_rung_bits << " bits";
+    }
 }
 
 // ----- Usability in standard unordered associative containers -----

--- a/tests/beman/big_int/hash.test.cpp
+++ b/tests/beman/big_int/hash.test.cpp
@@ -117,7 +117,17 @@ using namespace beman::big_int::literals;
     }
 }
 
+// Whether `x` is one of the values std::hash hands to the builtin std::int64_t hash.
+[[nodiscard]] bool fits_int64(const big_int& x) {
+    return x >= std::numeric_limits<std::int64_t>::min() && x <= std::numeric_limits<std::int64_t>::max();
+}
+
+// Values that `std::int64_t` can represent take the digest of that `std::int64_t`;
+// everything else takes SipHash-2-4 over the trimmed bytes of the magnitude.
 [[nodiscard]] std::size_t expected_hash(const big_int& x) {
+    if (fits_int64(x)) {
+        return std::hash<std::int64_t>{}(static_cast<std::int64_t>(x));
+    }
     return fold_to_size_t(reference_siphash24(magnitude_bytes(x), x < 0));
 }
 
@@ -343,9 +353,10 @@ TEST(Hash, CrossInplaceBitsForZero) {
 TEST(Hash, MatchesSipHash24OverTrimmedValueBytes) {
     // [big.int.hash] requires the hash to depend only on the integer value, which
     // includes not depending on the limb width. A single build cannot instantiate two
-    // limb widths, but it can check the property that makes them agree: the digest is
+    // limb widths, but it can check the properties that make them agree: a value in the
+    // range of `std::int64_t` is hashed as that `std::int64_t`, and everything else by
     // SipHash-2-4 over the trimmed little-endian bytes of the magnitude. The reference
-    // is given those bytes, so it cannot observe the limb width either.
+    // is given the value and those bytes, so it cannot observe the limb width either.
     const std::hash<big_int> h{};
 
     // Every magnitude width up to 264 bits, so every limb and block boundary of both
@@ -376,13 +387,36 @@ TEST(Hash, MatchesPublishedSipHash24Vectors) {
     // The integer whose trimmed little-endian byte string is {0x00, 0x01, ..., k-1}
     // is exactly the k-byte input of the published SipHash-2-4 test vectors, under the
     // key detail::siphash uses. These digests are fixed by a reference outside this
-    // library, and so cannot follow the limb width. Zero takes the length-0 vector;
-    // there is no length-1 case, because {0x00} is not a trimmed byte string.
+    // library, and so cannot follow the limb width. Lengths nine through sixteen are the
+    // shortest that carry a magnitude beyond the range of `std::int64_t`, so they take
+    // the SipHash path, and between them they cover every block and tail length.
     const std::hash<big_int> h{};
 
-    EXPECT_EQ(h(big_int{0}), fold_to_size_t(0x726fdb47dd0e0e31ULL));
-
     static constexpr std::uint64_t digests[] = {
+        0x9e0082df0ba9e4b0ULL, // {0x00, 0x01, ..., 0x08}
+        0x7a5dbbc594ddb9f3ULL, // {0x00, 0x01, ..., 0x09}
+        0xf4b32f46226bada7ULL, // and so on up to
+        0x751e8fbc860ee5fbULL,
+        0x14ea5627c0843d90ULL,
+        0xf723ca908e7af2eeULL,
+        0xa129ca6149be45e5ULL,
+        0x3f2acc7f57c29bdbULL, // {0x00, 0x01, ..., 0x0F}
+    };
+
+    for (std::size_t k = 9; k <= 16; ++k) {
+        big_int x{0};
+        for (std::size_t i = k; i-- > 0;) {
+            x = (x << 8) + big_int{i};
+        }
+        ASSERT_FALSE(fits_int64(x)) << "length " << k;
+        EXPECT_EQ(h(x), fold_to_size_t(digests[k - 9])) << "length " << k;
+    }
+
+    // The digest of the magnitude alone is still the published vector for the shorter
+    // inputs, even where std::hash now answers from the builtin instead. Zero takes the
+    // length-0 vector; there is no length-1 case, because {0x00} is not trimmed.
+    static constexpr std::uint64_t short_digests[] = {
+        0x726fdb47dd0e0e31ULL, // {}
         0x0d6c8009d9a94f5aULL, // {0x00, 0x01}
         0x85676696d7fb7e2dULL, // {0x00, 0x01, 0x02}
         0xcf2794e0277187b7ULL, // and so on up to
@@ -392,13 +426,94 @@ TEST(Hash, MatchesPublishedSipHash24Vectors) {
         0x93f5f5799a932462ULL, // {0x00, 0x01, ..., 0x07}
     };
 
+    EXPECT_EQ(beman::big_int::detail::siphash(big_int{0}.representation(), false), fold_to_size_t(short_digests[0]));
+
     for (std::size_t k = 2; k <= 8; ++k) {
         big_int x{0};
         for (std::size_t i = k; i-- > 0;) {
             x = (x << 8) + big_int{i};
         }
-        EXPECT_EQ(h(x), fold_to_size_t(digests[k - 2])) << "length " << k;
+        EXPECT_EQ(beman::big_int::detail::siphash(x.representation(), false), fold_to_size_t(short_digests[k - 1]))
+            << "length " << k;
     }
+}
+
+// ----- Values in the range of std::int64_t hash as the builtin does -----
+
+TEST(Hash, MatchesBuiltinHashInInt64Range) {
+    // A `big_int` and an `std::int64_t` of the same value must agree, so that a program
+    // can hash the two interchangeably.
+    const std::hash<big_int>      h{};
+    const std::hash<std::int64_t> builtin{};
+
+    constexpr std::int64_t min = std::numeric_limits<std::int64_t>::min();
+    constexpr std::int64_t max = std::numeric_limits<std::int64_t>::max();
+
+    for (const std::int64_t v :
+         {min, min + 1, min / 2, -4294967296LL, -1LL, 0LL, 1LL, 4294967295LL, 4294967296LL, max / 2, max - 1, max}) {
+        EXPECT_EQ(h(big_int{v}), builtin(v)) << "value " << v;
+    }
+
+    for (std::int64_t v = -300; v <= 300; ++v) {
+        EXPECT_EQ(h(big_int{v}), builtin(v)) << "value " << v;
+    }
+
+    // Every power of two in range, and its neighbours, so both sides of each limb and
+    // byte boundary of the builtin path are covered.
+    for (int bit = 0; bit < 63; ++bit) {
+        const std::int64_t power = std::int64_t{1} << bit;
+        for (const std::int64_t v : {power, power - 1, -power, -power + 1}) {
+            EXPECT_EQ(h(big_int{v}), builtin(v)) << "value " << v;
+        }
+    }
+}
+
+TEST(Hash, MatchesBuiltinHashAcrossInplaceBits) {
+    // The builtin path is taken on the value, not on where the value is stored, so a
+    // value that is in place for one parameterization and heap-allocated for another
+    // still lands on the builtin digest.
+    constexpr std::int64_t min = std::numeric_limits<std::int64_t>::min();
+    constexpr std::int64_t max = std::numeric_limits<std::int64_t>::max();
+
+    for (const std::int64_t v : {min, -1LL, 0LL, 42LL, max}) {
+        const std::size_t expected = std::hash<std::int64_t>{}(v);
+        EXPECT_EQ(std::hash<basic_big_int<32>>{}(basic_big_int<32>{v}), expected) << "value " << v;
+        EXPECT_EQ(std::hash<basic_big_int<64>>{}(basic_big_int<64>{v}), expected) << "value " << v;
+        EXPECT_EQ(std::hash<basic_big_int<256>>{}(basic_big_int<256>{v}), expected) << "value " << v;
+        EXPECT_EQ(std::hash<basic_big_int<1024>>{}(basic_big_int<1024>{v}), expected) << "value " << v;
+    }
+}
+
+TEST(Hash, BuiltinPathEndsAtTheInt64Boundary) {
+    // The value just past each end of the range is hashed the other way, and must not
+    // collide with the boundary value it neighbours.
+    const std::hash<big_int> h{};
+
+    const big_int max{std::numeric_limits<std::int64_t>::max()};
+    const big_int min{std::numeric_limits<std::int64_t>::min()};
+    const big_int past_max = max + big_int{1};
+    const big_int past_min = min - big_int{1};
+
+    ASSERT_TRUE(fits_int64(max));
+    ASSERT_TRUE(fits_int64(min));
+    ASSERT_FALSE(fits_int64(past_max));
+    ASSERT_FALSE(fits_int64(past_min));
+
+    EXPECT_EQ(h(max), expected_hash(max));
+    EXPECT_EQ(h(min), expected_hash(min));
+    EXPECT_EQ(h(past_max), expected_hash(past_max));
+    EXPECT_EQ(h(past_min), expected_hash(past_min));
+
+    EXPECT_NE(h(max), h(past_max));
+    EXPECT_NE(h(min), h(past_min));
+    EXPECT_NE(h(past_max), h(past_min));
+
+    // -2^63 is the one magnitude of full 64-bit width that stays on the builtin path;
+    // +2^63 has the same magnitude and must not follow it there.
+    const big_int negative_pow63 = min;
+    const big_int positive_pow63 = past_max;
+    EXPECT_EQ(h(negative_pow63), std::hash<std::int64_t>{}(std::numeric_limits<std::int64_t>::min()));
+    EXPECT_NE(h(positive_pow63), h(negative_pow63));
 }
 
 // ----- Usability in standard unordered associative containers -----

--- a/tests/beman/big_int/hash.test.cpp
+++ b/tests/beman/big_int/hash.test.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <bit>
+#include <compare>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -118,7 +119,7 @@ using namespace beman::big_int::literals;
     }
 }
 
-// ----- The ladder of builtin signed integer types std::hash defers to -----
+// ----- The ladder of signed `_BitInt` types std::hash defers to -----
 
 namespace detail = beman::big_int::detail;
 
@@ -144,7 +145,7 @@ template <class T>
         return false;
     } else {
         const big_int bound = big_int{1} << (detail::width_v<T> - 1);
-        return x >= -bound && x < bound;
+        return std::is_gteq(x <=> -bound) && std::is_lt(x <=> bound);
     }
 }
 
@@ -159,22 +160,29 @@ template <class T>
     return false;
 }
 
-// The rungs are nested ranges, so the widest one decides which path a value takes.
+// The rungs are nested ranges, so the widest one decides which path a value takes. Where
+// the implementation hashes no `_BitInt` at all, every value takes SipHash.
 [[nodiscard]] bool takes_builtin_path(const big_int& x) {
-    const big_int bound = big_int{1} << (widest_rung_bits - 1);
-    return x >= -bound && x < bound;
+    if constexpr (widest_rung_bits == 0) {
+        return false;
+    } else {
+        const big_int bound = big_int{1} << (widest_rung_bits - 1);
+        return std::is_gteq(x <=> -bound) && std::is_lt(x <=> bound);
+    }
 }
 
-// A value a builtin signed integer type can represent takes the digest of the narrowest
-// such type; everything else takes SipHash-2-4 over the trimmed bytes of the magnitude.
+// A value takes the digest of the narrowest signed `_BitInt` that can represent it, where
+// the implementation hashes that type; everything else takes SipHash-2-4 over the trimmed
+// bytes of the magnitude.
 [[nodiscard]] std::size_t expected_hash(const big_int& x) {
     std::size_t digest{};
-    if (expected_builtin_digest<std::int64_t>(x, digest) ||          //
+    if (expected_builtin_digest<detail::hash_rung_64>(x, digest) ||  //
         expected_builtin_digest<detail::hash_rung_128>(x, digest) || //
+        expected_builtin_digest<detail::hash_rung_192>(x, digest) || //
         expected_builtin_digest<detail::hash_rung_256>(x, digest)) {
         return digest;
     }
-    return fold_to_size_t(reference_siphash24(magnitude_bytes(x), x < 0));
+    return fold_to_size_t(reference_siphash24(magnitude_bytes(x), std::is_lt(x <=> 0)));
 }
 
 // ----- Type-level checks for the std::hash specialization -----
@@ -488,84 +496,128 @@ TEST(Hash, MatchesPublishedSipHash24Vectors) {
 
 // ----- Values in the range of std::int64_t hash as the builtin does -----
 
-TEST(Hash, MatchesBuiltinHashInInt64Range) {
-    // A `big_int` and an `std::int64_t` of the same value must agree, so that a program
-    // can hash the two interchangeably.
-    const std::hash<big_int>      h{};
-    const std::hash<std::int64_t> builtin{};
+// The values used to sweep the narrowest rung. A typed array rather than a braced list:
+// `std::int64_t` is `long` on some targets and `long long` on others, so a list of
+// literals has no one deduced type.
+constexpr std::int64_t int64_min = std::numeric_limits<std::int64_t>::min();
+constexpr std::int64_t int64_max = std::numeric_limits<std::int64_t>::max();
 
-    constexpr std::int64_t min = std::numeric_limits<std::int64_t>::min();
-    constexpr std::int64_t max = std::numeric_limits<std::int64_t>::max();
+static constexpr std::int64_t sweep_values[]{int64_min,
+                                             int64_min + 1,
+                                             int64_min / 2,
+                                             -4294967296,
+                                             -1,
+                                             0,
+                                             1,
+                                             4294967295,
+                                             4294967296,
+                                             int64_max / 2,
+                                             int64_max - 1,
+                                             int64_max};
 
-    // A typed array rather than a braced list: `std::int64_t` is `long` on some targets
-    // and `long long` on others, so a list of literals has no one deduced type.
-    static constexpr std::int64_t values[]{
-        min, min + 1, min / 2, -4294967296, -1, 0, 1, 4294967295, 4294967296, max / 2, max - 1, max};
+TEST(Hash, MatchesBitPreciseHashInTheNarrowestRung) {
+    if constexpr (!detail::std_hashable<detail::hash_rung_64>) {
+        GTEST_SKIP() << "this implementation does not hash a 64-bit _BitInt";
+    } else {
+        // A `big_int` and a `_BitInt(64)` of the same value must agree, so that a program
+        // can hash the two interchangeably.
+        using rung = detail::hash_rung_64;
+        const std::hash<big_int> h{};
+        const std::hash<rung>    builtin{};
 
-    for (const std::int64_t v : values) {
-        EXPECT_EQ(h(big_int{v}), builtin(v)) << "value " << v;
-    }
+        for (const std::int64_t v : sweep_values) {
+            EXPECT_EQ(h(big_int{v}), builtin(static_cast<rung>(v))) << "value " << v;
+        }
 
-    for (std::int64_t v = -300; v <= 300; ++v) {
-        EXPECT_EQ(h(big_int{v}), builtin(v)) << "value " << v;
-    }
+        for (std::int64_t v = -300; v <= 300; ++v) {
+            EXPECT_EQ(h(big_int{v}), builtin(static_cast<rung>(v))) << "value " << v;
+        }
 
-    // Every power of two in range, and its neighbours, so both sides of each limb and
-    // byte boundary of the builtin path are covered.
-    for (int bit = 0; bit < 63; ++bit) {
-        const std::int64_t power = std::int64_t{1} << bit;
-        for (const std::int64_t v : {power, power - 1, -power, -power + 1}) {
-            EXPECT_EQ(h(big_int{v}), builtin(v)) << "value " << v;
+        // Every power of two in range, and its neighbours, so both sides of each limb and
+        // byte boundary of the rung are covered.
+        for (int bit = 0; bit < 63; ++bit) {
+            const std::int64_t power = std::int64_t{1} << bit;
+            for (const std::int64_t v : {power, power - 1, -power, -power + 1}) {
+                EXPECT_EQ(h(big_int{v}), builtin(static_cast<rung>(v))) << "value " << v;
+            }
         }
     }
 }
 
-TEST(Hash, MatchesBuiltinHashAcrossInplaceBits) {
-    // The builtin path is taken on the value, not on where the value is stored, so a
-    // value that is in place for one parameterization and heap-allocated for another
-    // still lands on the builtin digest.
-    constexpr std::int64_t min = std::numeric_limits<std::int64_t>::min();
-    constexpr std::int64_t max = std::numeric_limits<std::int64_t>::max();
+TEST(Hash, AgreesWithInt64WhereTheTwoBuiltinDigestsAgree) {
+    // The narrowest rung and `std::int64_t` hold the same values, so wherever the
+    // implementation gives the two the same digest, which libc++ does since it hashes a
+    // scalar by its object representation, a `big_int` agrees with `std::int64_t` as well.
+    // Nothing to check where the implementation makes them differ, or hashes no `_BitInt`.
+    if constexpr (!detail::std_hashable<detail::hash_rung_64>) {
+        GTEST_SKIP() << "this implementation does not hash a 64-bit _BitInt";
+    } else {
+        using rung = detail::hash_rung_64;
+        if (std::hash<rung>{}(rung{42}) != std::hash<std::int64_t>{}(42)) {
+            GTEST_SKIP() << "this implementation hashes _BitInt(64) and std::int64_t differently";
+        }
 
-    static constexpr std::int64_t values[]{min, -1, 0, 42, max};
-
-    for (const std::int64_t v : values) {
-        const std::size_t expected = std::hash<std::int64_t>{}(v);
-        EXPECT_EQ(std::hash<basic_big_int<32>>{}(basic_big_int<32>{v}), expected) << "value " << v;
-        EXPECT_EQ(std::hash<basic_big_int<64>>{}(basic_big_int<64>{v}), expected) << "value " << v;
-        EXPECT_EQ(std::hash<basic_big_int<256>>{}(basic_big_int<256>{v}), expected) << "value " << v;
-        EXPECT_EQ(std::hash<basic_big_int<1024>>{}(basic_big_int<1024>{v}), expected) << "value " << v;
+        const std::hash<big_int> h{};
+        for (const std::int64_t v : sweep_values) {
+            EXPECT_EQ(h(big_int{v}), std::hash<std::int64_t>{}(v)) << "value " << v;
+        }
     }
 }
 
-TEST(Hash, BuiltinPathEndsAtTheWidestRung) {
-    // The value just past each end of the widest rung is hashed the other way, and must
-    // not collide with the boundary value it neighbours.
-    const std::hash<big_int> h{};
+TEST(Hash, MatchesBitPreciseHashAcrossInplaceBits) {
+    // The rung is chosen on the value, not on where the value is stored, so a value that
+    // is in place for one parameterization and heap-allocated for another still lands on
+    // the same digest.
+    if constexpr (!detail::std_hashable<detail::hash_rung_64>) {
+        GTEST_SKIP() << "this implementation does not hash a 64-bit _BitInt";
+    } else {
+        using rung = detail::hash_rung_64;
 
-    const big_int bound    = big_int{1} << (widest_rung_bits - 1);
-    const big_int max      = bound - big_int{1};
-    const big_int min      = -bound;
-    const big_int past_max = max + big_int{1};
-    const big_int past_min = min - big_int{1};
+        static constexpr std::int64_t values[]{int64_min, -1, 0, 42, int64_max};
 
-    ASSERT_TRUE(takes_builtin_path(max));
-    ASSERT_TRUE(takes_builtin_path(min));
-    ASSERT_FALSE(takes_builtin_path(past_max));
-    ASSERT_FALSE(takes_builtin_path(past_min));
-
-    EXPECT_EQ(h(max), expected_hash(max));
-    EXPECT_EQ(h(min), expected_hash(min));
-    EXPECT_EQ(h(past_max), expected_hash(past_max));
-    EXPECT_EQ(h(past_min), expected_hash(past_min));
-
-    EXPECT_NE(h(max), h(past_max));
-    EXPECT_NE(h(min), h(past_min));
-    EXPECT_NE(h(past_max), h(past_min));
+        for (const std::int64_t v : values) {
+            const std::size_t expected = std::hash<rung>{}(static_cast<rung>(v));
+            EXPECT_EQ(std::hash<basic_big_int<32>>{}(basic_big_int<32>{v}), expected) << "value " << v;
+            EXPECT_EQ(std::hash<basic_big_int<64>>{}(basic_big_int<64>{v}), expected) << "value " << v;
+            EXPECT_EQ(std::hash<basic_big_int<256>>{}(basic_big_int<256>{v}), expected) << "value " << v;
+            EXPECT_EQ(std::hash<basic_big_int<1024>>{}(basic_big_int<1024>{v}), expected) << "value " << v;
+        }
+    }
 }
 
-// Checks the values that can only be represented by rung `T`, which is the rung above one
-// of `narrower_bits` bits. Does nothing where the target has no such rung.
+TEST(Hash, BitPrecisePathEndsAtTheWidestRung) {
+    // The value just past each end of the widest rung is hashed the other way, and must
+    // not collide with the boundary value it neighbours.
+    if constexpr (widest_rung_bits == 0) {
+        GTEST_SKIP() << "this implementation hashes no _BitInt, so every value takes SipHash";
+    } else {
+        const std::hash<big_int> h{};
+
+        const big_int bound    = big_int{1} << (widest_rung_bits - 1);
+        const big_int max      = bound - big_int{1};
+        const big_int min      = -bound;
+        const big_int past_max = max + big_int{1};
+        const big_int past_min = min - big_int{1};
+
+        ASSERT_TRUE(takes_builtin_path(max));
+        ASSERT_TRUE(takes_builtin_path(min));
+        ASSERT_FALSE(takes_builtin_path(past_max));
+        ASSERT_FALSE(takes_builtin_path(past_min));
+
+        EXPECT_EQ(h(max), expected_hash(max));
+        EXPECT_EQ(h(min), expected_hash(min));
+        EXPECT_EQ(h(past_max), expected_hash(past_max));
+        EXPECT_EQ(h(past_min), expected_hash(past_min));
+
+        EXPECT_NE(h(max), h(past_max));
+        EXPECT_NE(h(min), h(past_min));
+        EXPECT_NE(h(past_max), h(past_min));
+    }
+}
+
+// Checks the values that only rung `T` can represent, `T` being the rung above one of
+// `narrower_bits` bits, or the narrowest rung where that is zero. Does nothing where the
+// implementation does not hash `T`.
 template <class T>
 [[nodiscard]] std::size_t check_rung(const std::size_t narrower_bits) {
     std::size_t checked = 0;
@@ -578,8 +630,9 @@ template <class T>
         const std::hash<big_int> h{};
 
         // The narrower rung stops at a magnitude of 2^(narrower_bits - 1), so these are
-        // the first values past it, and the last this rung reaches.
-        const big_int first_beyond = big_int{1} << (narrower_bits - 1);
+        // the first values past it, and the last this rung reaches. With no narrower rung
+        // the sweep starts at one.
+        const big_int first_beyond = narrower_bits == 0 ? big_int{1} : big_int{1} << (narrower_bits - 1);
         const big_int largest      = (big_int{1} << (bits - 1)) - big_int{1};
 
         for (const big_int& x :
@@ -592,14 +645,24 @@ template <class T>
     return checked;
 }
 
-TEST(Hash, MatchesBuiltinHashOnTheWiderRungs) {
-    if constexpr (widest_rung_bits <= 64) {
-        GTEST_SKIP() << "no integer type wider than 64 bits is hashable on this target";
+TEST(Hash, MatchesBitPreciseHashOnEveryRung) {
+    if constexpr (widest_rung_bits == 0) {
+        GTEST_SKIP() << "this implementation hashes no _BitInt, so every value takes SipHash";
     } else {
-        std::size_t checked = check_rung<detail::hash_rung_128>(64);
-        checked += check_rung<detail::hash_rung_256>(bits_128_rung != 0 ? bits_128_rung : 64);
+        // Each rung is checked against the widest rung narrower than it, skipping the ones
+        // this implementation does not hash.
+        constexpr std::size_t bits_64_rung  = rung_bits<detail::hash_rung_64>();
+        constexpr std::size_t bits_192_rung = rung_bits<detail::hash_rung_192>();
+        constexpr std::size_t below_128     = bits_64_rung;
+        constexpr std::size_t below_192     = bits_128_rung != 0 ? bits_128_rung : below_128;
+        constexpr std::size_t below_256     = bits_192_rung != 0 ? bits_192_rung : below_192;
 
-        // A rung was reported wider than 64 bits, so something must have been checked.
+        std::size_t checked = check_rung<detail::hash_rung_64>(0);
+        checked += check_rung<detail::hash_rung_128>(below_128);
+        checked += check_rung<detail::hash_rung_192>(below_192);
+        checked += check_rung<detail::hash_rung_256>(below_256);
+
+        // A rung was reported, so something must have been checked.
         EXPECT_GT(checked, 0U) << "widest rung " << widest_rung_bits << " bits";
     }
 }

--- a/tests/beman/big_int/hash.test.cpp
+++ b/tests/beman/big_int/hash.test.cpp
@@ -449,8 +449,12 @@ TEST(Hash, MatchesBuiltinHashInInt64Range) {
     constexpr std::int64_t min = std::numeric_limits<std::int64_t>::min();
     constexpr std::int64_t max = std::numeric_limits<std::int64_t>::max();
 
-    for (const std::int64_t v :
-         {min, min + 1, min / 2, -4294967296LL, -1LL, 0LL, 1LL, 4294967295LL, 4294967296LL, max / 2, max - 1, max}) {
+    // A typed array rather than a braced list: `std::int64_t` is `long` on some targets
+    // and `long long` on others, so a list of literals has no one deduced type.
+    static constexpr std::int64_t values[]{
+        min, min + 1, min / 2, -4294967296, -1, 0, 1, 4294967295, 4294967296, max / 2, max - 1, max};
+
+    for (const std::int64_t v : values) {
         EXPECT_EQ(h(big_int{v}), builtin(v)) << "value " << v;
     }
 
@@ -475,7 +479,9 @@ TEST(Hash, MatchesBuiltinHashAcrossInplaceBits) {
     constexpr std::int64_t min = std::numeric_limits<std::int64_t>::min();
     constexpr std::int64_t max = std::numeric_limits<std::int64_t>::max();
 
-    for (const std::int64_t v : {min, -1LL, 0LL, 42LL, max}) {
+    static constexpr std::int64_t values[]{min, -1, 0, 42, max};
+
+    for (const std::int64_t v : values) {
         const std::size_t expected = std::hash<std::int64_t>{}(v);
         EXPECT_EQ(std::hash<basic_big_int<32>>{}(basic_big_int<32>{v}), expected) << "value " << v;
         EXPECT_EQ(std::hash<basic_big_int<64>>{}(basic_big_int<64>{v}), expected) << "value " << v;

--- a/tests/beman/big_int/pmr.test.cpp
+++ b/tests/beman/big_int/pmr.test.cpp
@@ -653,7 +653,7 @@ TEST(Pmr, HashEqualsAcrossResources) {
 }
 
 TEST(Pmr, HashEqualsBetweenPmrAndNonPmr) {
-    // The hash is computed over the limb span and sign bit, so a pmr value
+    // The hash is computed over the value alone, so a pmr value
     // and a non-pmr value that hold the same number must hash identically
     // (modulo the allocator type parameter on the std::hash<...> instantiation).
     const big_int     non_pmr{0xDEAD'BEEFU};


### PR DESCRIPTION
I think we've questioned whether or not to do this a few times. I think this follows since if we have two values that compare equal, their hashes will also compare equal. I'll label it as a question; I just happened to be thinking about it again because of our earlier hash related issue.
