### PR TITLE
Make assignment strong against a throwing allocation

### DIFF
--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -725,12 +725,10 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
 
         // Slow path: current buffer is too small. Each branch releases our buffer
         // with our current allocator, before any propagation, and publishes the
-        // control words only once the storage they describe is in place. We may
-        // also be able to adopt src's buffer if the allocators are compatible.
+        // control words only once the storage they describe is in place.
         if (src.is_representation_inplace() && needed <= inplace_capacity) {
-            // Both src and the requested headroom fit inline. Reaching here needs a
-            // heap buffer smaller than the inline one, which nothing produces, so
-            // there is nothing to release; just propagate (if applicable) and copy.
+            // Both src and the requested headroom fit inline. No buffer to
+            // adopt or allocate; just propagate (if applicable) and copy limbs.
             if constexpr (propagate_alloc) {
                 m_alloc = std::forward<Src>(src).m_alloc;
             }
@@ -772,10 +770,9 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
         }
 
         // Fall back to a fresh allocation of `needed` limbs. Secure it before
-        // releasing our own buffer, so a throwing allocation leaves `*this`
-        // unchanged. When the allocator propagates, the new block has to come
-        // from `src`'s allocator while the old block still has to be released
-        // with ours, so allocate through a copy of `src`'s.
+        // releasing ours, so a throwing allocation leaves `*this` unchanged. A
+        // propagating allocator has to serve the new block while ours still has to
+        // release the old, so allocate through a copy of `src`'s.
         const alloc_result allocation = [&] {
             if constexpr (propagate_alloc) {
                 allocator_type src_alloc(src.m_alloc);

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -576,12 +576,13 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
     template <detail::cv_unqualified_floating_point F>
     constexpr void assign_from_float(F value) noexcept;
 
-    [[nodiscard]] constexpr alloc_result alloc_limbs(size_type n);
-    constexpr void                       free_limbs(pointer p, size_type n);
-    constexpr void                       free_storage();
-    constexpr void                       grow(size_type limbs_needed);
-    constexpr void                       copy_n_to_allocation(const limb_type* p, size_type n, alloc_result out);
-    constexpr void                       push_back_limb(limb_type limb);
+    [[nodiscard]] static constexpr alloc_result alloc_limbs_from(allocator_type& a, size_type n);
+    [[nodiscard]] constexpr alloc_result        alloc_limbs(size_type n);
+    constexpr void                              free_limbs(pointer p, size_type n);
+    constexpr void                              free_storage();
+    constexpr void                              grow(size_type limbs_needed);
+    constexpr void copy_n_to_allocation(const limb_type* p, size_type n, alloc_result out);
+    constexpr void push_back_limb(limb_type limb);
 
     // We are limited in our shifting to what we can encode into our control block, which is 30 (or 27) bits of limbs
     // Our max shift is then the number of bits represented in these blocks plus the theoretical 63 (or 31)
@@ -722,20 +723,19 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
             return;
         }
 
-        // Slow path: current buffer is too small.
-        // Release it (with our current allocator, before any propagation) and
-        // get a new allocation. We may also be able to adopt src's buffer if
-        // the allocators are compatible (stateless, propagating, or just equal).
-        free_storage();
-        m_size_and_sign = src.m_size_and_sign;
-
+        // Slow path: current buffer is too small. Each branch releases our buffer
+        // with our current allocator, before any propagation, and publishes the
+        // control words only once the storage they describe is in place. We may
+        // also be able to adopt src's buffer if the allocators are compatible.
         if (src.is_representation_inplace() && needed <= inplace_capacity) {
+            free_storage();
             // Both src and the requested headroom fit inline. No buffer to
             // adopt or allocate; just propagate (if applicable) and copy limbs.
             if constexpr (propagate_alloc) {
                 m_alloc = std::forward<Src>(src).m_alloc;
             }
-            m_capacity = 0;
+            m_capacity      = 0;
+            m_size_and_sign = src.m_size_and_sign;
             for (std::size_t i = 0; i < inplace_capacity; ++i) {
                 m_storage.limbs[i] = src.m_storage.limbs[i];
             }
@@ -749,11 +749,13 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
             // allocators compare equal at runtime.
             if (!src.is_representation_inplace()) {
                 if constexpr (propagate_alloc || alloc_traits::is_always_equal::value) {
+                    free_storage();
                     if constexpr (propagate_alloc) {
                         m_alloc = std::forward<Src>(src).m_alloc;
                     }
                     m_capacity             = src.m_capacity;
                     m_storage.data         = src.m_storage.data;
+                    m_size_and_sign        = src.m_size_and_sign;
                     src.m_capacity         = 0;
                     src.m_size_and_sign    = 1;
                     src.m_storage.limbs[0] = limb_type{0};
@@ -769,15 +771,28 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
             // allocate-and-copy path below.
         }
 
+        // Fall back to a fresh allocation of `needed` limbs. Secure it before
+        // releasing our own buffer, so a throwing allocation leaves `*this`
+        // unchanged. When the allocator propagates, the new block has to come
+        // from `src`'s allocator while the old block still has to be released
+        // with ours, so allocate through a copy of `src`'s.
+        const alloc_result allocation = [&] {
+            if constexpr (propagate_alloc) {
+                allocator_type src_alloc(src.m_alloc);
+                return alloc_limbs_from(src_alloc, needed);
+            } else {
+                return alloc_limbs(needed);
+            }
+        }();
+        copy_n_to_allocation(src.limb_ptr(), src_count, allocation);
+
+        free_storage();
         if constexpr (propagate_alloc) {
             m_alloc = std::forward<Src>(src).m_alloc;
         }
-
-        // Fall back to a fresh allocation of `needed` limbs.
-        const alloc_result allocation = alloc_limbs(needed);
-        copy_n_to_allocation(src.limb_ptr(), src_count, allocation);
-        m_capacity     = static_cast<std::uint32_t>(allocation.count);
-        m_storage.data = allocation.ptr;
+        m_capacity      = static_cast<std::uint32_t>(allocation.count);
+        m_storage.data  = allocation.ptr;
+        m_size_and_sign = src.m_size_and_sign;
     }
 
     // Efficiently performs `*this |= bits << offset`, as if `bits` was wrapped in `basic_big_int`.
@@ -3293,17 +3308,22 @@ constexpr void basic_big_int<b, L, A>::assign_from_float(const F value) noexcept
 }
 
 template <std::size_t b, class L, class A>
-constexpr auto basic_big_int<b, L, A>::alloc_limbs(const size_type n) -> alloc_result {
+constexpr auto basic_big_int<b, L, A>::alloc_limbs_from(allocator_type& a, const size_type n) -> alloc_result {
     BEMAN_BIG_INT_ASSERT(n != 0);
 #if defined(__cpp_lib_allocate_at_least) && __cpp_lib_allocate_at_least >= 202302L
     if constexpr (detail::traits_has_allocate_at_least<alloc_traits, A>) {
-        return alloc_traits::allocate_at_least(m_alloc, n);
+        return alloc_traits::allocate_at_least(a, n);
     } else {
-        return {.ptr = alloc_traits::allocate(m_alloc, n), .count = n};
+        return {.ptr = alloc_traits::allocate(a, n), .count = n};
     }
 #else
-    return {.ptr = alloc_traits::allocate(m_alloc, n), .count = n};
+    return {.ptr = alloc_traits::allocate(a, n), .count = n};
 #endif
+}
+
+template <std::size_t b, class L, class A>
+constexpr auto basic_big_int<b, L, A>::alloc_limbs(const size_type n) -> alloc_result {
+    return alloc_limbs_from(m_alloc, n);
 }
 
 template <std::size_t b, class L, class A>

--- a/include/beman/big_int/big_int.hpp
+++ b/include/beman/big_int/big_int.hpp
@@ -728,9 +728,9 @@ class BEMAN_BIG_INT_TRIVIAL_ABI basic_big_int {
         // control words only once the storage they describe is in place. We may
         // also be able to adopt src's buffer if the allocators are compatible.
         if (src.is_representation_inplace() && needed <= inplace_capacity) {
-            free_storage();
-            // Both src and the requested headroom fit inline. No buffer to
-            // adopt or allocate; just propagate (if applicable) and copy limbs.
+            // Both src and the requested headroom fit inline. Reaching here needs a
+            // heap buffer smaller than the inline one, which nothing produces, so
+            // there is nothing to release; just propagate (if applicable) and copy.
             if constexpr (propagate_alloc) {
                 m_alloc = std::forward<Src>(src).m_alloc;
             }

--- a/tests/beman/big_int/allocation.test.cpp
+++ b/tests/beman/big_int/allocation.test.cpp
@@ -1,6 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // SPDX-License-Identifier: BSL-1.0
 
+#include <cstddef>
+#include <memory>
+#include <new>
+#include <type_traits>
+#include <utility>
+
 #include <beman/big_int.hpp>
 #include <gtest/gtest.h>
 
@@ -195,6 +201,83 @@ consteval bool test_reserve_representation_preserves_value() {
 static_assert(test_reserve_representation_preserves_value());
 
 // ----- runtime tests -----
+
+// A stateful allocator that propagates on copy and move assignment. Because it
+// holds state it is not always-equal, so a growing assignment cannot reuse or
+// steal the source's buffer and has to allocate. `id` lets the test observe
+// which allocator ends up owning the destination, and `fail` arms a throw.
+// Two words wide, so the owning basic_big_int has no trailing padding.
+template <class T>
+struct pocca_alloc {
+    using value_type                             = T;
+    using propagate_on_container_copy_assignment = std::true_type;
+    using propagate_on_container_move_assignment = std::true_type;
+
+    std::size_t id   = 0;
+    bool*       fail = nullptr;
+
+    pocca_alloc() = default;
+    explicit pocca_alloc(std::size_t allocator_id, bool* fail_flag = nullptr) noexcept
+        : id{allocator_id}, fail{fail_flag} {}
+    template <class U>
+    pocca_alloc(const pocca_alloc<U>& other) noexcept : id{other.id}, fail{other.fail} {}
+
+    [[nodiscard]] T* allocate(std::size_t n) {
+        if (fail != nullptr && *fail) {
+            throw std::bad_alloc{};
+        }
+        return std::allocator<T>{}.allocate(n);
+    }
+    void deallocate(T* p, std::size_t n) noexcept { std::allocator<T>{}.deallocate(p, n); }
+
+    template <class U>
+    bool operator==(const pocca_alloc<U>& other) const noexcept {
+        return id == other.id;
+    }
+};
+
+using pocca_big_int = beman::big_int::
+    basic_big_int<64, beman::big_int::uint_multiprecision_t, pocca_alloc<beman::big_int::uint_multiprecision_t>>;
+
+TEST(Allocation, PropagatingAssignmentAllocatesThroughSourceAllocator) {
+    pocca_big_int dst{7, pocca_alloc<beman::big_int::uint_multiprecision_t>{1U}};
+    pocca_big_int src{1, pocca_alloc<beman::big_int::uint_multiprecision_t>{2U}};
+    src <<= 4000;
+
+    dst = src;
+
+    EXPECT_EQ(dst, src);
+    EXPECT_EQ(dst.get_allocator().id, 2U);
+}
+
+TEST(Allocation, PropagatingMoveAssignmentStealsAndPublishesCount) {
+    pocca_big_int dst{7, pocca_alloc<beman::big_int::uint_multiprecision_t>{1U}};
+    pocca_big_int src{1, pocca_alloc<beman::big_int::uint_multiprecision_t>{2U}};
+    src <<= 4000;
+    const pocca_big_int expected = src;
+
+    dst = std::move(src);
+
+    EXPECT_EQ(dst, expected);
+    EXPECT_EQ(dst.get_allocator().id, 2U);
+}
+
+TEST(Allocation, PropagatingAssignmentIsStrongWhenAllocationThrows) {
+    bool          fail = false;
+    pocca_big_int dst{7, pocca_alloc<beman::big_int::uint_multiprecision_t>{1U}};
+    pocca_big_int src{1, pocca_alloc<beman::big_int::uint_multiprecision_t>{2U, &fail}};
+    src <<= 4000;
+
+    fail = true;
+    EXPECT_THROW(dst = src, std::bad_alloc);
+
+    // Strong: the value and the allocator both survive the failed assignment.
+    EXPECT_EQ(dst, 7);
+    EXPECT_EQ(dst.get_allocator().id, 1U);
+    fail = false;
+    dst  = src;
+    EXPECT_EQ(dst, src);
+}
 
 TEST(Allocation, SizeDefault) {
     beman::big_int::big_int x;

--- a/tests/beman/big_int/pmr.test.cpp
+++ b/tests/beman/big_int/pmr.test.cpp
@@ -792,6 +792,41 @@ TEST(Pmr, UnsynchronizedPoolResource) {
     EXPECT_EQ(to_string(x), to_string(big_int{1} << 16));
 }
 
+TEST(Pmr, ThrowingAllocationDuringAssignmentLeavesValueUnchanged) {
+    // A throwing allocation inside assignment leaves the destination untouched.
+    pmr_big_int wide{};
+    wide = 1;
+    wide <<= 4000;
+
+    {
+        alignas(uint_multiprecision_t) unsigned char buffer[64];
+        std::pmr::monotonic_buffer_resource          res{buffer, sizeof buffer, std::pmr::null_memory_resource()};
+        pmr_big_int                                  x{&res};
+        x = 1;
+        x <<= 100;
+        ASSERT_FALSE(is_inplace(x));
+        const std::string before = to_string(x);
+
+        EXPECT_THROW(x = wide, std::bad_alloc);
+
+        EXPECT_EQ(to_string(x), before);
+        x = 42;
+        EXPECT_EQ(x, 42);
+    }
+    {
+        std::pmr::monotonic_buffer_resource res{std::pmr::null_memory_resource()};
+        pmr_big_int                         x{&res};
+        x = 7;
+        ASSERT_TRUE(is_inplace(x));
+
+        EXPECT_THROW(x = wide, std::bad_alloc);
+
+        EXPECT_EQ(x, 7);
+        x = 42;
+        EXPECT_EQ(x, 42);
+    }
+}
+
 TEST(Pmr, NullMemoryResourceForcesInlineOnly) {
     // null_memory_resource throws bad_alloc on any allocation, so as long as
     // we keep the value within the single inline limb, no heap is touched.


### PR DESCRIPTION
Investigation and fix were AI-assisted; I ran both debug presets, ASan and UBSan, and `pre-commit` locally.

Closes: #335.

`assign_value`'s slow path freed the destination's buffer and published the source's limb count before allocating, so a throw left the control words describing freed storage. Each branch now writes them only after the storage they describe is in place, and the fresh-allocation branch allocates before it frees, so a throw leaves the destination unchanged.

Under a propagating allocator the new block has to come from the source's allocator while the old one is still released with ours, so it is allocated through a copy of the source's; hence the new static `alloc_limbs_from`. That path had no coverage before, since no allocator in the suite set `propagate_on_container_copy_assignment`, so `allocation.test.cpp` gains a stateful propagating allocator.
